### PR TITLE
Tests & WIP redirecting / to relevant team pages

### DIFF
--- a/src/app/components/IndexComponent.js
+++ b/src/app/components/IndexComponent.js
@@ -1,13 +1,43 @@
 import React, { Component, PropTypes } from 'react';
+import Relay from 'react-relay';
+import MeRoute from '../relay/MeRoute';
 
 class IndexComponent extends Component {
   render() {
-    return (
-      <div>
-        <h2 className="main-title">Welcome to Checkdesk</h2>
-      </div>
-    );
+    return null;
   }
 }
 
-export default IndexComponent;
+const IndexContainer = Relay.createContainer(IndexComponent, {
+  fragments: {
+    me: () => Relay.QL`
+      fragment on User {
+        current_team {
+          id
+        }
+      }
+    `
+  }
+});
+
+class Index extends Component {
+  render() {
+    var route = new MeRoute();
+    return (<Relay.RootContainer Component={IndexContainer} route={route} />);
+  }
+
+  componentDidMount() {
+    var redirectTo;
+    const currentTeam = this.props.me ? this.props.me.current_team : null;
+
+    if (currentTeam) {
+      redirectTo = ('/team/' + currentTeam.id);
+    } else {
+      redirectTo = ('/teams/new');
+    }
+
+    this.props.history.push(redirectTo);
+  }
+}
+
+export default Index;

--- a/src/app/containers/Root.js
+++ b/src/app/containers/Root.js
@@ -26,7 +26,7 @@ export default class Root extends Component {
       <Provider store={store}>
         <Router history={history}>
           <Route path="/" component={App}>
-            <IndexRoute component={IndexComponent} />
+            <IndexRoute component={Index} />
             <Route path="tos" component={TermsOfService} public={true} />
             <Route path="sources" component={Sources} />
             <Route path="sources/new" component={CreateAccount} />

--- a/test/spec/app_spec.rb
+++ b/test/spec/app_spec.rb
@@ -146,6 +146,11 @@ describe 'app' do
       expect(displayed_name == 'USER WITH EMAIL').to be(true)
     end
 
+    it "should redirect new users from / to /teams/new" do
+      login_with_email
+      expect(@driver.current_url.to_s == 'http://localhost:3333/teams/new').to be(true)
+    end
+
     it "should have footer" do
       login_with_email
       @driver.navigate.to 'http://localhost:3333/tos'
@@ -682,6 +687,21 @@ describe 'app' do
       sleep 1
       press_button('.create-team__submit-button')
       sleep 5
+      expect(@driver.current_url.to_s.match(/^http:\/\/localhost:3333\/team\/[0-9]+/).nil?).to be(false)
+    end
+
+    it "should redirect / to current team if exists" do
+      login_with_email
+      @driver.navigate.to 'http://localhost:3333/teams/new'
+      sleep 1
+      fill_field('#team-name-container', "Team #{Time.now}")
+      sleep 1
+      fill_field('#team-subdomain-container', "team#{Time.now.to_i}")
+      sleep 1
+      press_button('.create-team__submit-button')
+      sleep 5
+      @driver.navigate.to 'http://localhost:3333/'
+      sleep 1
       expect(@driver.current_url.to_s.match(/^http:\/\/localhost:3333\/team\/[0-9]+/).nil?).to be(false)
     end
 


### PR DESCRIPTION
An attempt at solving ticket #4956.

I haven't been able to try this at all because my checkdesk
app is currently broken, so it might be wildly incorrect, but
hopefully the intent is clear from the code. 

In case not: We want to send users from / to /teams/new if they
don't have a team yet. If they do, send them to /team/:current.
