### PR TITLE
Add CSS selectors to handle custom electionland status colors

### DIFF
--- a/src/app/styles/components/annotation/_annotation.scss
+++ b/src/app/styles/components/annotation/_annotation.scss
@@ -76,7 +76,7 @@
 
 .annotation__status {
   @include app-kicker(11px);
-  @include media-status-colors;
+  @include media-status-font-colors;
   margin-left: 3px;
   margin-right: 2px;
 }

--- a/src/app/styles/components/media/_media-detail.scss
+++ b/src/app/styles/components/media/_media-detail.scss
@@ -2,8 +2,7 @@
   padding: 8px 14px 10px 14px;
   border: $layout-border;
   border-radius: 2px;
-  @include media-status-border-colors;
-  @include media-status-bg-colors;
+  @include media-status-background-and-border-colors;
   box-shadow: $layout-box-shadow;
   margin-bottom: 14px;
 }

--- a/src/app/styles/components/media/_media-status.scss
+++ b/src/app/styles/components/media/_media-status.scss
@@ -28,7 +28,7 @@ $menu-status-item-padding: 11px 15px 11px 13px;
   position: relative;
   border-left: 1px solid transparent;
 
-  @include media-status-colors;
+  @include media-status-font-colors;
 }
 
 .media-status__message {
@@ -82,14 +82,33 @@ $menu-status-item-padding: 11px 15px 11px 13px;
 }
 
 .media-status__menu-item {
-  @include media-status-colors;
-
+  @include media-status-font-colors;
   $hover-bg-opacity: 0.15;
-  &--undetermined:hover { background: rgba($blue-100, $hover-bg-opacity); }
-  &--in-progress:hover { background: rgba($orange-100, $hover-bg-opacity); }
-  &--verified:hover { background: rgba($green-100, $hover-bg-opacity); }
-  &--false:hover { background: rgba($red-100, $hover-bg-opacity); }
-  &--not-applicable:hover { background: rgba($gray-100, $hover-bg-opacity); }
+
+  &--undetermined:hover { 
+    background: rgba($blue-100, $hover-bg-opacity); 
+  }
+
+  &--in-progress:hover,
+  &--important-in-progress:hover { 
+    background: rgba($orange-100, $hover-bg-opacity); 
+  }
+
+  &--verified:hover, 
+  &--important-authenticated:hover { 
+    background: rgba($green-100, $hover-bg-opacity); 
+  }
+
+  &--false:hover, 
+  &--important-false:hover { 
+    background: rgba($red-100, $hover-bg-opacity); 
+  }
+
+  &--not-applicable-2:hover,
+  &--not-applicable:hover,
+  &--important-inconclusive:hover { 
+    background: rgba($gray-100, $hover-bg-opacity); 
+  }
 
   border-bottom: $layout-border; // TODO: consistent opacity
   padding: $menu-status-item-padding;

--- a/src/app/styles/components/media/_media-status.scss
+++ b/src/app/styles/components/media/_media-status.scss
@@ -106,7 +106,8 @@ $menu-status-item-padding: 11px 15px 11px 13px;
 
   &--not-applicable-2:hover,
   &--not-applicable:hover,
-  &--important-inconclusive:hover { 
+  &--important-inconclusive:hover,
+  &--inconclusive:hover { 
     background: rgba($gray-100, $hover-bg-opacity); 
   }
 

--- a/src/app/styles/components/media/_media-status.scss
+++ b/src/app/styles/components/media/_media-status.scss
@@ -83,33 +83,7 @@ $menu-status-item-padding: 11px 15px 11px 13px;
 
 .media-status__menu-item {
   @include media-status-font-colors;
-  $hover-bg-opacity: 0.15;
-
-  &--undetermined:hover { 
-    background: rgba($blue-100, $hover-bg-opacity); 
-  }
-
-  &--in-progress:hover,
-  &--important-in-progress:hover { 
-    background: rgba($orange-100, $hover-bg-opacity); 
-  }
-
-  &--verified:hover, 
-  &--important-authenticated:hover { 
-    background: rgba($green-100, $hover-bg-opacity); 
-  }
-
-  &--false:hover, 
-  &--important-false:hover { 
-    background: rgba($red-100, $hover-bg-opacity); 
-  }
-
-  &--not-applicable-2:hover,
-  &--not-applicable:hover,
-  &--important-inconclusive:hover,
-  &--inconclusive:hover { 
-    background: rgba($gray-100, $hover-bg-opacity); 
-  }
+  @include media-status-menu-hover-colors;
 
   border-bottom: $layout-border; // TODO: consistent opacity
   padding: $menu-status-item-padding;

--- a/src/app/styles/theme/_colors.scss
+++ b/src/app/styles/theme/_colors.scss
@@ -86,29 +86,63 @@ $media-status-green-bg: $hint-green;
 $media-status-red-bg: $pippin-red;
 $media-status-gray-bg: $gray-100;
 
-@mixin media-status-colors {
-  &--undetermined { color: $media-status-blue; }
-  &--in-progress { color: $media-status-orange; }
-  &--verified { color: $media-status-green; }
-  &--false { color: $media-status-red; }
-  &--not-applicable { color: $media-status-gray; }
+@mixin media-status-font-colors {
+  &--undetermined { 
+    color: $media-status-blue; 
+  }
+  
+  &--in-progress,
+  &--important-in-progress { 
+    color: $media-status-orange; 
+  }
+  
+  &--verified,
+  &--important-authenticated { 
+    color: $media-status-green; 
+  }
+  
+  &--false,
+  &--important-false { 
+    color: $media-status-red; 
+  }
+  
+  &--not-applicable,
+  &--important-inconclusive,
+  &--not-applicable-2,
+  &--marked-for-deletion { 
+    color: $media-status-gray; 
+  }
 }
 
-@mixin media-status-bg-colors {
-  $alpha: 0.17;
-  &--undetermined { background: $media-status-blue-bg; }
-  &--in-progress { background: $media-status-orange-bg; }
-  &--verified { background: $media-status-green-bg; }
-  &--false { background: $media-status-red-bg; }
-  &--inconclusive { background: $media-status-gray-bg; }
-}
+@mixin media-status-background-and-border-colors {
+  &--undetermined { 
+    background: $media-status-blue-bg;
+    border-color: $media-status-blue;
+  }
 
-@mixin media-status-border-colors {
-  $saturation: 100%;
-  $alpha: 1.0;
-  &--undetermined { border-color: $media-status-blue; }
-  &--in-progress { border-color: $media-status-orange; }
-  &--verified { border-color: $media-status-green; }
-  &--false { border-color: $media-status-red; }
-  &--not-applicable { border-color: $media-status-gray; }
+  &--in-progress, 
+  &--important-in-progress { 
+    background: $media-status-orange-bg;
+    border-color: $media-status-orange; 
+  }
+
+  &--verified, 
+  &--important-authenticated { 
+    background: $media-status-green-bg;
+    border-color: $media-status-green; 
+  }
+  
+  &--false, 
+  &--important-false { 
+    background: $media-status-red-bg;
+    border-color: $media-status-red; 
+  }
+
+  &--not-applicable, 
+  &--important-inconclusive,
+  &--not-applicable-2,
+  &--marked-for-deletion { 
+    background: $media-status-gray-bg; 
+    border-color: $media-status-gray;
+  }
 }

--- a/src/app/styles/theme/_colors.scss
+++ b/src/app/styles/theme/_colors.scss
@@ -86,62 +86,57 @@ $media-status-green-bg: $hint-green;
 $media-status-red-bg: $pippin-red;
 $media-status-gray-bg: $gray-100;
 
+$orange-selectors: "&--in-progress, &--important-in-progress, &--important-in_progress";
+$blue-selectors: "&--undetermined";
+$green-selectors: "&--verified, &--important-authenticated";
+$red-selectors: "&--false, &--important-false";
+$gray-selectors: "&--not-applicable_2, &--not-applicable-2, &--marked-for-deletion &--marked-for_deletion";
+
 @mixin media-status-font-colors {
-  &--undetermined { 
+  
+  #{$blue-selectors} { 
     color: $media-status-blue; 
-  }
+  } 
   
-  &--in-progress,
-  &--important-in-progress { 
+  #{$orange-selectors} { 
     color: $media-status-orange; 
-  }
+  } 
   
-  &--verified,
-  &--important-authenticated { 
+  #{$green-selectors} { 
     color: $media-status-green; 
-  }
+  } 
   
-  &--false,
-  &--important-false { 
+  #{$red-selectors} { 
     color: $media-status-red; 
-  }
+  } 
   
-  &--not-applicable,
-  &--important-inconclusive,
-  &--not-applicable-2,
-  &--marked-for-deletion { 
-    color: $media-status-gray; 
+  #{$gray-selectors} { 
+    color: $media-status-gray;
   }
 }
 
 @mixin media-status-background-and-border-colors {
-  &--undetermined { 
+  #{$blue-selectors} { 
     background: $media-status-blue-bg;
     border-color: $media-status-blue;
   }
 
-  &--in-progress, 
-  &--important-in-progress { 
+  #{$orange-selectors} { 
     background: $media-status-orange-bg;
     border-color: $media-status-orange; 
   }
 
-  &--verified, 
-  &--important-authenticated { 
+  #{$green-selectors} { 
     background: $media-status-green-bg;
     border-color: $media-status-green; 
   }
   
-  &--false, 
-  &--important-false { 
+  #{$red-selectors} { 
     background: $media-status-red-bg;
     border-color: $media-status-red; 
   }
 
-  &--not-applicable, 
-  &--important-inconclusive,
-  &--not-applicable-2,
-  &--marked-for-deletion { 
+  #{$gray-selectors} { 
     background: $media-status-gray-bg; 
     border-color: $media-status-gray;
   }

--- a/src/app/styles/theme/_colors.scss
+++ b/src/app/styles/theme/_colors.scss
@@ -100,16 +100,41 @@ $media-status-red-hover-bg: rgba($red-100, $hover-bg-opacity);
 $media-status-grey-hover-bg: rgba($gray-300, $hover-bg-opacity);
 $media-status-black-hover-bg: rgba($firefly-40, $hover-bg-opacity);
 
+// Cheatsheet (because the text labels don't match the classes)
+//
+// BLUE 
+// • "New" = --undetermined
+//
+// ORANGE
+// • "In progress" = --in-progress
+// • "Important/In Progress" = --important-in_progress, --important-in-progress (EL ONLY)
+//
+// GREEN
+// • "Authenticated" = --verified 
+// • "Important/authenticated" = --important-authenticated (EL ONLY)
+//
+// RED
+// • "False" = --false 
+// • "Important/false" = --important-false (EL ONLY)
+// 
+// GREY
+// • "Not applicable" = --not-applicable_2, --not-applicable-2 (EL ONLY)
+// • "Marked for deletion" = --marked-for_deletion, --marked-for-deletion (EL ONLY)
+//
+// BLACK
+// • "Important/Inconclusive" = --important-inconclusive (EL ONLY)
+// • "Inconclusive" = --inconclusive 
+//
+
 // Status selectors
 //
 // Currently includes custom Electionland selectors — CGB 2016-11-5
-//
 $orange-selectors: "&--in-progress, &--important-in-progress, &--important-in_progress";
 $blue-selectors: "&--undetermined";
 $green-selectors: "&--verified, &--important-authenticated";
 $red-selectors: "&--false, &--important-false";
-$gray-selectors: "&--not-applicable, &--not-applicable_2, &--not-applicable-2, &--marked-for-deletion &--marked-for_deletion";
-$black-selectors: "&--important-inconclusive, &--inconclusive";
+$gray-selectors: "&--not-applicable_2, &--not-applicable-2, &--marked-for-deletion, &--marked-for_deletion";
+$black-selectors: "&--not-applicable, &--important-inconclusive, &--inconclusive";
 
 // Font colors of media status labels
 // 

--- a/src/app/styles/theme/_colors.scss
+++ b/src/app/styles/theme/_colors.scss
@@ -72,26 +72,47 @@ $firefly-60-2: rgba($firefly-60, 0.2);
 $firefly-60-5: rgba($firefly-60, 0.5);
 $firefly-60-8: rgba($firefly-60, 0.8);
 
-// media status colors
-
+// Media status colors (font and border color)
+//
 $media-status-blue: $blue-500;
 $media-status-orange: $orange-500;
 $media-status-green: $green-500;
 $media-status-red: $red-500;
-$media-status-gray: $gray-350;
+$media-status-gray: $firefly-40;
+$media-status-black: $firefly-90;
 
+// Media status background colors
+//
 $media-status-blue-bg: $hawkes-blue;
 $media-status-orange-bg: $seashell-peach;
 $media-status-green-bg: $hint-green;
 $media-status-red-bg: $pippin-red;
 $media-status-gray-bg: $gray-100;
+$media-status-black-bg: $gray-300;
 
+// Media status menu hover background colors
+//
+$hover-bg-opacity: 0.15;
+$media-status-blue-hover-bg: rgba($blue-100, $hover-bg-opacity);
+$media-status-orange-hover-bg: rgba($orange-100, $hover-bg-opacity); 
+$media-status-green-hover-bg: rgba($green-100, $hover-bg-opacity); 
+$media-status-red-hover-bg: rgba($red-100, $hover-bg-opacity); 
+$media-status-grey-hover-bg: rgba($gray-300, $hover-bg-opacity);
+$media-status-black-hover-bg: rgba($firefly-40, $hover-bg-opacity);
+
+// Status selectors
+//
+// Currently includes custom Electionland selectors — CGB 2016-11-5
+//
 $orange-selectors: "&--in-progress, &--important-in-progress, &--important-in_progress";
 $blue-selectors: "&--undetermined";
 $green-selectors: "&--verified, &--important-authenticated";
 $red-selectors: "&--false, &--important-false";
-$gray-selectors: "&--not-applicable_2, &--not-applicable-2, &--marked-for-deletion &--marked-for_deletion";
+$gray-selectors: "&--not-applicable, &--not-applicable_2, &--not-applicable-2, &--marked-for-deletion &--marked-for_deletion";
+$black-selectors: "&--important-inconclusive, &--inconclusive";
 
+// Font colors of media status labels
+// 
 @mixin media-status-font-colors {
   
   #{$blue-selectors} { 
@@ -109,12 +130,18 @@ $gray-selectors: "&--not-applicable_2, &--not-applicable-2, &--marked-for-deleti
   #{$red-selectors} { 
     color: $media-status-red; 
   } 
-  
+
   #{$gray-selectors} { 
     color: $media-status-gray;
   }
+  
+  #{$black-selectors} {
+    color: $media-status-black;
+  }
 }
 
