### PR TITLE
Remove `sleep` and increase `wait` in tests

### DIFF
--- a/test/spec/app_spec_helpers.rb
+++ b/test/spec/app_spec_helpers.rb
@@ -4,8 +4,7 @@ module AppSpecHelpers
   end
 
   def get_element(selector, type = :css)
-    sleep 3
-    wait = Selenium::WebDriver::Wait.new(timeout: 5)
+    wait = Selenium::WebDriver::Wait.new(timeout: 15)
     return wait.until {
       element = @driver.find_element(type, selector)
       element if element.displayed?
@@ -22,7 +21,6 @@ module AppSpecHelpers
         element
       end
     }
-    sleep 1
     input.send_keys(value)
   end
 


### PR DESCRIPTION
For me this change reduces the test suite time by 19%. More details on Mantis shortly.