### PR TITLE
Feature/mobile project description

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,7 +1,7 @@
 options:
   formatter: html
   # Output file instead of logging results
-  output-file: './linters/sass-lint.html'
+  # output-file: './linters/sass-lint.html'
   # Raise an error if more than 50 warnings are generated
   max-warnings: 3080
 files:

--- a/src/app/styles/components/project/_project-header.scss
+++ b/src/app/styles/components/project/_project-header.scss
@@ -96,12 +96,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis; // TODO: better
-  @media screen and (min-width: 700px) { width: 400px };
-  @media screen and (min-width: 800px) { width: 500px };
-  @media screen and (min-width: 900px) { width: 600px };
-  @media screen and (min-width: 1000px) { width: 700px };
-  @media screen and (min-width: 1100px) { width: 800px };
-  @media screen and (min-width: 1200px) { width: 900px };
+  @media screen and (min-width: 700px) { width: 400px; }
+  @media screen and (min-width: 800px) { width: 500px; }
+  @media screen and (min-width: 900px) { width: 600px; }
+  @media screen and (min-width: 1000px) { width: 700px; }
+  @media screen and (min-width: 1100px) { width: 800px; }
+  @media screen and (min-width: 1200px) { width: 900px; }
 
   @media screen and (max-width: $layout-mobile-breakpoint) {
     white-space: normal;

--- a/src/app/styles/components/project/_project-header.scss
+++ b/src/app/styles/components/project/_project-header.scss
@@ -56,6 +56,7 @@
 
 .project-header__project-copy {
   flex: 1;
+  cursor: default;
 }
 
 .project-header__project-name-input,
@@ -101,6 +102,12 @@
   @media screen and (min-width: 1000px) { width: 700px };
   @media screen and (min-width: 1100px) { width: 800px };
   @media screen and (min-width: 1200px) { width: 900px };
+
+  @media screen and (max-width: $layout-mobile-breakpoint) {
+    white-space: normal;
+    max-height: auto;
+  }
+
   &:hover {
     white-space: normal;
     overflow: auto;

--- a/src/app/styles/stylesheet.scss
+++ b/src/app/styles/stylesheet.scss
@@ -44,6 +44,7 @@
 body {
   margin: auto;
   width: 100%;
+  overflow-x: hidden;
 }
 
 .hidden {


### PR DESCRIPTION
WHAT

Fixes a problem where the project description would overflow the viewport on mobile.

BEFORE

There was horizontal overflow and if you scroll sideways it looks like this: 
<img width="397" alt="screen shot 2016-11-08 at 12 15 37 am" src="https://cloud.githubusercontent.com/assets/7366/20091723/1ce9d08e-a549-11e6-8fd1-99636d074476.png">



AFTER

Now it truncates the description and when you hover it correctly expands to show it all.

<img width="361" alt="screen shot 2016-11-08 at 12 15 50 am" src="https://cloud.githubusercontent.com/assets/7366/20091646/b806bf60-a548-11e6-8138-2ddbcdb8e155.png">
<img width="360" alt="screen shot 2016-11-08 at 12 15 44 am" src="https://cloud.githubusercontent.com/assets/7366/20091647/b80b41c0-a548-11e6-9427-8ca4005dd8c2.png">
