### PR TITLE
Enable EL suggested tags

### DIFF
--- a/data/suggestedTags.js
+++ b/data/suggestedTags.js
@@ -11,5 +11,6 @@ const elCategories = [
 ];
 
 export default {
-  "electionland-categories": elCategories
+  "electionland-categories": elCategories,
+  "electionland": elCategories,
 }


### PR DESCRIPTION
Currently the EL suggested tags only show on a team with the subdomain `electionland-categories` for QA purposes. This commit would additionally enable them for a team with the subdomain `electionland`. Once we're ready for that let's merge.