### PR TITLE
Feature/login copywriting

### DIFF
--- a/src/app/components/LoginMenu.js
+++ b/src/app/components/LoginMenu.js
@@ -12,7 +12,8 @@ class LoginMenu extends Component {
 
         <img className='login-menu__icon' src='/images/logo/logo-1.svg'/>
         <h1 className='login-menu__heading'>Sign in</h1>
-        <p className='login-menu__blurb'>Welcome to Check. Invite your team and online community in a secure environment to work together to validate breaking news content. Then, quickly show the work to your audience on social media or your news site. Currently in Beta. Optimized for Chrome desktop.</p>
+        <p className='login-menu__blurb' style="margin: 0 auto 1em; max-width: 500px;">Welcome to Check. Invite your team and online community in a secure environment to work together to verify breaking news content. Then, quickly show the work to your audience on social media or your news site.</p>
+        <p>Currently in Beta. Optimized for Chrome desktop.</p>
         <ul className="login-menu__options">
           <li className="item">
             <button onClick={loginTwitter} id="twitter-login" className='login-menu__button login-menu__button--twitter'>Sign in with Twitter</button>

--- a/src/app/components/LoginMenu.js
+++ b/src/app/components/LoginMenu.js
@@ -12,7 +12,7 @@ class LoginMenu extends Component {
 
         <img className='login-menu__icon' src='/images/logo/logo-1.svg'/>
         <h1 className='login-menu__heading'>Sign in</h1>
-        <p className='login-menu__blurb'>Verify breaking news with Check. <a href='/tour' className='login-menu__blurb-link'>Tour »</a></p>
+        <p className='login-menu__blurb'>Welcome to Check. Invite your team and online community in a secure environment to work together to validate breaking news content. Then, quickly show the work to your audience on social media or your news site. Currently in Beta. Optimized for Chrome desktop.</p>
         <ul className="login-menu__options">
           <li className="item">
             <button onClick={loginTwitter} id="twitter-login" className='login-menu__button login-menu__button--twitter'>Sign in with Twitter</button>


### PR DESCRIPTION
## What: 

- Copy changes to the log in screen. 
- Remove link to welcome tour.


## How:
It removes the It uses inline CSS — which should be integrated into the Sass  when possible (my environment is not working.)

## Before: 
![screen shot 2016-09-13 at 10 46 07 pm](https://cloud.githubusercontent.com/assets/7366/18501407/103afc42-7a05-11e6-8dd5-16b30336fbf5.png)

## After: 
![screen shot 2016-09-13 at 10 57 23 pm](https://cloud.githubusercontent.com/assets/7366/18501456/76c87142-7a05-11e6-982c-58738e17d232.png)
