### PR TITLE
Workaround for Sass compilation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "logo": "cd src/assets/images/logo && ./generate.sh && cd ..",
-    "style": "node-sass src/app/styles/stylesheet.scss --output-style=compressed | postcss --use autoprefixer -o build/web/css/stylesheet.css && cp -r src/app/styles/images build/web/",
+    "style": "npm run style:sass && npm run style:postcss && cp -r src/app/styles/images build/web/",
+    "style:sass": "mkdir -p .tmp && node-sass src/app/styles/stylesheet.scss --output-style=compressed > .tmp/stylesheet.css.tmp",
+    "style:postcss": "postcss --use autoprefixer -o build/web/css/stylesheet.css .tmp/stylesheet.css.tmp && rm .tmp/stylesheet.css.tmp",
     "style:rebuild": "npm rebuild node-sass && mkdir -p build/web/css 2>/dev/null && npm run style",
     "build": "rm -rf build/web && npm run style && npm run build:gulp",
     "build:gulp": "npm run transifex:download && BABEL_ENV=production gulp build:web && npm run transifex:upload",


### PR DESCRIPTION
I find that with the old command only up to ~65535 bytes
can be piped from Sass to PostCSS. This uses a temp file.

@karim, re: comments, I just removed the stderr log file since it isn't really necessary, and made the .tmp path change. Didn't break Travis.