### PR TITLE
Update position and color of beta warning

### DIFF
--- a/src/app/components/HeaderActions.js
+++ b/src/app/components/HeaderActions.js
@@ -24,6 +24,7 @@ class HeaderActions extends Component {
 
     return (
       <div className={this.bemClass('project-header__project-settings', this.state.isSettingsMenuOpen, '--active')}>
+        <span style="position: absolute; top: 0; right: 15px; font-size: 10px; border-radius: 0 0 4px 4px; background-color: #c00000; color: white!important; padding: 2px 4px;">EARLY DEMO</span>
         <i className='project-header__project-search-icon fa fa-search'></i>
         <i className='project-header__project-settings-icon fa fa-gear' onClick={this.toggleSettingsMenu.bind(this)}></i>
         <div className={this.bemClass('project-header__project-settings-overlay', this.state.isSettingsMenuOpen, '--active')} onClick={this.toggleSettingsMenu.bind(this)}></div>


### PR DESCRIPTION
## What: 
Update the position of the (temporary, inlined) "warning" banner about beta status.

## Before: 
![screen shot 2016-09-14 at 2 01 45 pm](https://cloud.githubusercontent.com/assets/7366/18529959/0d95798e-7a84-11e6-9609-19a5a48719ac.png)

## After: 

![screen shot 2016-09-14 at 2 02 17 pm](https://cloud.githubusercontent.com/assets/7366/18529970/1a13d106-7a84-11e6-8d0a-f0ff3586c383.png)