+// Borders and backgrounds of media items
+//
 @mixin media-status-background-and-border-colors {
   #{$blue-selectors} { 
     background: $media-status-blue-bg;
@@ -139,5 +166,50 @@ $gray-selectors: "&--not-applicable_2, &--not-applicable-2, &--marked-for-deleti
   #{$gray-selectors} { 
     background: $media-status-gray-bg; 
     border-color: $media-status-gray;
+  }
+
+  #{$black-selectors} {
+    background: $media-status-black-bg; 
+    border-color: $media-status-black;
+  }
+}
+
+// Backgrounds in the status menu
+//
+@mixin media-status-menu-hover-colors {
+  #{$blue-selectors} {
+    &:hover { 
+     background: $media-status-blue-hover-bg; 
+    }
+  }
+
+  #{$orange-selectors} { 
+    &:hover {
+      background: $media-status-orange-hover-bg;
+    }
+  }
+
+  #{$green-selectors} { 
+    &:hover {
+      background: $media-status-green-hover-bg;
+    }
+  }
+
+  #{$red-selectors} { 
+    &:hover {
+      background: $media-status-red-hover-bg;
+    }
+  }
+
+  #{$gray-selectors} {
+    &:hover {
+      background: $media-status-grey-hover-bg;
+    }
+  }
+  
+  #{$black-selectors} {
+    &:hover {
+      background: $media-status-black-hover-bg;
+    }
   }
 }


### PR DESCRIPTION
WHAT

Some of the new electionland colors like "important/verified" don't have sensible colors. 

BEFORE: 

The colors are just missing for some of the statuses.
<img width="818" alt="screen shot 2016-11-05 at 5 16 38 pm" src="https://cloud.githubusercontent.com/assets/7366/20034453/e2ddb316-a37b-11e6-8585-fc1d46229073.png">


AFTER: 

I added selectors so that the new statuses would be appropriately red/green/orange/grey. [I can't preview them locally so I have not provided a screenshot.]