### PR TITLE
Nix react-router-redux; CheckContext.history => browserHistory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12563,11 +12563,6 @@
         }
       }
     },
-    "react-router-redux": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
-      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
-    },
     "react-scrollbar-size": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "react-redux": "^5.0.1",
     "react-relay": "^1.7.0",
     "react-router": "^3.2.6",
-    "react-router-redux": "^4.0.5",
     "react-select": "^1.3.0",
     "redux": "^3.0.0",
     "redux-notify": "^0.2.0",

--- a/src/app/CheckContext.js
+++ b/src/app/CheckContext.js
@@ -1,8 +1,19 @@
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
 import { SET_CONTEXT } from './redux/ActionTypes';
 // import { request } from './redux/actions';
 import CheckNetworkLayer from './CheckNetworkLayer';
+
+function redirectToPreviousPageOr(path) {
+  const previousPage = window.storage.getValue('previousPage');
+  window.storage.set('previousPage', '');
+  if (previousPage && previousPage !== '') {
+    browserHistory.push(previousPage);
+  } else {
+    browserHistory.push(path);
+  }
+}
 
 // Verify if user is logged in, if so, start a session
 // and set the context based on session information
@@ -34,12 +45,10 @@ class CheckContext {
 
   startNetwork(token) {
     const context = this.getContextStore();
-    const { history } = context;
     const clientSessionId = context.clientSessionId || (`browser-${Date.now()}${parseInt(Math.random() * 1000000, 10)}`);
     this.setContextStore({ clientSessionId });
     Relay.injectNetworkLayer(new CheckNetworkLayer(config.relayPath, {
       caller: this.caller,
-      history,
       team: () => {
         const { team } = this.getContextStore();
         if (team) {
@@ -85,7 +94,7 @@ class CheckContext {
     this.setContextStore({ currentUser: userData });
 
     if (userData && !userData.accepted_terms) {
-      this.getContextStore().history.push('/check/user/terms-of-service');
+      browserHistory.push('/check/user/terms-of-service');
     } else {
       this.maybeRedirect(this.caller.props.location.pathname, userData);
       this.setContext();
@@ -132,7 +141,7 @@ class CheckContext {
     }
     this.setContextStore(newContext);
 
-    this.redirectToPreviousPageOr(path);
+    redirectToPreviousPageOr(path);
   }
 
   // When accessing Check root, redirect to a friendlier location if needed:
@@ -145,7 +154,7 @@ class CheckContext {
 
     const userCurrentTeam = userData.current_team;
     if (!userCurrentTeam) {
-      this.redirectToPreviousPageOr('/check/teams/find');
+      redirectToPreviousPageOr('/check/teams/find');
       return;
     }
     let projectNode = null;
@@ -157,16 +166,6 @@ class CheckContext {
       this.setContextAndRedirect(project.team, project);
     } else {
       this.setContextAndRedirect(userCurrentTeam, null);
-    }
-  }
-
-  redirectToPreviousPageOr(path) {
-    const previousPage = window.storage.getValue('previousPage');
-    window.storage.set('previousPage', '');
-    if (previousPage && previousPage !== '') {
-      this.getContextStore().history.push(previousPage);
-    } else {
-      this.getContextStore().history.push(path);
     }
   }
 }

--- a/src/app/CheckNetworkLayer.js
+++ b/src/app/CheckNetworkLayer.js
@@ -1,4 +1,5 @@
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import { defineMessages } from 'react-intl';
 import util from 'util';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
@@ -122,15 +123,14 @@ class CheckNetworkLayer extends Relay.DefaultNetworkLayer {
       // eslint-disable-next-line no-console
       console.debug('%cSending request to backend ', 'font-weight: bold');
     }
-    const { history } = this._init;
     if (result.status === 404 && window.location.pathname !== '/check/not-found') {
-      history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
     } else if (result.status === 401 || result.status === 403) {
       const team = this._init.team();
       if (team !== '') {
-        history.push(`/${team}/join`);
+        browserHistory.push(`/${team}/join`);
       } else if (window.location.pathname !== '/check/forbidden') {
-        history.push('/check/forbidden');
+        browserHistory.push('/check/forbidden');
       }
     }
   }

--- a/src/app/components/ChangePasswordComponent.js
+++ b/src/app/components/ChangePasswordComponent.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
+import { browserHistory } from 'react-router';
 import Relay from 'react-relay/classic';
 import Button from '@material-ui/core/Button';
 import TextField from 'material-ui/TextField';
 import ChangePasswordMutation from '../relay/mutations/ChangePasswordMutation';
-import CheckContext from '../CheckContext';
 import globalStrings from '../globalStrings';
 import { stringHelper } from '../customHelpers';
 import { getErrorMessage } from '../helpers';
@@ -52,10 +51,6 @@ class ChangePasswordComponent extends Component {
     return decodeURIComponent(window.location.search.replace(new RegExp(`^(?:.*[&\\?]${encodeURIComponent(key).replace(/[.+*]/g, '\\$&')}(?:\\=([^&]*))?)?.*$`, 'i'), '$1'));
   }
 
-  getHistory() {
-    return new CheckContext(this).getContextStore().history;
-  }
-
   handleChangeCurrentPassword(e) {
     this.setState({ current_password: e.target.value });
   }
@@ -81,7 +76,7 @@ class ChangePasswordComponent extends Component {
       const fallbackMessage = this.props.intl.formatMessage(globalStrings.unknownError, { supportEmail: stringHelper('SUPPORT_EMAIL') });
       const message = getErrorMessage(transaction, fallbackMessage);
       if (this.props.type === 'reset-password') {
-        this.getHistory().push({ pathname: '/check/user/password-reset', state: { errorMsg: message } });
+        browserHistory.push({ pathname: '/check/user/password-reset', state: { errorMsg: message } });
         return;
       }
       this.setState({ errorMsg: message });
@@ -166,9 +161,5 @@ class ChangePasswordComponent extends Component {
     );
   }
 }
-
-ChangePasswordComponent.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(ChangePasswordComponent);

--- a/src/app/components/DrawerNavigationComponent.js
+++ b/src/app/components/DrawerNavigationComponent.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import Button from '@material-ui/core/Button';
 import Drawer from '@material-ui/core/Drawer';
 import Divider from '@material-ui/core/Divider';
@@ -67,10 +67,6 @@ class DrawerNavigationComponent extends Component {
     return new CheckContext(this).getContextStore().currentUser;
   }
 
-  getHistory() {
-    return new CheckContext(this).getContextStore().history;
-  }
-
   setContextTeam() {
     const context = new CheckContext(this);
     const { team } = this.props;
@@ -107,7 +103,7 @@ class DrawerNavigationComponent extends Component {
   }
 
   handleClickTeamSettings() {
-    this.getHistory().push(`/${this.props.team.slug}/settings`);
+    browserHistory.push(`/${this.props.team.slug}/settings`);
   }
 
   render() {

--- a/src/app/components/Header.js
+++ b/src/app/components/Header.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import styled from 'styled-components';
 import Relay from 'react-relay/classic';
 import TeamPublicHeader from './team/TeamPublicHeader';
 import ProjectHeader from './project/ProjectHeader';
-import CheckContext from '../CheckContext';
 import PublicTeamRoute from '../relay/PublicTeamRoute';
 import teamPublicFragment from '../relay/teamPublicFragment';
 
@@ -40,15 +39,11 @@ class HeaderComponent extends React.Component {
     this.handleQuery();
   }
 
-  getContext() {
-    return new CheckContext(this).getContextStore();
-  }
-
   handleQuery = () => {
     const { team, teamSlug } = this.props;
 
     if (!team && teamSlug) {
-      this.getContext().history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
     }
   };
 
@@ -101,10 +96,6 @@ class HeaderComponent extends React.Component {
     );
   }
 }
-
-HeaderComponent.contextTypes = {
-  store: PropTypes.object,
-};
 
 const Header = (props) => {
   if (props.inTeamContext) {

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import {
   FormattedMessage,
   injectIntl,
@@ -11,7 +10,7 @@ import FAFacebook from 'react-icons/lib/fa/facebook-official';
 import FATwitter from 'react-icons/lib/fa/twitter';
 import MDEmail from 'react-icons/lib/md/email';
 import rtlDetect from 'rtl-detect';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import Button from '@material-ui/core/Button';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import TextField from '@material-ui/core/TextField';
@@ -20,7 +19,6 @@ import styled from 'styled-components';
 import Message from './Message';
 import UploadImage from './UploadImage';
 import UserTosForm from './UserTosForm';
-import CheckContext from '../CheckContext';
 import { login, request } from '../redux/actions';
 import { mapGlobalMessage } from './MappedMessage';
 import { stringHelper } from '../customHelpers';
@@ -207,10 +205,6 @@ class Login extends Component {
     }
   }
 
-  getHistory() {
-    return new CheckContext(this).getContextStore().history;
-  }
-
   handleCheckTos() {
     this.setState({ checkedTos: !this.state.checkedTos });
   }
@@ -231,7 +225,6 @@ class Login extends Component {
   }
 
   emailLogin() {
-    const history = this.getHistory();
     const params = {
       'api_user[email]': this.state.email,
       'api_user[password]': this.state.password,
@@ -250,14 +243,13 @@ class Login extends Component {
     const successCallback = () => {
       this.setState({ message: null });
       this.props.loginCallback();
-      history.push('/');
+      browserHistory.push('/');
     };
 
     request('post', 'users/sign_in', failureCallback, successCallback, params);
   }
 
   registerEmail() {
-    const history = this.getHistory();
     const form = document.forms.register;
     const params = {
       'api_user[email]': this.state.email,
@@ -280,7 +272,7 @@ class Login extends Component {
     const successCallback = () => {
       this.setState({ message: null });
       this.props.loginCallback();
-      history.push(window.location.pathname);
+      browserHistory.push(window.location.pathname);
     };
 
     if (this.state.checkedTos && this.state.checkedPp) {
@@ -576,10 +568,6 @@ Login.propTypes = {
   // https://github.com/yannickcr/eslint-plugin-react/issues/1389
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
-};
-
-Login.contextTypes = {
-  store: PropTypes.object,
 };
 
 export default injectIntl(Login);

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { Router, Route, browserHistory, IndexRoute } from 'react-router';
-import { syncHistoryWithStore } from 'react-router-redux';
 import ReactGA from 'react-ga';
 import { IntlProvider } from 'react-intl';
 import deepEqual from 'deep-equal';
@@ -239,11 +238,10 @@ class Root extends Component {
   }
 
   setStore() {
-    const history = syncHistoryWithStore(browserHistory, this.props.store);
     const context = this.getContext();
     const store = context.store || this.props.store;
 
-    const data = { history, locale: this.props.locale };
+    const data = { locale: this.props.locale };
 
     if (config.pusherKey) {
       // Pusher is imported at runtime from a <script file> tag.
@@ -273,7 +271,7 @@ class Root extends Component {
         <RootLocale locale={locale} />
         <IntlProvider locale={locale} messages={translations}>
           <Provider store={store}>
-            <Router history={this.state.history} onUpdate={Root.logPageView}>
+            <Router history={browserHistory} onUpdate={Root.logPageView}>
               <Route path="/" component={App}>
                 <IndexRoute component={Team} />
                 <Route path="check/user/already-confirmed" component={UserAlreadyConfirmed} public />

--- a/src/app/components/UserPasswordChange.js
+++ b/src/app/components/UserPasswordChange.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import { browserHistory } from 'react-router';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -9,7 +9,6 @@ import Button from '@material-ui/core/Button';
 import rtlDetect from 'rtl-detect';
 import PageTitle from './PageTitle';
 import ChangePasswordComponent from './ChangePasswordComponent';
-import CheckContext from '../CheckContext';
 import { stringHelper } from '../customHelpers';
 import { StyledPasswordChange } from '../styles/js/shared';
 
@@ -32,6 +31,10 @@ const messages = defineMessages({
   },
 });
 
+function handleSignIn() {
+  browserHistory.push('/');
+}
+
 class UserPasswordChange extends Component {
   constructor(props) {
     super(props);
@@ -42,14 +45,6 @@ class UserPasswordChange extends Component {
 
   static getQueryStringValue(key) {
     return decodeURIComponent(window.location.search.replace(new RegExp(`^(?:.*[&\\?]${encodeURIComponent(key).replace(/[.+*]/g, '\\$&')}(?:\\=([^&]*))?)?.*$`, 'i'), '$1'));
-  }
-
-  getHistory() {
-    return new CheckContext(this).getContextStore().history;
-  }
-
-  handleSignIn() {
-    this.getHistory().push('/');
   }
 
   showConfirm() {
@@ -71,7 +66,7 @@ class UserPasswordChange extends Component {
                 />
               </CardContent>
               <CardActions className="user-password-change__actions">
-                <Button color="primary" onClick={this.handleSignIn.bind(this)}>
+                <Button color="primary" onClick={handleSignIn}>
                   <FormattedMessage id="passwordChange.signIn" defaultMessage="Got it" />
                 </Button>
               </CardActions>
@@ -98,9 +93,5 @@ class UserPasswordChange extends Component {
     );
   }
 }
-
-UserPasswordChange.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(UserPasswordChange);

--- a/src/app/components/UserPasswordReset.js
+++ b/src/app/components/UserPasswordReset.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import { browserHistory } from 'react-router';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import Relay from 'react-relay/classic';
 import Card from '@material-ui/core/Card';
@@ -29,7 +29,7 @@ const messages = defineMessages({
   },
 });
 
-class UserPasswordReset extends Component {
+class UserPasswordReset extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/app/components/media/CreateMedia.js
+++ b/src/app/components/media/CreateMedia.js
@@ -62,7 +62,7 @@ class CreateProjectMedia extends Component {
 
     const onSuccess = (response) => {
       const rid = response.createProjectSource.project_source.dbid;
-      context.history.push(prefix + rid);
+      browserHistory.push(prefix + rid);
       this.setState({ message: null });
     };
 
@@ -91,7 +91,7 @@ class CreateProjectMedia extends Component {
     const onSuccess = (response) => {
       if (getFilters() !== '{}') {
         const rid = response.createProjectMedia.project_media.dbid;
-        context.history.push(prefix + rid);
+        browserHistory.push(prefix + rid);
       }
       this.setState({ message: null });
     };

--- a/src/app/components/media/MediaActions.js
+++ b/src/app/components/media/MediaActions.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import IconMoreVert from '@material-ui/icons/MoreVert';
 import IconButton from '@material-ui/core/IconButton';
@@ -9,7 +9,6 @@ import ListItemText from '@material-ui/core/ListItemText';
 import styled from 'styled-components';
 import rtlDetect from 'rtl-detect';
 import { can } from '../Can';
-import CheckContext from '../../CheckContext';
 
 const StyledIconMenuWrapper = styled.div`
   margin-${props => (props.isRtl ? 'right' : 'left')}: auto;
@@ -37,16 +36,14 @@ class MediaActions extends Component {
 
   handleEmbed() {
     const { media } = this.props;
-    const { history } = new CheckContext(this).getContextStore();
     const projectPart = media.project_id ? `/project/${media.project_id}` : '';
-    history.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/embed`);
+    browserHistory.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/embed`);
   }
 
   handleMemebuster = () => {
     const { media } = this.props;
-    const { history } = new CheckContext(this).getContextStore();
     const projectPart = media.project_id ? `/project/${media.project_id}` : '';
-    history.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/memebuster`);
+    browserHistory.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/memebuster`);
   };
 
   render() {
@@ -255,9 +252,5 @@ class MediaActions extends Component {
       : null;
   }
 }
-
-MediaActions.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(MediaActions);

--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { injectIntl, FormattedMessage, defineMessages } from 'react-intl';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -127,7 +127,6 @@ class MediaActionsBarComponent extends Component {
   handleMoveProjectMedia() {
     const { media } = this.props;
     const { dstProj: { dbid: projectId } } = this.state;
-    const { history } = this.getContext();
 
     const onFailure = (transaction) => {
       this.fail(transaction);
@@ -137,7 +136,7 @@ class MediaActionsBarComponent extends Component {
     const context = this.getContext();
 
     const onSuccess = () => {
-      history.push(path);
+      browserHistory.push(path);
     };
 
     Relay.Store.commitUpdate(
@@ -167,7 +166,7 @@ class MediaActionsBarComponent extends Component {
       );
       this.context.setMessage(message);
       const path = `/${media.team.slug}/media/${media.dbid}`;
-      context.history.push(path);
+      browserHistory.push(path);
     };
 
     Relay.Store.commitUpdate(

--- a/src/app/components/media/MediaSearch.js
+++ b/src/app/components/media/MediaSearch.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
+import { browserHistory } from 'react-router';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import styled from 'styled-components';
@@ -10,7 +11,6 @@ import MediasLoading from './MediasLoading';
 import Media from './Media';
 import MediaActionsBar from './MediaActionsBar';
 import SearchRoute from '../../relay/SearchRoute';
-import CheckContext from '../../CheckContext';
 import { units, black54 } from '../../styles/js/shared';
 
 const messages = defineMessages({
@@ -101,17 +101,13 @@ class MediaSearchComponent extends React.Component {
     this.updateUrl();
   }
 
-  getContext() {
-    return new CheckContext(this);
-  }
-
   setOffset(offset) {
     const query = this.searchQueryFromRouterState();
     query.esoffset = offset;
     delete query.id;
     query.noid = true;
     const pathname = window.location.pathname.match(/^(\/[^/]+\/(project\/[0-9]+\/)?media\/[0-9]+)/)[1];
-    this.currentContext().history.push({ pathname, state: { query } });
+    browserHistory.push({ pathname, state: { query } });
   }
 
   updateUrl() {
@@ -122,7 +118,7 @@ class MediaSearchComponent extends React.Component {
       if (item_navigation_offset > -1 && item_navigation_offset !== currentOffset) {
         query.esoffset = this.props.search.item_navigation_offset;
         const pathname = window.location.pathname.match(/^(\/[^/]+\/(project\/[0-9]+\/)?media\/[0-9]+)/)[1];
-        this.currentContext().history.push({ pathname, state: { query } });
+        browserHistory.push({ pathname, state: { query } });
       } else {
         const currId = parseInt(window.location.pathname.match(/^\/[^/]+\/(project\/[0-9]+\/)?media\/([0-9]+)/)[2], 10);
         const medias = this.props.search.medias.edges;
@@ -134,7 +130,7 @@ class MediaSearchComponent extends React.Component {
             projectPart = `project/${medias[0].node.project_id}/`;
           }
           const pathname = `${teamSlug}/${projectPart}media/${newId}`;
-          this.currentContext().history.push({ pathname, state: { query } });
+          browserHistory.push({ pathname, state: { query } });
         }
       }
     }
@@ -147,10 +143,6 @@ class MediaSearchComponent extends React.Component {
       searchQuery = state.query;
     }
     return Object.assign({}, searchQuery);
-  }
-
-  currentContext() {
-    return this.getContext().getContextStore();
   }
 
   previousItem() {
@@ -223,7 +215,6 @@ class MediaSearchComponent extends React.Component {
 }
 
 MediaSearchComponent.contextTypes = {
-  store: PropTypes.object,
   router: PropTypes.object,
 };
 
@@ -312,7 +303,6 @@ class MediaSearch extends React.PureComponent {
 }
 
 MediaSearch.contextTypes = {
-  store: PropTypes.object,
   router: PropTypes.object,
 };
 

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
@@ -71,10 +72,9 @@ class MediaStatusCommon extends Component {
 
   handleEdit() {
     const { media } = this.props;
-    const { history } = new CheckContext(this).getContextStore();
     const projectPart = media.project_id ? `/project/${media.project_id}` : '';
     this.setState({ showConfirmation: false });
-    history.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/embed`);
+    browserHistory.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/embed`);
   }
 
   handleStatusClick = (clickedStatus, smoochBotInstalled) => {

--- a/src/app/components/media/MediaTags.js
+++ b/src/app/components/media/MediaTags.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, intlShape, injectIntl } from 'react-intl';
+import { browserHistory } from 'react-router';
 import Relay from 'react-relay/classic';
 import mergeWith from 'lodash.mergewith';
 import xor from 'lodash.xor';
@@ -11,7 +12,6 @@ import CancelIcon from '@material-ui/icons/Cancel';
 import Can from '../Can';
 import UpdateLanguageMutation from '../../relay/mutations/UpdateLanguageMutation';
 import LanguageSelector from '../LanguageSelector';
-import CheckContext from '../../CheckContext';
 import { searchQueryFromUrl, urlFromSearchQuery } from '../search/Search';
 import { getErrorMessage, bemClass } from '../../helpers';
 import {
@@ -185,8 +185,7 @@ class MediaTags extends Component {
 
   handleTagViewClick(tagString) {
     const url = this.searchTagUrl(tagString);
-    const { history } = new CheckContext(this).getContextStore();
-    history.push(url);
+    browserHistory.push(url);
   }
 
   render() {
@@ -298,7 +297,6 @@ MediaTags.propTypes = {
 };
 
 MediaTags.contextTypes = {
-  store: PropTypes.object,
   setMessage: PropTypes.func,
 };
 

--- a/src/app/components/project/CreateProject.js
+++ b/src/app/components/project/CreateProject.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import Relay from 'react-relay/classic';
 import Card from '@material-ui/core/Card';
@@ -73,8 +74,6 @@ class CreateProject extends Component {
   handleSubmit(e) {
     const title = this.projectInput.getValue();
     const { team } = this.props;
-    const context = new CheckContext(this);
-    const { history } = context.getContextStore();
 
     const onFailure = (transaction) => {
       const fallbackMessage = this.props.intl.formatMessage(messages.error, { supportEmail: stringHelper('SUPPORT_EMAIL') });
@@ -85,7 +84,7 @@ class CreateProject extends Component {
     const onSuccess = (response) => {
       const { createProject: { project } } = response;
       const path = `/${team.slug}/project/${project.dbid}`;
-      history.push(path);
+      browserHistory.push(path);
       if (this.props.onCreate) {
         this.props.onCreate();
       }

--- a/src/app/components/project/Project.js
+++ b/src/app/components/project/Project.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import Relay from 'react-relay/classic';
 import isEqual from 'lodash.isequal';
 import ProjectActions from './ProjectActions';
@@ -58,7 +59,7 @@ class ProjectComponent extends Component {
     context.setContextStore(newContext);
 
     if (notFound) {
-      currentContext.history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
     }
   }
 

--- a/src/app/components/project/ProjectActions.js
+++ b/src/app/components/project/ProjectActions.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import IconMoreVert from '@material-ui/icons/MoreVert';
@@ -23,8 +24,7 @@ class ProjectActions extends Component {
   };
 
   handleEdit = () => {
-    const { history } = new CheckContext(this).getContextStore();
-    history.push(`${window.location.pathname.match(/.*\/project\/\d+/)[0]}/edit`);
+    browserHistory.push(`${window.location.pathname.match(/.*\/project\/\d+/)[0]}/edit`);
   };
 
   handleOpenMenu = (e) => {
@@ -56,7 +56,7 @@ class ProjectActions extends Component {
   }
 
   handleDestroy() {
-    const { project, team, history } = new CheckContext(this).getContextStore();
+    const { project, team } = new CheckContext(this).getContextStore();
 
     const onSuccess = () => {
       const message = (
@@ -86,7 +86,7 @@ class ProjectActions extends Component {
       { onSuccess, onFailure },
     );
 
-    history.push(`/${team.slug}/all-items`);
+    browserHistory.push(`/${team.slug}/all-items`);
   }
 
   render() {

--- a/src/app/components/project/ProjectEdit.js
+++ b/src/app/components/project/ProjectEdit.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import Relay from 'react-relay/classic';
 import TextField from 'material-ui/TextField';
@@ -69,7 +70,7 @@ class ProjectEditComponent extends Component {
     context.setContextStore(newContext);
 
     if (notFound) {
-      currentContext.history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
     }
   }
 
@@ -88,7 +89,7 @@ class ProjectEditComponent extends Component {
   }
 
   backToProject = () => {
-    this.currentContext().history.push(window.location.pathname.match(/.*\/project\/\d+/)[0]);
+    browserHistory.push(window.location.pathname.match(/.*\/project\/\d+/)[0]);
   };
 
   canSubmit = () => (
@@ -111,7 +112,7 @@ class ProjectEditComponent extends Component {
       const fallbackMessage = this.props.intl.formatMessage(messages.error, { supportEmail: stringHelper('SUPPORT_EMAIL') });
       const message = getErrorMessage(transaction, fallbackMessage);
       this.context.setMessage(message);
-      this.currentContext().history.push(`${window.location.pathname}/edit`);
+      browserHistory.push(`${window.location.pathname}/edit`);
     };
 
     Relay.Store.commitUpdate(

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -1,24 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import IconArrowBack from '@material-ui/icons/ArrowBack';
 import IconButton from '@material-ui/core/IconButton';
 import { FormattedMessage } from 'react-intl';
 import ProjectRoute from '../../relay/ProjectRoute';
 import { urlFromSearchQuery } from '../search/Search';
 import { Row, Text, HeaderTitle, FadeIn, SlideIn, black54 } from '../../styles/js/shared';
-import CheckContext from '../../CheckContext';
 
 class ProjectHeaderComponent extends React.PureComponent {
-  getContext() {
-    return new CheckContext(this);
-  }
-
-  currentContext() {
-    return this.getContext().getContextStore();
-  }
-
   render() {
     const { props } = this;
     const currentProject = props.project;
@@ -28,9 +19,9 @@ class ProjectHeaderComponent extends React.PureComponent {
     const regexMedia = /project\/[0-9]+\/media\/[0-9]/;
     const regexSource = /\/source\/[0-9]/;
     let mediaQuery = null;
-    const { state } = this.currentContext().history.getCurrentLocation();
-    if (state && state.query) {
-      mediaQuery = state.query;
+    const { loc } = browserHistory.getCurrentLocation(); // TODO use props
+    if (loc && loc.query) {
+      mediaQuery = loc.query;
     }
     const isProjectSubpage = regexMedia.test(path) || regexSource.test(path);
 
@@ -107,7 +98,6 @@ class ProjectHeaderComponent extends React.PureComponent {
 }
 
 ProjectHeaderComponent.contextTypes = {
-  store: PropTypes.object,
   router: PropTypes.object,
 };
 

--- a/src/app/components/search/SearchQueryComponent.js
+++ b/src/app/components/search/SearchQueryComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { FormattedMessage, FormattedHTMLMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { browserHistory } from 'react-router';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Dialog from '@material-ui/core/Dialog';
@@ -270,7 +271,7 @@ class SearchQueryComponent extends React.Component {
     const prefix = searchPrefixFromUrl();
     const url = urlFromSearchQuery(query, prefix);
 
-    this.getContext().getContextStore().history.push(url);
+    browserHistory.push(url);
   }
 
   keywordIsActive = () => {

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { defineMessages, injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
 import sortby from 'lodash.sortby';
 import isEqual from 'lodash.isequal';
@@ -188,7 +189,7 @@ class SearchResultsComponent extends React.Component {
 
     const url = urlFromSearchQuery(query, path);
 
-    this.getContext().getContextStore().history.push(url);
+    browserHistory.push(url);
   }
 
   handleSelect = (selectedMedia) => {

--- a/src/app/components/source/SourceComponent.js
+++ b/src/app/components/source/SourceComponent.js
@@ -8,6 +8,7 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+import { browserHistory } from 'react-router';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -739,7 +740,7 @@ class SourceComponent extends Component {
     this.onClear();
     const { team, projectId, sourceId } = this.props.params;
 
-    this.getContext().history.push(`/${team}/project/${projectId}/source/${sourceId}`);
+    browserHistory.push(`/${team}/project/${projectId}/source/${sourceId}`);
   }
 
   handleChangeLink(e, index) {
@@ -782,9 +783,8 @@ class SourceComponent extends Component {
 
   handleClickEditSource() {
     const { team, projectId, sourceId } = this.props.params;
-    const { history } = this.getContext();
 
-    history.push(`/${team}/project/${projectId}/source/${sourceId}/edit`);
+    browserHistory.push(`/${team}/project/${projectId}/source/${sourceId}/edit`);
   }
 
   isProjectSource() {

--- a/src/app/components/source/UserComponent.js
+++ b/src/app/components/source/UserComponent.js
@@ -31,7 +31,7 @@ class UserComponent extends React.Component {
   componentWillMount() {
     const { user } = this.props;
     if (!user.is_active) {
-      this.getContext().history.push('/check/forbidden');
+      browserHistory.push('/check/forbidden');
     }
   }
 

--- a/src/app/components/source/UserInfo.js
+++ b/src/app/components/source/UserInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
+import { browserHistory } from 'react-router';
 import rtlDetect from 'rtl-detect';
 import IconEdit from '@material-ui/icons/Edit';
 import AccountChips from './AccountChips';
@@ -46,9 +47,9 @@ const UserInfo = (props) => {
                   className="source__edit-source-button"
                   onClick={() => {
                     if (props.user.dbid === props.context.currentUser.dbid) {
-                      props.context.history.push('/check/me/edit');
+                      browserHistory.push('/check/me/edit');
                     } else {
-                      props.context.history.push(`/check/user/${props.user.dbid}/edit`);
+                      browserHistory.push(`/check/user/${props.user.dbid}/edit`);
                     }
                   }}
                   tooltip={props.intl.formatMessage(globalStrings.edit)}

--- a/src/app/components/source/UserInfoEdit.js
+++ b/src/app/components/source/UserInfoEdit.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import { injectIntl, defineMessages } from 'react-intl';
 import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -14,7 +14,6 @@ import SourcePicture from './SourcePicture';
 import Message from '../Message';
 import UploadImage from '../UploadImage';
 import globalStrings from '../../globalStrings';
-import CheckContext from '../../CheckContext';
 import UpdateSourceMutation from '../../relay/mutations/UpdateSourceMutation';
 import { updateUserNameEmail } from '../../relay/mutations/UpdateUserNameEmailMutation';
 import CreateAccountSourceMutation from '../../relay/mutations/CreateAccountSourceMutation';
@@ -89,6 +88,10 @@ const messages = defineMessages({
   },
 });
 
+function handleLeaveEditMode() {
+  browserHistory.push('/check/me');
+}
+
 class UserInfoEdit extends React.Component {
   constructor(props) {
     super(props);
@@ -131,11 +134,6 @@ class UserInfoEdit extends React.Component {
 
   handleEditProfileImg() {
     this.setState({ editProfileImg: true });
-  }
-
-  handleLeaveEditMode() {
-    const { history } = new CheckContext(this).getContextStore();
-    history.push('/check/me');
   }
 
   handleSubmit(e) {
@@ -202,7 +200,7 @@ class UserInfoEdit extends React.Component {
 
     this.setState({ submitDisabled, message });
     if (!isEditing) {
-      this.handleLeaveEditMode();
+      handleLeaveEditMode();
     }
   };
 
@@ -576,7 +574,7 @@ class UserInfoEdit extends React.Component {
               <div className="source__edit-buttons-cancel-save">
                 <Button
                   className="source__edit-cancel-button"
-                  onClick={this.handleLeaveEditMode.bind(this)}
+                  onClick={handleLeaveEditMode}
                 >
                   {this.props.intl.formatMessage(globalStrings.cancel)}
                 </Button>
@@ -596,9 +594,5 @@ class UserInfoEdit extends React.Component {
     );
   }
 }
-
-UserInfoEdit.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(UserInfoEdit);

--- a/src/app/components/team/CreateTeamCard.js
+++ b/src/app/components/team/CreateTeamCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import XRegExp from 'xregexp';
 import {
   FormattedMessage,
@@ -126,7 +126,7 @@ class CreateTeamCard extends React.Component {
       context.team = team;
 
       const path = `/${team.slug}`;
-      context.history.push(path);
+      browserHistory.push(path);
     };
 
     Relay.Store.commitUpdate(

--- a/src/app/components/team/FindTeamCard.js
+++ b/src/app/components/team/FindTeamCard.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   FormattedMessage,
   defineMessages,
   injectIntl,
 } from 'react-intl';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import TextField from 'material-ui/TextField';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -14,7 +13,6 @@ import CardActions from '@material-ui/core/CardActions';
 import Button from '@material-ui/core/Button';
 import styled from 'styled-components';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
-import CheckContext from '../../CheckContext';
 import {
   black38,
   caption,
@@ -70,16 +68,12 @@ class FindTeamCard extends React.Component {
     this.handleQuery();
   }
 
-  getContext() {
-    return new CheckContext(this).getContextStore();
-  }
-
   handleQuery = () => {
     const { team, teamSlug } = this.props;
 
     if (teamSlug) {
       if (team && (teamSlug === team.slug)) {
-        this.getContext().history.push(`/${team.slug}/join`);
+        browserHistory.push(`/${team.slug}/join`);
       } else {
         this.setState({ message: this.props.intl.formatMessage(messages.teamNotFound) });
       }
@@ -93,7 +87,7 @@ class FindTeamCard extends React.Component {
   handleSubmit = (e) => {
     e.preventDefault();
     const { slug } = this.state;
-    this.getContext().history.push(`/check/teams/find/${slug}`);
+    browserHistory.push(`/check/teams/find/${slug}`);
   };
 
   render() {
@@ -170,9 +164,5 @@ class FindTeamCard extends React.Component {
     );
   }
 }
-
-FindTeamCard.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(FindTeamCard);

--- a/src/app/components/team/JoinTeamComponent.js
+++ b/src/app/components/team/JoinTeamComponent.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -50,7 +50,7 @@ class JoinTeamComponent extends Component {
     const { team } = this.props;
 
     if (!team) {
-      this.getContext().history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
       this.setState({ willRedirect: true });
       return;
     }
@@ -111,7 +111,7 @@ class JoinTeamComponent extends Component {
         }
       });
       if (redirect) {
-        this.getContext().history.push(`/${team.slug}`);
+        browserHistory.push(`/${team.slug}`);
       }
     }
   }

--- a/src/app/components/team/SwitchTeamsComponent.js
+++ b/src/app/components/team/SwitchTeamsComponent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { FormattedMessage, defineMessages, intlShape, injectIntl } from 'react-intl';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -57,7 +57,7 @@ class SwitchTeamsComponent extends Component {
 
   setCurrentTeam(team, user) {
     const context = this.getContext();
-    const { history, currentUser } = context.getContextStore();
+    const { currentUser } = context.getContextStore();
 
     currentUser.current_team = team;
     context.setContextStore({ team, currentUser });
@@ -70,7 +70,7 @@ class SwitchTeamsComponent extends Component {
 
     const onSuccess = () => {
       const path = `/${team.slug}/all-items`;
-      history.push(path);
+      browserHistory.push(path);
     };
 
     Relay.Store.commitUpdate(
@@ -202,7 +202,7 @@ class SwitchTeamsComponent extends Component {
         { isUserSelf ?
           <CardActions>
             <Button
-              onClick={() => this.getContext().getContextStore().history.push('/check/teams/new')}
+              onClick={() => browserHistory.push('/check/teams/new')}
             >
               <FormattedMessage id="switchTeams.newTeamLink" defaultMessage="Create Workspace" />
             </Button>

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import deepEqual from 'deep-equal';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
 import rtlDetect from 'rtl-detect';
 import { withStyles } from '@material-ui/core/styles';
 import Tabs from '@material-ui/core/Tabs';
@@ -94,7 +95,7 @@ class TeamComponent extends Component {
     if (!store.team || store.team.slug !== team.slug) {
       context.setContextStore({ team });
       const path = `/${team.slug}`;
-      store.history.push(path);
+      browserHistory.push(path);
     }
   }
 

--- a/src/app/components/team/TeamHeaderComponent.js
+++ b/src/app/components/team/TeamHeaderComponent.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 import styled from 'styled-components';
 import { injectIntl } from 'react-intl';
 import TeamAvatar from './TeamAvatar';
@@ -37,7 +38,7 @@ class TeamHeaderComponent extends Component {
     const { team } = this.props;
 
     if (!team) {
-      this.getContext().history.push('/check/not-found');
+      browserHistory.push('/check/not-found');
       this.setState({ willRedirect: true });
       return;
     }
@@ -47,10 +48,6 @@ class TeamHeaderComponent extends Component {
 
   componentWillUpdate() {
     this.updateContext();
-  }
-
-  getContext() {
-    return new CheckContext(this);
   }
 
   updateContext() {

--- a/src/app/components/team/TeamInfo.js
+++ b/src/app/components/team/TeamInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
 import MdLock from '@material-ui/icons/Lock';
 import MdPublic from '@material-ui/icons/Public';
 import MdLink from '@material-ui/icons/Link';
@@ -91,7 +92,7 @@ const TeamInfo = (props) => {
               <Can permissions={team.permissions} permission="update Team">
                 <SmallerStyledIconButton
                   className="team-menu__edit-team-button"
-                  onClick={() => props.context.history.push(`/${props.team.slug}/edit`)}
+                  onClick={() => browserHistory.push(`/${props.team.slug}/edit`)}
                   tooltip={
                     <FormattedMessage id="teamInfo.editTeam" defaultMessage="Edit" />
                   }

--- a/src/app/components/team/TeamInfoEdit.js
+++ b/src/app/components/team/TeamInfoEdit.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { browserHistory } from 'react-router';
 import Relay from 'react-relay/classic';
 import rtlDetect from 'rtl-detect';
 import Button from '@material-ui/core/Button';
@@ -10,7 +10,6 @@ import Message from '../Message';
 import UploadImage from '../UploadImage';
 import globalStrings from '../../globalStrings';
 import { getErrorMessage, validateURL } from '../../helpers';
-import CheckContext from '../../CheckContext';
 import UpdateTeamMutation from '../../relay/mutations/UpdateTeamMutation';
 import {
   StyledButtonGroup,
@@ -96,8 +95,7 @@ class TeamInfoEdit extends React.Component {
   }
 
   handleLeaveEditMode() {
-    const { history } = new CheckContext(this).getContextStore();
-    history.push(`/${this.props.team.slug}`);
+    browserHistory.push(`/${this.props.team.slug}`);
   }
 
   handleChange(key, e) {
@@ -297,10 +295,6 @@ TeamInfoEdit.propTypes = {
   // https://github.com/yannickcr/eslint-plugin-react/issues/1389
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
-};
-
-TeamInfoEdit.contextTypes = {
-  store: PropTypes.object,
 };
 
 export default injectIntl(TeamInfoEdit);

--- a/src/app/components/user/UserMenu.js
+++ b/src/app/components/user/UserMenu.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
 import UserUtil from './UserUtil';
-import CheckContext from '../../CheckContext';
 import UserMenuItems from '../UserMenuItems';
 import UserAvatar from '../UserAvatar';
 import {
@@ -21,17 +19,9 @@ class UserMenu extends React.Component {
     anchorEl: null,
   };
 
-  getHistory() {
-    return new CheckContext(this).getContextStore().history;
-  }
-
   handleClick = (event) => {
     this.setState({ anchorEl: event.currentTarget });
   };
-
-  handleClickEdit() {
-    this.getHistory().push('/check/me/edit');
-  }
 
   handleClose = () => {
     this.setState({ anchorEl: null });
@@ -86,9 +76,5 @@ class UserMenu extends React.Component {
     );
   }
 }
-
-UserMenu.contextTypes = {
-  store: PropTypes.object,
-};
 
 export default injectIntl(UserMenu);

--- a/src/app/redux/app.js
+++ b/src/app/redux/app.js
@@ -1,14 +1,9 @@
-import { LOCATION_CHANGE } from 'react-router-redux';
 import { NOTIFY_SEND, NOTIFY_RECEIVE, SET_CONTEXT } from './ActionTypes';
 
 export default function app(state_ = { session: null }, action) {
   const state = state_;
   if (action.type === SET_CONTEXT) {
     state.context = action;
-    return state;
-  }
-  if (action.type === LOCATION_CHANGE) {
-    state.routing = { locationBeforeTransitions: action.payload };
     return state;
   }
   if (action.type === NOTIFY_SEND || action.type === NOTIFY_RECEIVE) {

--- a/src/app/redux/index.js
+++ b/src/app/redux/index.js
@@ -1,5 +1,4 @@
 import { combineReducers } from 'redux';
-import { routerReducer } from 'react-router-redux';
 import app from './app';
 
-export default combineReducers({ app, routing: routerReducer });
+export default combineReducers({ app });


### PR DESCRIPTION
browserHistory is a more-obvious global now. It was always a global,
but CheckContext made that hard to spot. *We should not use globals*,
and so every `browserHistory.push()` is bad! But that's no reason to
obfuscate it.

Why was react-router-redux there? Well, it helps when one uses Redux
Dev Tools to "rewind" the state -- making the URL part of the state.
No devs use this. And since our Redux state is mutable, it was never
usable.

This removes some uses of `CheckContext`. Eventually, we should remove
_all_ uses of `CheckContext` ... and then #8090 deprecation warnings
should be easier to address.

(cherry picked from commit 2b58f7e27fd1d2755ab3c41384443a6df90322bd)