### PR TITLE
6221 missing twitter metadata

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,5 +41,7 @@
 
         //Todo: improve a11y compliance
         "jsx-a11y/no-static-element-interactions": "warn",
+
+        no-irregular-whitespace: ["error", { "skipComments": true }],
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,5 +38,8 @@
 
         //Todo: Refactor to only have one component per file (or set this rule to off)
         "react/no-multi-comp": "warn",
+
+        //Todo: improve a11y compliance
+        "jsx-a11y/no-static-element-interactions": "warn",
     }
 }

--- a/src/app/components/media/MediaUtil.js
+++ b/src/app/components/media/MediaUtil.js
@@ -5,66 +5,66 @@ import FaTwitter from 'react-icons/lib/fa/twitter';
 import FaYoutubePlay from 'react-icons/lib/fa/youtube-play';
 import MdLink from 'react-icons/lib/md/link';
 import { defineMessages } from 'react-intl';
-import { truncateLength } from '../../helpers';
 import config from 'config';
+import { truncateLength } from '../../helpers';
 
 const messages = defineMessages({
   notesCount: {
     id: 'media.notesCount',
-    defaultMessage: '{notesCount, plural, =0 {No notes} one {1 note} other {# notes}}'
+    defaultMessage: '{notesCount, plural, =0 {No notes} one {1 note} other {# notes}}',
   },
   typeTwitter: {
     id: 'media.typeTwitter',
-    defaultMessage: 'Tweet'
+    defaultMessage: 'Tweet',
   },
   typeFacebook: {
     id: 'media.typeFacebook',
-    defaultMessage: 'Facebook post'
+    defaultMessage: 'Facebook post',
   },
   typeInstagram: {
     id: 'media.typeInstagram',
-    defaultMessage: 'Instagram'
+    defaultMessage: 'Instagram',
   },
   typeVideo: {
     id: 'media.typeVideo',
-    defaultMessage: 'Video'
+    defaultMessage: 'Video',
   },
   typeClaim: {
     id: 'media.typeClaim',
-    defaultMessage: 'Claim'
+    defaultMessage: 'Claim',
   },
   bridge_typeClaim: {
     id: 'bridge.media.typeClaim',
-    defaultMessage: 'Quote'
+    defaultMessage: 'Quote',
   },
   typeImage: {
     id: 'media.typeImage',
-    defaultMessage: 'Image'
+    defaultMessage: 'Image',
   },
   typePage: {
     id: 'media.typePage',
-    defaultMessage: 'Page'
+    defaultMessage: 'Page',
   },
   onDomain: {
     id: 'media.onDomain',
-    defaultMessage: '{typeLabel} on {domain}'
+    defaultMessage: '{typeLabel} on {domain}',
   },
   byAttribution: {
     id: 'media.byAttribution',
-    defaultMessage: '{typeLabel} by {attribution}'
+    defaultMessage: '{typeLabel} by {attribution}',
   },
   withText: {
     id: 'media.withText',
-    defaultMessage: '{typeLabel}: {text}'
+    defaultMessage: '{typeLabel}: {text}',
   },
   favoritesCount: {
     id: 'media.favoritesCount',
-    defaultMessage: '{favoritesCount, plural, =0 {} one {1 favorite} other {# favorites}}'
+    defaultMessage: '{favoritesCount, plural, =0 {} one {1 favorite} other {# favorites}}',
   },
   retweetsCount: {
     id: 'media.retweetsCount',
-    defaultMessage: '{retweetsCount, plural, =0 {} one {1 retweet} other {# retweets}}'
-  }
+    defaultMessage: '{retweetsCount, plural, =0 {} one {1 retweet} other {# retweets}}',
+  },
 });
 
 const MediaUtil = {
@@ -88,26 +88,23 @@ const MediaUtil = {
     return data.author_url;
   },
 
-  mediaType(media, data) {
+  mediaType(media) {
     let type = null;
     try {
-      const socialMedia = ({
+      const socialMedia = {
         'twitter.com': messages.typeTwitter,
         'facebook.com': messages.typeFacebook,
         'instagram.com': messages.typeInstagram,
         'youtube.com': messages.typeVideo,
-      }[media.domain]);
+      }[media.domain];
 
       if (socialMedia) {
         type = socialMedia;
-      }
-      else if (media.quote) {
-        type = (config.appName === 'check') ? messages.typeClaim : messages.bridge_typeClaim;
-      }
-      else if (media.embed_path) {
+      } else if (media.quote) {
+        type = config.appName === 'check' ? messages.typeClaim : messages.bridge_typeClaim;
+      } else if (media.embed_path) {
         type = messages.typeImage;
-      }
-      else if (media.domain) {
+      } else if (media.domain) {
         type = messages.typePage;
       }
     } catch (e) {
@@ -133,14 +130,16 @@ const MediaUtil = {
       const type = this.mediaType(media, data);
       typeLabel = intl.formatMessage(type);
       if (type === messages.typePage) {
-        return intl.formatMessage(messages.onDomain, {typeLabel, domain: media.domain});
+        return intl.formatMessage(messages.onDomain, { typeLabel, domain: media.domain });
       } else if (type === messages.typeImage) {
         return data.title || typeLabel;
       } else if (type === messages.typeClaim) {
-        return (data.title && data.title != media.quote) ? data.title : typeLabel;
+        return data.title && data.title !== media.quote ? data.title : typeLabel;
       }
       const attribution = this.authorName(media, data);
-      return attribution ? intl.formatMessage(messages.byAttribution, {typeLabel, attribution}) : typeLabel;
+      return attribution
+        ? intl.formatMessage(messages.byAttribution, { typeLabel, attribution })
+        : typeLabel;
     } catch (e) {
       return typeLabel || '';
     }
@@ -156,15 +155,19 @@ const MediaUtil = {
       const type = this.mediaType(media, data);
       typeLabel = intl.formatMessage(type);
       if (type === messages.typePage) {
-        return intl.formatMessage(messages.onDomain, {typeLabel, domain: media.domain});
+        return intl.formatMessage(messages.onDomain, { typeLabel, domain: media.domain });
       } else if (type === messages.typeClaim) {
         const text = data.quote;
-        return text ? intl.formatMessage(messages.withText, {typeLabel, text}) : typeLabel;
+        return text ? intl.formatMessage(messages.withText, { typeLabel, text }) : typeLabel;
       }
       const attribution = this.authorName(media, data);
       const text = this.bodyText(media, data);
-      const byAttribution = attribution ? intl.formatMessage(messages.byAttribution, {typeLabel, attribution}) : typeLabel;
-      return text ? intl.formatMessage(messages.withText, {typeLabel: byAttribution, text}) : byAttribution;
+      const byAttribution = attribution
+        ? intl.formatMessage(messages.byAttribution, { typeLabel, attribution })
+        : typeLabel;
+      return text
+        ? intl.formatMessage(messages.withText, { typeLabel: byAttribution, text })
+        : byAttribution;
     } catch (e) {
       return typeLabel || '';
     }
@@ -172,13 +175,14 @@ const MediaUtil = {
 
   // Return a text fragment "X notes" with proper pluralization.
   notesCount(media, data, intl) {
-    return intl.formatMessage(messages.notesCount, {notesCount: media.log_count});
+    return intl.formatMessage(messages.notesCount, { notesCount: media.log_count });
   },
 
-  createdAt(media) { // check media
+  createdAt(media) {
+    // check media
     let date = null;
     try {
-      date = new Date(parseInt(media.published) * 1000);
+      date = new Date(parseInt(media.published, 10) * 1000);
       if (isNaN(date)) date = null;
     } catch (e) {
       date = null;
@@ -186,7 +190,8 @@ const MediaUtil = {
     return date;
   },
 
-  embedPublishedAt(media, data) { // embedded media
+  embedPublishedAt(media, data) {
+    // embedded media
     let date = null;
     try {
       date = new Date(data.published_at);
@@ -215,19 +220,25 @@ const MediaUtil = {
       return <FaInstagram />;
     case 'facebook.com':
       return <FaFacebookSquare />;
-    default :
+    default:
       return <MdLink />;
     }
   },
 
-  stats(media, data) {
+  stats(media, data, intl) {
     try {
-      return ({
-        'twitter.com': [
-          intl.formatMessage(messages.favoritesCount, {favoritesCount: data.favorite_count}),
-          intl.formatMessage(messages.retweetsCount, {retweetsCount: data.retweet_count}),
-        ],
-      }[media.domain] || []);
+      return (
+        {
+          'twitter.com': [
+            intl.formatMessage(messages.favoritesCount, {
+              favoritesCount: data.raw.api.favorite_count,
+            }),
+            intl.formatMessage(messages.retweetsCount, {
+              retweetsCount: data.raw.api.retweet_count,
+            }),
+          ],
+        }[media.domain] || []
+      );
     } catch (e) {
       return [];
     }

--- a/src/app/components/media/SocialMediaCard.js
+++ b/src/app/components/media/SocialMediaCard.js
@@ -1,12 +1,11 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
-import { Link } from 'react-router';
+import deepEqual from 'deep-equal';
 import MediaUtil from './MediaUtil';
 import MediaInspector from './MediaInspector';
 import AuthorPicture from '../AuthorPicture';
 import TimeBefore from '../TimeBefore';
 import { bemClass } from '../../helpers';
-import deepEqual from 'deep-equal';
 import ParsedText from '../ParsedText';
 
 const messages = defineMessages({
@@ -25,19 +24,19 @@ class SocialMediaCard extends Component {
     };
   }
 
-  handleBodyClick(e) {
+  shouldComponentUpdate(nextProps, nextState) {
+    return !deepEqual(nextProps, this.props) || !deepEqual(nextState, this.state);
+  }
+
+  handleBodyClick() {
     if (!this.props.condensed) {
       // only open inspector on media page
       this.setState({ isInspectorActive: true });
     }
   }
 
-  handleInspectorDismiss(e) {
+  handleInspectorDismiss() {
     this.setState({ isInspectorActive: false });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return !deepEqual(nextProps, this.props) || !deepEqual(nextState, this.state);
   }
 
   render() {

--- a/src/app/components/media/SocialMediaCard.js
+++ b/src/app/components/media/SocialMediaCard.js
@@ -26,7 +26,8 @@ class SocialMediaCard extends Component {
   }
 
   handleBodyClick(e) {
-    if (!this.props.condensed) { // only open inspector on media page
+    if (!this.props.condensed) {
+      // only open inspector on media page
       this.setState({ isInspectorActive: true });
     }
   }
@@ -52,26 +53,49 @@ class SocialMediaCard extends Component {
 
     return (
       <article className="social-media-card">
-        <MediaInspector media={media} isActive={this.state.isInspectorActive} dismiss={this.handleInspectorDismiss.bind(this)} />
+        <MediaInspector
+          media={media}
+          isActive={this.state.isInspectorActive}
+          dismiss={this.handleInspectorDismiss.bind(this)}
+        />
         <div className="social-media-column-alpha">
           <div className="social-media-card__header / card-header">
             <AuthorPicture media={media} data={data} />
             <div className="social-media-card__header-text-primary / header-text-primary">
-              <a href={authorUrl} target="_blank" rel="noopener noreferrer" className="social-media-card__name">{authorName || authorUsername}</a>
-              { ((authorName && authorUsername) && (authorName !== authorUsername)) ?
-                <a href={authorUrl} target="_blank" rel="noopener noreferrer" className="social-media-card__username">{authorUsername}</a> : null
-              }
+              <a
+                href={authorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-media-card__name"
+              >
+                {authorName || authorUsername}
+              </a>
+              {authorName && authorUsername && authorName !== authorUsername
+                ? <a
+                  href={authorUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="social-media-card__username"
+                >
+                  {authorUsername}
+                </a>
+                : null}
             </div>
           </div>
 
-          <div className={bemClass('social-media-card__body', condensed, '--condensed')} onClick={this.handleBodyClick.bind(this)}>
+          <div
+            className={bemClass('social-media-card__body', condensed, '--condensed')}
+            onClick={this.handleBodyClick.bind(this)}
+          >
             <div className="social-media-card__body-text"><ParsedText text={bodyText} /></div>
           </div>
 
           <span className="social-media-card__header-text-secondary">
-            { MediaUtil.socialIcon(media.domain) }
+            {MediaUtil.socialIcon(media.domain)}
             <a href={url} target="_blank" rel="noopener noreferrer">
-              {embedPublishedAt ? <TimeBefore date={embedPublishedAt} /> : this.props.intl.formatMessage(messages.link)}
+              {embedPublishedAt
+                ? <TimeBefore date={embedPublishedAt} />
+                : this.props.intl.formatMessage(messages.link)}
             </a>
           </span>
           <div className="social-media-card__footer">
@@ -80,9 +104,12 @@ class SocialMediaCard extends Component {
         </div>
 
         <div className="social-media-column-omega">
-          {bodyImageUrl ?
-            <div className="social-media-card__body-image" style={{ backgroundImage: `url(${bodyImageUrl})` }} />
-          : null }
+          {bodyImageUrl
+            ? <div
+              className="social-media-card__body-image"
+              style={{ backgroundImage: `url(${bodyImageUrl})` }}
+            />
+            : null}
         </div>
       </article>
     );

--- a/src/app/components/media/SocialMediaCard.js
+++ b/src/app/components/media/SocialMediaCard.js
@@ -98,7 +98,7 @@ class SocialMediaCard extends Component {
             </a>
           </span>
           <div className="social-media-card__footer">
-            {stats.map(stat => <span className="social-media-card__footer-stat">{stat}</span>)}
+            {stats.map(stat => <span key={stat} className="social-media-card__footer-stat">{stat}</span>)}
           </div>
         </div>
 

--- a/test/unit/social_media_card.spec.js
+++ b/test/unit/social_media_card.spec.js
@@ -1,62 +1,68 @@
-// import React from 'react';
-// import Relay from 'react-relay';
-// import { IntlProvider } from 'react-intl';
-// import { shallow } from 'enzyme';
-// import { expect } from 'chai';
-// import SocialMediaCard from '../../src/app/components/media/SocialMediaCard';
+import React from 'react';
+import Relay from 'react-relay';
+import { IntlProvider } from 'react-intl';
+import { render } from 'enzyme';
+import { expect } from 'chai';
+import SocialMediaCard from '../../src/app/components/media/SocialMediaCard';
 
-// const tweetMedia = {
-//   __dataID__: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
-//   id: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
-//   dbid: 5176,
-//   url: 'https://twitter.com/mollypriddy/status/895081687989669888',
-//   quote: null,
-//   published: '1502397128',
-//   updated_at: '1502397129',
-//   embed: '',
-//   log_count: 0,
-//   verification_statuses: '',
-//   translation_statuses: '',
-//   overridden: '{"title":false,
-//     "description":false,
-//     "username":false}',
-//   project_id: 444,
-//   pusher_channel: '',
-//   language: null,
-//   language_code: null,
-//   domain: 'twitter.com',
-//   permissions: '{"read ProjectMedia":true,
-//     "update ProjectMedia":true,
-//     "destroy ProjectMedia":true,
-//     "create Comment":true,
-//     "create Flag":true,
-//     "create Status":true,
-//     "create Tag":true,
-//     "create Dynamic":true,
-//     "create Task":true}',
-//   last_status: 'undetermined',
-//   field_value: 'pending',
-//   translation_status: {},
-//   last_status_obj: {},
-//   project: {},
-//   media: {},
-//   user: {},
-//   team: {},
-//   tags: {},
-//   embed_path: '',
-// };
+const tweetMedia = {
+  __dataID__: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
+  id: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
+  dbid: 5176,
+  url: 'https://twitter.com/mollypriddy/status/895081687989669888',
+  quote: null,
+  published: '1502397128',
+  updated_at: '1502397129',
+  embed: '',
+  log_count: 0,
+  verification_statuses: '',
+  translation_statuses: '',
+  overridden: '{"title":false,"description":false,"username":false}',
+  project_id: 444,
+  pusher_channel: '',
+  language: null,
+  language_code: null,
+  domain: 'twitter.com',
+  permissions: JSON.stringify({
+    "read ProjectMedia": true,
+    "update ProjectMedia": true,
+    "destroy ProjectMedia": true,
+    "create Comment": true,
+    "create Flag": true,
+    "create Status": true,
+    "create Tag": true,
+    "create Dynamic": true,
+    "create Task": true
+  }),
+  last_status: 'undetermined',
+  field_value: 'pending',
+  translation_status: {},
+  last_status_obj: {},
+  project: {},
+  media: {},
+  user: {},
+  team: {},
+  tags: {},
+  embed_path: '',
+};
+
+const data = {
+  raw: {
+    api: {
+      favorite_count: 10,
+      retweet_count: 20
+    }
+  }
+};
 
 describe('<SocialMediaCard />', () => {
-  it('WIP skipped...');
-
-  // TODO make this test work — CGB 2017-8-10
-  //
-  // it('shows stats for tweets on project page', () => {
-  //   const twitterCard = shallow(
-  //     <IntlProvider locale="en">
-  //       <SocialMediaCard condensed media={tweetMedia} />
-  //     </IntlProvider>);
-  //   console.log(twitterCard.debug());
-  // expect(twitterCard.find('.social-media-card')).to.equal(true);
-  // });
+  it('shows stats for tweets on project page', () => {
+    const twitterCard = render(
+      <IntlProvider locale="en">
+        <SocialMediaCard condensed media={tweetMedia} data={data} />
+      </IntlProvider>
+    );
+    expect(twitterCard.text()).to.contain("10 favorites");
+    expect(twitterCard.text()).to.contain("20 retweets");
+  });
 });

--- a/test/unit/social_media_card.spec.js
+++ b/test/unit/social_media_card.spec.js
@@ -1,0 +1,62 @@
+// import React from 'react';
+// import Relay from 'react-relay';
+// import { IntlProvider } from 'react-intl';
+// import { shallow } from 'enzyme';
+// import { expect } from 'chai';
+// import SocialMediaCard from '../../src/app/components/media/SocialMediaCard';
+
+// const tweetMedia = {
+//   __dataID__: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
+//   id: 'UHJvamVjdE1lZGlhLzUxNzY=\n',
+//   dbid: 5176,
+//   url: 'https://twitter.com/mollypriddy/status/895081687989669888',
+//   quote: null,
+//   published: '1502397128',
+//   updated_at: '1502397129',
+//   embed: '',
+//   log_count: 0,
+//   verification_statuses: '',
+//   translation_statuses: '',
+//   overridden: '{"title":false,
+//     "description":false,
+//     "username":false}',
+//   project_id: 444,
+//   pusher_channel: '',
+//   language: null,
+//   language_code: null,
+//   domain: 'twitter.com',
+//   permissions: '{"read ProjectMedia":true,
+//     "update ProjectMedia":true,
+//     "destroy ProjectMedia":true,
+//     "create Comment":true,
+//     "create Flag":true,
+//     "create Status":true,
+//     "create Tag":true,
+//     "create Dynamic":true,
+//     "create Task":true}',
+//   last_status: 'undetermined',
+//   field_value: 'pending',
+//   translation_status: {},
+//   last_status_obj: {},
+//   project: {},
+//   media: {},
+//   user: {},
+//   team: {},
+//   tags: {},
+//   embed_path: '',
+// };
+
+describe('<SocialMediaCard />', () => {
+  it('WIP skipped...');
+
+  // TODO make this test work — CGB 2017-8-10
+  //
+  // it('shows stats for tweets on project page', () => {
+  //   const twitterCard = shallow(
+  //     <IntlProvider locale="en">
+  //       <SocialMediaCard condensed media={tweetMedia} />
+  //     </IntlProvider>);
+  //   console.log(twitterCard.debug());
+  // expect(twitterCard.find('.social-media-card')).to.equal(true);
+  // });
+});


### PR DESCRIPTION
- most changes are linting
- in stats() I am calling `favoritesCount: data.raw.api.favorite_count` because `data.favorite_count` is missing now — not sure why that changed
- not sure how to get the new test to work, but I sketched out an approach where I'm mocking `tweetMedia` object and passing it to the `media` prop on `SocialMediaCard`

Before: 
<img width="679" alt="screen shot 2017-08-10 at 1 32 16 pm" src="https://user-images.githubusercontent.com/7366/29194202-6bb55982-7ddd-11e7-93de-05d20b0e1c1b.png">

After: 
<img width="703" alt="screen shot 2017-08-10 at 1 31 05 pm" src="https://user-images.githubusercontent.com/7366/29194212-72881f74-7ddd-11e7-8c12-1b7f1b98fa8d.png">