### PR TITLE
Feature/teams page

### DIFF
--- a/src/app/components/TeamSidebar.js
+++ b/src/app/components/TeamSidebar.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import FontAwesome from 'react-fontawesome';
 import CreateProject from './project/CreateProject';
 import MeRoute from '../relay/MeRoute';
+import SwitchTeams from './team/SwitchTeams';
 
 class TeamSidebarComponent extends Component {
   constructor(props) {
@@ -111,80 +112,19 @@ class TeamSidebarComponent extends Component {
         </section>
 
         <footer className='team-sidebar__footer'>
-          <button onClick={this.handleSwitchTeams.bind(this)} className='team-sidebar__switch-teams'>
+          <button onClick={this.handleSwitchTeams.bind(this)} className='team-sidebar__switch-teams-button'>
             <FontAwesome className='team-sidebar__switch-teams-icon' name='random' />
             <span>Switch Teams</span>
           </button>
 
-          {/* possibly should decompose into separate component */}
-          <div className={'switch-teams' + (this.state.isSwitchTeamsActive ? ' switch-teams--active' : '')} onClick={this.handleSwitchTeamsClose.bind(this)}>
-            <section className='switch-teams__modal'>
-              <button className='switch-teams__modal-close' onClick={this.handleSwitchTeamsClose.bind(this)}>×</button>
-
-              <h2 className='switch-teams__modal-title'>
-                <FontAwesome className='switch-teams__modal-title-icon' name='random' />
+          <div className={'team-sidebar__switch-teams-overlay' + (this.state.isSwitchTeamsActive ? ' team-sidebar__switch-teams-overlay--active' : '')} onClick={this.handleSwitchTeamsClose.bind(this)}>
+            <section className='team-sidebar__switch-teams-modal'>
+              <button className='team-sidebar__switch-teams-close' onClick={this.handleSwitchTeamsClose.bind(this)}>×</button>
+              <h2 className='team-sidebar__switch-teams-title'>
+                <FontAwesome className='team-sidebar__switch-teams-title-icon' name='random' />
                 <span>Switch Teams</span>
               </h2>
-
-              <ul className='switch-teams__teams'>
-
-                {/* 1. current team */}
-                {(() => { 
-                  if (currentTeam) {
-                    return (
-                      <li className='switch-teams__team switch-teams__team--current'>
-                        <Link to={'/team/' + currentTeam.dbid} className='switch-teams__team-link'>
-                          <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + currentTeam.avatar + ')'}}></div>
-                          <div className='switch-teams__team-copy'>
-                            <h3 className='switch-teams__team-name'>{currentTeam.name}</h3>
-                            <span className='switch-teams__team-members-count'>{membersCountString(currentTeam.members_count)}</span>
-                          </div>
-                          <div className='switch-teams__team-actions'>
-                            <FontAwesome className='switch-teams__team-caret' name='angle-right' />
-                          </div>
-                        </Link>
-                      </li>
-                    );
-                  }
-                })()}
-
-                {/* 2. iterate through other teams the user belongs to */}
-                {otherTeams.map(function(team) {
-                  return (
-                    <li className='switch-teams__team'>
-                      <Link to={team.url} className='switch-teams__team-link'>
-                        <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + team.avatar + ')'}}></div>
-                        <div className='switch-teams__team-copy'>
-                          <h3 className='switch-teams__team-name'>{team.name}</h3>
-                          <span className='switch-teams__team-members-count'>{membersCountString(team.membersCount)}</span>
-                        </div>
-                        <div className='switch-teams__team-actions'>
-                          <FontAwesome className='switch-teams__team-caret' name='angle-right' />
-                        </div>
-                      </Link>
-                    </li>
-                  );
-                })}
-
-                {/* 3. iterate through any teams the user has requested to join but not been approved yet */}
-                {pendingTeams.map(function(team) {
-                  return (
-                    <li className='switch-teams__team switch-teams__team--pending'>
-                      <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + team.avatar + ')'}}></div>
-                      <div className='switch-teams__team-copy'>
-                        <h3 className='switch-teams__team-name'><Link to={team.url}>{team.name}</Link></h3>
-                        <span className='switch-teams__team-join-request-message'>You requested to join</span>
-                      </div>
-                      <div className='switch-teams__team-actions'>
-                        <button className='switch-teams__cancel-join-request'>Cancel</button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-
-              {/* 4. new team */}
-              <Link to='/teams/new' className='switch-teams__new-team-link'>+ New team</Link>
+              <SwitchTeams currentTeam={currentTeam} otherTeams={otherTeams} pendingTeams={pendingTeams} />
             </section>
           </div>
         </footer>

--- a/src/app/components/team/SwitchTeams.js
+++ b/src/app/components/team/SwitchTeams.js
@@ -1,0 +1,81 @@
+import React, { Component, PropTypes } from 'react';
+import Relay from 'react-relay';
+import { Link } from 'react-router';
+import FontAwesome from 'react-fontawesome';
+import MeRoute from '../../relay/MeRoute';
+
+class SwitchTeams extends Component {
+  render() {
+    var currentTeam = this.props.currentTeam;
+    var otherTeams = this.props.otherTeams;
+    var pendingTeams = this.props.pendingTeams;
+
+    function membersCountString(count) {
+      if (typeof count === 'number') {
+        return count.toString() + ' member' + (count === 1 ? '' : 's');
+      }
+    }
+
+    return (
+      <div className='switch-teams'>
+        <ul className='switch-teams__teams'>
+
+          {(() => {
+            if (currentTeam) {
+              return (
+                <li className='switch-teams__team switch-teams__team--current'>
+                  <Link to={'/team/' + currentTeam.dbid} className='switch-teams__team-link'>
+                    <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + currentTeam.avatar + ')'}}></div>
+                    <div className='switch-teams__team-copy'>
+                      <h3 className='switch-teams__team-name'>{currentTeam.name}</h3>
+                      <span className='switch-teams__team-members-count'>{membersCountString(currentTeam.members_count)}</span>
+                    </div>
+                    <div className='switch-teams__team-actions'>
+                      <FontAwesome className='switch-teams__team-caret' name='angle-right' />
+                    </div>
+                  </Link>
+                </li>
+              );
+            }
+          })()}
+
+          {otherTeams.map(function(team) {
+            return (
+              <li className='switch-teams__team'>
+                <Link to={team.url} className='switch-teams__team-link'>
+                  <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + team.avatar + ')'}}></div>
+                  <div className='switch-teams__team-copy'>
+                    <h3 className='switch-teams__team-name'>{team.name}</h3>
+                    <span className='switch-teams__team-members-count'>{membersCountString(team.membersCount)}</span>
+                  </div>
+                  <div className='switch-teams__team-actions'>
+                    <FontAwesome className='switch-teams__team-caret' name='angle-right' />
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+
+          {pendingTeams.map(function(team) {
+            return (
+              <li className='switch-teams__team switch-teams__team--pending'>
+                <div className='switch-teams__team-avatar' style={{'background-image': 'url(' + team.avatar + ')'}}></div>
+                <div className='switch-teams__team-copy'>
+                  <h3 className='switch-teams__team-name'><Link to={team.url}>{team.name}</Link></h3>
+                  <span className='switch-teams__team-join-request-message'>You requested to join</span>
+                </div>
+                <div className='switch-teams__team-actions'>
+                  <button className='switch-teams__cancel-join-request'>Cancel</button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        <Link to='/teams/new' className='switch-teams__new-team-link'>+ New team</Link>
+      </div>
+    );
+  }
+}
+
+export default SwitchTeams;

--- a/src/app/components/team/Teams.js
+++ b/src/app/components/team/Teams.js
@@ -1,0 +1,62 @@
+import React, { Component, PropTypes } from 'react';
+import Relay from 'react-relay';
+import { Link } from 'react-router';
+import FontAwesome from 'react-fontawesome';
+import MeRoute from '../../relay/MeRoute';
+import SwitchTeams from './SwitchTeams.js'
+
+class TeamsComponent extends Component {
+  render() {
+    var currentTeam = this.props.me.current_team;
+
+    // TODO: use real data
+    var otherTeams = [
+      {
+        name: 'ProPublica',
+        avatar: 'https://pbs.twimg.com/profile_images/660147326091182081/Q4TLW_Fe.jpg',
+        url: '/team/2',
+        membersCount: 10
+      }
+    ];
+    var pendingTeams = [
+      {
+        name: 'Bellingcat',
+        avatar: 'https://pbs.twimg.com/profile_images/615058568300097536/WpTJfNg3.png',
+        url: '/team/3',
+      }
+    ];
+
+    return (
+      <section className='teams'>
+        <div className='teams__content'>
+          <h2 className='teams__main-heading'>Your Teams</h2>
+          <SwitchTeams currentTeam={currentTeam} otherTeams={otherTeams} pendingTeams={pendingTeams} />
+        </div>
+      </section>
+    );
+  }
+}
+
+const TeamsContainer = Relay.createContainer(TeamsComponent, {
+  fragments: {
+    me: () => Relay.QL`
+      fragment on User {
+        current_team {
+          id,
+          name,
+          avatar,
+          members_count
+        }
+      }
+    `
+  }
+});
+
+class Teams extends Component {
+  render() {
+    var route = new MeRoute();
+    return (<Relay.RootContainer Component={TeamsContainer} route={route} />);
+  }
+}
+
+export default Teams;

--- a/src/app/containers/Root.js
+++ b/src/app/containers/Root.js
@@ -11,6 +11,7 @@ import TeamMembers  from '../components/team/TeamMembers';
 import CreateTeam from '../components/team/CreateTeam'
 import JoinTeam from '../components/team/JoinTeam.js';
 import Project from '../components/project/Project.js';
+import Teams from '../components/team/Teams.js';
 
 export default class Root extends Component {
   static propTypes = {
@@ -39,6 +40,7 @@ export default class Root extends Component {
             <Route path="team/:teamId/members" component={TeamMembers} />
             <Route path="team/:teamId" component={Team} />
             <Route path="teams/new" component={CreateTeam} fullscreen={true} />
+            <Route path="teams" component={Teams} fullscreen={true} />
             <Route path="project/:projectId" component={Project} />
             <Route path="*" component={NotFound} public={true} />
           </Route>

--- a/src/app/styles/components/_sources.scss
+++ b/src/app/styles/components/_sources.scss
@@ -4,7 +4,6 @@
 
 .sources__heading {
   @include app-heading;
-  text-align: center;
 }
 
 .sources__list {

--- a/src/app/styles/components/team/_join-team.scss
+++ b/src/app/styles/components/team/_join-team.scss
@@ -4,7 +4,6 @@
 
 .join-team__main-heading {
   @include app-heading;
-  text-align: center;
 }
 
 .join-team__blurb {

--- a/src/app/styles/components/team/_switch-teams.scss
+++ b/src/app/styles/components/team/_switch-teams.scss
@@ -1,50 +1,6 @@
 .switch-teams {
-  background-color: rgba(0, 0, 0, 0.75);
-  position: fixed;
-  top: 0; right: 0; bottom: 0; left: 0;
-  width: 100vw; // required if ancestor has transform, e.g. active mobile sidebar. TODO: general solution for overlays
-  z-index: 10;
-
-  opacity: 0;
-  transition: opacity 200ms ease;
-  pointer-events: none;
-  &--active {
-    pointer-events: auto;
-    opacity: 1;
-  }
-}
-
-// modal
-
-.switch-teams__modal {
-  position: absolute;
-  bottom: 0; left: 0;
-  width: 400px;
-  max-height: 100%;
-  padding: 15px 15px 30px 15px;
   background-color: #fff;
-  color: $dark-gray-text;
 }
-
-.switch-teams__modal-title {
-  font-size: 14px;
-  font-weight: normal;
-  color: $light-gray-text;
-  margin: 10px 0 23px 13px;
-}
-
-.switch-teams__modal-title-icon {
-  margin-right: 7px;
-  font-size: 0.95em;
-}
-
-.switch-teams__modal-close {
-  @include close-button;
-  position: absolute; top: 11px; right: 24px;
-  opacity: 0.8;
-}
-
-// teams
 
 .switch-teams__teams, {
   margin-bottom: 10px;

--- a/src/app/styles/components/team/_team-members.scss
+++ b/src/app/styles/components/team/_team-members.scss
@@ -7,7 +7,6 @@
 
 .team-members__main-heading {
   @include app-heading;
-  text-align: center;
 }
 
 // edit buttons

--- a/src/app/styles/components/team/_team-sidebar.scss
+++ b/src/app/styles/components/team/_team-sidebar.scss
@@ -127,7 +127,7 @@ team-sidebar__sources-link
   position: relative;
 }
 
-.team-sidebar__switch-teams {
+.team-sidebar__switch-teams-button {
   @include unbutton;
   font-size: 14px;
   width: 100%;
@@ -141,6 +141,52 @@ team-sidebar__sources-link
 }
 
 .team-sidebar__switch-teams-icon {
+  margin-right: 7px;
+  font-size: 0.95em;
+}
+
+// switch teams modal
+
+.team-sidebar__switch-teams-overlay {
+  background-color: rgba(0, 0, 0, 0.75);
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+  width: 100vw; // required if ancestor has transform, e.g. active mobile sidebar. TODO: general solution for overlays
+  z-index: 10;
+
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+  &--active {
+    pointer-events: auto;
+    opacity: 1;
+  }
+}
+
+.team-sidebar__switch-teams-modal {
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 400px;
+  max-height: 100%;
+  padding: 15px 15px 30px 15px;
+  background-color: #fff;
+  color: $dark-gray-text;
+}
+
+.team-sidebar__switch-teams-close {
+  @include close-button;
+  position: absolute; top: 11px; right: 24px;
+  opacity: 0.8;
+}
+
+.team-sidebar__switch-teams-title {
+  font-size: 14px;
+  font-weight: normal;
+  color: $light-gray-text;
+  margin: 10px 0 23px 13px;
+}
+
+.team-sidebar__switch-teams-title-icon {
   margin-right: 7px;
   font-size: 0.95em;
 }

--- a/src/app/styles/components/team/_teams.scss
+++ b/src/app/styles/components/team/_teams.scss
@@ -1,0 +1,13 @@
+.teams {
+  background-color: #fff;
+}
+
+.teams__content {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 15px;
+}
+
+.teams__main-heading {
+  @include app-heading;
+}

--- a/src/app/styles/stylesheet.scss
+++ b/src/app/styles/stylesheet.scss
@@ -23,6 +23,7 @@
 @import 'components/team/switch-teams';
 @import 'components/team/team-members';
 @import 'components/team/team-sidebar';
+@import 'components/team/teams';
 @import 'components/sources';
 @import 'components/team';
 @import 'source';

--- a/src/app/styles/theme/_typography.scss
+++ b/src/app/styles/theme/_typography.scss
@@ -22,6 +22,7 @@ $font-stack-serif: "Merriweather", Georgia, serif;
 
 @mixin app-heading {
   @include onboarding-heading;
+  text-align: center;
 }
 
 @mixin app-blurb {


### PR DESCRIPTION
@caiosba, @ahmed, can you take a look and LMK if you think this is reasonable?

This branch finishes https://mantis.meedan.com/view.php?id=4955 by creating a /teams page. In the process (and per your request) it decomposes the team switcher out of TeamSidebar.js, into SwitchTeams.js.

The architecture is basically:
- `<TeamSidebar>` renders `<SwitchTeams>` wrapped in a little markup/styles for the corner modal.
- /teams will try to render `<Teams>`.
- `<Teams>` renders `<SwitchTeams>` wrapped in a little markup for being centered and fullscreen.

The part I'm least sure about is which component(s) should be responsible for data. Right now `<SwitchTeams>` is dumb and assumes it receives all data via props, and `<TeamSidebar>` and `<Teams>` have a Relay Container. Perhaps it should be the other way around though. 

I can fix whatever needs fixing if you point me in the right direction. Or you or Ahmed could take this from here if you think that's easier.

Related: https://mantis.meedan.com/view.php?id=4976
