### PR TITLE
 Prevent squished images. Improve thumbnail layout on mobile. #5428

### DIFF
--- a/src/app/styles/components/media/_social-media-card.scss
+++ b/src/app/styles/components/media/_social-media-card.scss
@@ -62,6 +62,9 @@
   justify-content: space-between;
   align-items: flex-start;
   font-size: 18px;
+  @media all and (max-width: $layout-mobile-breakpoint-small) {
+    flex-wrap: wrap;
+  }
 }
 
 .social-media-card__body-text {
@@ -70,6 +73,10 @@
 
 .social-media-card__body-image {
   @include image(72px);
+  flex-shrink: 0;
+  @media all and (max-width: $layout-mobile-breakpoint-small) {
+    margin-top: 8px;
+  }
 }
 
 .social-media-card__footer {

--- a/src/app/styles/theme/_layout.scss
+++ b/src/app/styles/theme/_layout.scss
@@ -20,6 +20,7 @@ $layout-column-width-narrow: 900px;
 $layout-column-width-wide: 1200px + 30px;
 
 $layout-mobile-breakpoint-smallest: 320px;
+$layout-mobile-breakpoint-small: 450px;
 $layout-mobile-breakpoint: 680px;
 $layout-tablet-breakpoint: $layout-column-width-narrow;
 $layout-widescreen-breakpoint: $layout-column-width-wide;


### PR DESCRIPTION
WHAT

Sometimes images were getting squished. This makes them stay their correct width.

BEFORE

The image was too skinny: 

<img width="422" alt="screen shot 2016-11-08 at 12 21 32 am" src="https://cloud.githubusercontent.com/assets/7366/20092464/34a410a0-a54d-11e6-97b1-38e894acbcd3.png">

AFTER

The image is wider: 
<img width="588" alt="screen shot 2016-11-08 at 12 23 42 am" src="https://cloud.githubusercontent.com/assets/7366/20092477/42fc270a-a54d-11e6-892a-140fbce9cfa2.png">

But on very small viewports the wider image would overflow: 

<img width="365" alt="screen shot 2016-11-08 at 12 38 45 am" src="https://cloud.githubusercontent.com/assets/7366/20092490/550d9da2-a54d-11e6-9c73-a6e45d192355.png">

So this also fixes it so they reflow underneath: 

<img width="368" alt="screen shot 2016-11-08 at 12 39 16 am" src="https://cloud.githubusercontent.com/assets/7366/20092498/5d9e9fac-a54d-11e6-826d-ccbba7f1751b.png">

