### PR TITLE
Hide the actions menu on search page

### DIFF
--- a/src/app/styles/components/search/_search.scss
+++ b/src/app/styles/components/search/_search.scss
@@ -71,10 +71,9 @@
   }
 }
 
-// hack
-
-.search {
-  .media-status__menu {
-    display: none; // TODO: refactor media card vs. detail vs search
-  }
+// Report tagging in search results
+// Embargoed 2016-11-6 — CB 
+//
+.search__results .media-actions__icon {
+  display: none;
 }


### PR DESCRIPTION
WHAT

On the search page, hide the actions menu on reports, because edit mode doesn't work reliably ATM.

BEFORE: 
<img width="992" alt="screen shot 2016-11-06 at 8 13 07 pm" src="https://cloud.githubusercontent.com/assets/7366/20046365/b9b4f0de-a45d-11e6-9381-98544117e0e2.png">

AFTER:
<img width="1019" alt="screen shot 2016-11-06 at 8 12 57 pm" src="https://cloud.githubusercontent.com/assets/7366/20046364/b9a165e6-a45d-11e6-8a86-d96c61502634.png">

