### PR TITLE
<SearchQuery>: FragmentContainer, not RootContainer [#6211]

### DIFF
--- a/src/app/components/search/SearchQuery.js
+++ b/src/app/components/search/SearchQuery.js
@@ -1,85 +1,36 @@
-import React from 'react';
 import Relay from 'react-relay/classic';
-import isEqual from 'lodash.isequal';
 import SearchQueryComponent from './SearchQueryComponent';
-import TeamNodeRoute from '../../relay/TeamNodeRoute';
 
-const queryWithoutProjects = Relay.QL`
-  fragment on Team {
-    id,
-    dbid,
-    verification_statuses,
-    tag_texts(first: 10000) {
-      edges {
-        node {
-          text
+export default Relay.createContainer(SearchQueryComponent, {
+  fragments: {
+    team: () => Relay.QL`
+      fragment on Team {
+        id
+        dbid
+        verification_statuses
+        tag_texts(first: 10000) {
+          edges {
+            node {
+              text
+            }
+          }
+        }
+        pusher_channel
+        dynamic_search_fields_json_schema
+        rules_search_fields_json_schema
+        name
+        slug
+        projects(first: 10000) {
+          edges {
+            node {
+              title
+              dbid
+              id
+              description
+            }
+          }
         }
       }
-    },
-    pusher_channel,
-    dynamic_search_fields_json_schema,
-    rules_search_fields_json_schema,
-    name,
-    slug,
-  }
-`;
-
-const queryWithProjects = Relay.QL`
-  fragment on Team {
-    id,
-    dbid,
-    verification_statuses,
-    tag_texts(first: 10000) {
-      edges {
-        node {
-          text
-        }
-      }
-    },
-    pusher_channel,
-    dynamic_search_fields_json_schema,
-    rules_search_fields_json_schema,
-    name,
-    slug,
-    projects(first: 10000) {
-      edges {
-        node {
-          title,
-          dbid,
-          id,
-          description
-        }
-      }
-    }
-  }
-`;
-
-class SearchQuery extends React.Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(this.state, nextState) ||
-           !isEqual(this.props, nextProps);
-  }
-
-  render() {
-    const gqlquery = this.props.project ? queryWithoutProjects : queryWithProjects;
-
-    const SearchQueryContainer = Relay.createContainer(SearchQueryComponent, {
-      fragments: {
-        team: () => gqlquery,
-      },
-    });
-
-    // eslint-disable-next-line no-underscore-dangle
-    const queryRoute = new TeamNodeRoute({ id: this.props.team.__dataID__ });
-
-    return (
-      <Relay.RootContainer
-        Component={SearchQueryContainer}
-        route={queryRoute}
-        renderFetched={data => <SearchQueryContainer {...this.props} {...data} />}
-      />
-    );
-  }
-}
-
-export default SearchQuery;
+    `,
+  },
+});

--- a/src/app/components/search/SearchQueryComponent.js
+++ b/src/app/components/search/SearchQueryComponent.js
@@ -807,6 +807,18 @@ SearchQueryComponent.propTypes = {
   clientSessionId: PropTypes.string.isRequired,
   query: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired, // onChange({ ... /* query */ }) => undefined
+  team: PropTypes.shape({
+    dynamic_search_fields_json_schema: PropTypes.shape({
+      properties: PropTypes.object.isRequired,
+    }).isRequired,
+    rules_search_fields_json_schema: PropTypes.shape({
+      rules: PropTypes.shape({
+        properties: PropTypes.arrayOf(PropTypes.shape({
+          label: PropTypes.string.isRequired,
+        }).isRequired).isRequired,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 SearchQueryComponent.contextTypes = {

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -311,7 +311,7 @@ class SearchResultsComponent extends React.PureComponent {
       ? this.props.search.medias.edges.map(({ node }) => node)
       : [];
 
-    const count = this.props.search ? this.props.search.number_of_results : 0;
+    const count = this.props.search.number_of_results;
     const { team } = this.props.search;
     const isIdInSearchResults = wantedId => projectMedias.some(({ id }) => id === wantedId);
     const selectedProjectMediaIds = this.state.selectedProjectMediaIds.filter(isIdInSearchResults);
@@ -502,6 +502,7 @@ const SearchResultsContainer = Relay.createContainer(withPusher(SearchResultsCom
         pusher_channel,
         team {
           ${BulkActions.getFragment('team')}
+          ${SearchQuery.getFragment('team')}
           id
           slug
           search_id,


### PR DESCRIPTION
I was getting an exception on dev involving a null team. Dunno why,
but deleting the query deletes the possibility of unexpected results.
It's also faster and part of #6211.