### PR TITLE
Feature/4997 client permissions

### DIFF
--- a/src/app/components/Can.js
+++ b/src/app/components/Can.js
@@ -1,8 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 
 function can(permissionsData, permission) {
-  const permissions = JSON.parse(permissionsData);
-  return permissions[permission];
+  try {
+    const permissions = JSON.parse(permissionsData);
+    return permissions[permission];
+  } catch (e) {
+    throw `Error parsing permissions data: ${permissionsData}`
+  }
 }
 
 class Can extends Component {

--- a/src/app/components/Can.js
+++ b/src/app/components/Can.js
@@ -1,13 +1,13 @@
 import React, { Component, PropTypes } from 'react';
 
-class Can extends Component {
-  can(permission) {
-    const permissions = JSON.parse(this.props.permissions);
-    return permissions[permission];
-  }
+function can(permissionsData, permission) {
+  const permissions = JSON.parse(permissionsData);
+  return permissions[permission];
+}
 
+class Can extends Component {
   render() {
-    if (this.can(this.props.permission)) {
+    if (can(this.props.permissions, this.props.permission)) {
       return (this.props.children);
     }
     else {
@@ -16,4 +16,4 @@ class Can extends Component {
   }
 }
 
-export default Can;
+export { Can as default, can };

--- a/src/app/components/media/Media.js
+++ b/src/app/components/media/Media.js
@@ -18,6 +18,7 @@ const MediaContainer = Relay.createContainer(MediaComponent, {
         last_status,
         annotations_count,
         domain,
+        permissions,
         user {
           name,
           source {

--- a/src/app/components/media/MediaStatus.js
+++ b/src/app/components/media/MediaStatus.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import FontAwesome from 'react-fontawesome';
 import Relay from 'react-relay';
 import CreateStatusMutation from '../../relay/CreateStatusMutation';
+import Can, { can } from '../Can';
 
 class MediaStatus extends Component {
   constructor(props) {
@@ -13,8 +14,13 @@ class MediaStatus extends Component {
     };
   }
 
+  canUpdate() {
+    return can(this.props.media.permissions, "update Media");
+  }
+
   toggleMediaStatusMenu() {
-    this.setState({ isMediaStatusMenuOpen: !this.state.isMediaStatusMenuOpen });
+    const newState = this.canUpdate() ? !this.state.isMediaStatusMenuOpen : false;
+    this.setState({ isMediaStatusMenuOpen: newState });
   }
 
   bemClass(baseClass, modifierBoolean, modifierSuffix) {
@@ -74,13 +80,15 @@ class MediaStatus extends Component {
     const status = media.last_status;
 
     return (
-      <div className={this.bemClass('media-status', this.state.isMediaStatusMenuOpen, '--active')} onClick={this.toggleMediaStatusMenu.bind(this)}>
+      <div className={this.bemClass('media-status', this.canUpdate(), '--editable')} onClick={this.toggleMediaStatusMenu.bind(this)}>
         <div className={this.bemClass('media-status__overlay', this.state.isMediaStatusMenuOpen, '--active')} onClick={this.toggleMediaStatusMenu.bind(this)}></div>
 
         <div className={'media-status__current' + this.currentStatusToClass(status)}>
           <i className="media-status__icon media-status__icon--circle / fa fa-circle"></i>
           <span className='media-status__label'>{status}</span>
-          <i className="media-status__icon media-status__icon--caret / fa fa-caret-down"></i>
+          <Can permissions={media.permissions} permission="update Media">
+            <i className="media-status__icon media-status__icon--caret / fa fa-caret-down"></i>
+          </Can>
           <span className='media-status__message'>{this.state.message}</span>
         </div>
         <ul className={this.bemClass('media-status__menu', this.state.isMediaStatusMenuOpen, '--active')}>

--- a/src/app/components/project/Project.js
+++ b/src/app/components/project/Project.js
@@ -104,7 +104,8 @@ const ProjectContainer = Relay.createContainer(ProjectComponent, {
               jsondata,
               annotations_count,
               domain,
-              last_status
+              last_status,
+              permissions
             }
           }
         }

--- a/src/app/components/project/Project.js
+++ b/src/app/components/project/Project.js
@@ -6,6 +6,7 @@ import ProjectHeader from './ProjectHeader';
 import MediasAndAnnotations from '../MediasAndAnnotations';
 import TeamSidebar from '../TeamSidebar';
 import { CreateMedia } from '../media';
+import Can from '../Can';
 
 class ProjectComponent extends Component {
   redirect() {
@@ -51,7 +52,9 @@ class ProjectComponent extends Component {
             annotatedType="Project"
             types={['comment']} />
 
-          <CreateMedia {...this.props} />
+          <Can permissions={project.permissions} permission='create Media'>
+            <CreateMedia {...this.props} />
+          </Can>
         </div>
       </div>
     );
@@ -66,6 +69,7 @@ const ProjectContainer = Relay.createContainer(ProjectComponent, {
         dbid,
         title,
         description,
+        permissions,
         team {
           id,
           dbid,

--- a/src/app/components/source/Annotations.js
+++ b/src/app/components/source/Annotations.js
@@ -1,7 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import Annotation from './Annotation';
 import AddAnnotation from './AddAnnotation';
- 
+import Can, { can } from '../Can';
+
 class Annotations extends Component {
   render() {
     const props = this.props;
@@ -16,7 +17,9 @@ class Annotations extends Component {
         })}
         </ul>
 
-        <AddAnnotation annotated={props.annotated} annotatedType={props.annotatedType} types={props.types} />
+        <Can permissions={props.annotated.permissions} permission={`update ${props.annotatedType}`}>
+          <AddAnnotation annotated={props.annotated} annotatedType={props.annotatedType} types={props.types} />
+        </Can>
       </div>
     );
   }

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -12,6 +12,7 @@ import Message from '../Message';
 import CreateContactMutation from '../../relay/CreateContactMutation';
 import UpdateContactMutation from '../../relay/UpdateContactMutation';
 import CreateProject from '../project/CreateProject';
+import Can from '../Can';
 
 class TeamComponent extends Component {
   constructor(props) {
@@ -233,9 +234,11 @@ class TeamComponent extends Component {
                   <Link to={'/project/' + p.node.dbid} className='team__project-link'>{p.node.title}</Link>
                 </li>
               ))}
-              <li className='team__new-project'>
-                <CreateProject className='team__new-project-input' team={team} />
-              </li>
+              <Can permissions={team.permissions} permission="create Project">
+                <li className='team__new-project'>
+                  <CreateProject className='team__new-project-input' team={team} />
+                </li>
+              </Can>
             </ul>
           </div>
         </section>

--- a/src/app/styles/components/media/_media-status.scss
+++ b/src/app/styles/components/media/_media-status.scss
@@ -6,7 +6,7 @@ $menu-status-item-padding: 11px 15px 11px 13px;
   left: -15px;
 
   margin-bottom: 5px;
-  cursor: pointer;
+  &--editable { cursor: pointer; }
 }
 
 .media-status__icon {


### PR DESCRIPTION
This continues down the list of components on #4997, with hiding the media status dropdown (7ec9cf1). 

I had to extend Caio's new <Can> component to be able to call it from non-JSX (3ebb04b) and we should probably get his feedback on Monday before merging.