### PR TITLE
Substitute props.intl.formatMessage with <FormattedMessage />

### DIFF
--- a/src/app/components/source/UserInfoEdit.js
+++ b/src/app/components/source/UserInfoEdit.js
@@ -50,10 +50,6 @@ const messages = defineMessages({
     id: 'userInfoEdit.userSendEmailNotification',
     defaultMessage: 'Receive email notifications',
   },
-  addLink: {
-    id: 'userInfoEdit.addLink',
-    defaultMessage: 'Add Link',
-  },
   editError: {
     id: 'userInfoEdit.editError',
     defaultMessage: 'Sorry, an error occurred while updating your profile. Please try again and contact {supportEmail} if the condition persists.',
@@ -65,11 +61,6 @@ const messages = defineMessages({
   addLinkLabel: {
     id: 'userInfoEdit.addLinkLabel',
     defaultMessage: 'Add a link',
-  },
-  addLinkHelper: {
-    id: 'userInfoEdit.addLinkHelper',
-    defaultMessage:
-      'Add a link to a web page or social media profile. Note: this does not affect your login method.',
   },
   emailConfirmed: {
     id: 'userInfoEdit.emailConfirmed',
@@ -448,8 +439,8 @@ class UserInfoEdit extends React.Component {
               null :
               <StyledHelper>
                 <FormattedMessage 
-                  id={messages.addLinkHelper.id} 
-                  defaultMessage={messages.addLinkHelper.defaultMessage} 
+                  id="userInfoEdit.addLinkHelper"
+                  defaultMessage="Add a link to a web page or social media profile. Note: this does not affect your login method."
                 />
               </StyledHelper>}
           </div>))}
@@ -485,10 +476,7 @@ class UserInfoEdit extends React.Component {
                   onClick={this.handleEditProfileImg.bind(this)}
                   color="primary"
                 >
-                  <FormattedMessage 
-                    id={globalStrings.edit.id} 
-                    defaultMessage={globalStrings.edit.defaultMessage} 
-                  />
+                  <FormattedMessage {...globalStrings.edit} />
                 </Button>
               </StyledAvatarEditButton>
               : null}
@@ -560,8 +548,8 @@ class UserInfoEdit extends React.Component {
                   onClick={this.handleAddLink.bind(this)}
                 >
                   <FormattedMessage 
-                    id={messages.addLink.id} 
-                    defaultMessage={messages.addLink.defaultMessage} 
+                    id="userInfoEdit.addLink"
+                    defaultMessage="Add Link"
                   />
                 </Button>
               </div>
@@ -571,10 +559,7 @@ class UserInfoEdit extends React.Component {
                   className="source__edit-cancel-button"
                   onClick={handleLeaveEditMode}
                 >
-                  <FormattedMessage 
-                    id={globalStrings.cancel.id} 
-                    defaultMessage={globalStrings.cancel.defaultMessage} 
-                  />
+                  <FormattedMessage {...globalStrings.cancel} />
                 </Button>
                 <Button
                   variant="contained"
@@ -582,10 +567,7 @@ class UserInfoEdit extends React.Component {
                   color="primary"
                   onClick={this.handleSubmit.bind(this)}
                 >
-                  <FormattedMessage 
-                    id={globalStrings.save.id} 
-                    defaultMessage={globalStrings.save.defaultMessage} 
-                  />
+                  <FormattedMessage {...globalStrings.save} />
                 </Button>
               </div>
             </StyledButtonGroup>

--- a/src/app/components/source/UserInfoEdit.js
+++ b/src/app/components/source/UserInfoEdit.js
@@ -447,7 +447,10 @@ class UserInfoEdit extends React.Component {
             {link.error ?
               null :
               <StyledHelper>
-                {this.props.intl.formatMessage(messages.addLinkHelper)}
+                <FormattedMessage 
+                  id={messages.addLinkHelper.id} 
+                  defaultMessage={messages.addLinkHelper.defaultMessage} 
+                />
               </StyledHelper>}
           </div>))}
       </div>
@@ -482,7 +485,10 @@ class UserInfoEdit extends React.Component {
                   onClick={this.handleEditProfileImg.bind(this)}
                   color="primary"
                 >
-                  {this.props.intl.formatMessage(globalStrings.edit)}
+                  <FormattedMessage 
+                    id={globalStrings.edit.id} 
+                    defaultMessage={globalStrings.edit.defaultMessage} 
+                  />
                 </Button>
               </StyledAvatarEditButton>
               : null}
@@ -553,7 +559,10 @@ class UserInfoEdit extends React.Component {
                   color="primary"
                   onClick={this.handleAddLink.bind(this)}
                 >
-                  {this.props.intl.formatMessage(messages.addLink)}
+                  <FormattedMessage 
+                    id={messages.addLink.id} 
+                    defaultMessage={messages.addLink.defaultMessage} 
+                  />
                 </Button>
               </div>
 
@@ -562,7 +571,10 @@ class UserInfoEdit extends React.Component {
                   className="source__edit-cancel-button"
                   onClick={handleLeaveEditMode}
                 >
-                  {this.props.intl.formatMessage(globalStrings.cancel)}
+                  <FormattedMessage 
+                    id={globalStrings.cancel.id} 
+                    defaultMessage={globalStrings.cancel.defaultMessage} 
+                  />
                 </Button>
                 <Button
                   variant="contained"
@@ -570,7 +582,10 @@ class UserInfoEdit extends React.Component {
                   color="primary"
                   onClick={this.handleSubmit.bind(this)}
                 >
-                  {this.props.intl.formatMessage(globalStrings.save)}
+                  <FormattedMessage 
+                    id={globalStrings.save.id} 
+                    defaultMessage={globalStrings.save.defaultMessage} 
+                  />
                 </Button>
               </div>
             </StyledButtonGroup>

--- a/src/app/components/source/UserInfoEdit.js
+++ b/src/app/components/source/UserInfoEdit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { browserHistory } from 'react-router';
-import { injectIntl, defineMessages } from 'react-intl';
+import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -438,7 +438,7 @@ class UserInfoEdit extends React.Component {
             {link.error ?
               null :
               <StyledHelper>
-                <FormattedMessage 
+                <FormattedMessage
                   id="userInfoEdit.addLinkHelper"
                   defaultMessage="Add a link to a web page or social media profile. Note: this does not affect your login method."
                 />
@@ -547,7 +547,7 @@ class UserInfoEdit extends React.Component {
                   color="primary"
                   onClick={this.handleAddLink.bind(this)}
                 >
-                  <FormattedMessage 
+                  <FormattedMessage
                     id="userInfoEdit.addLink"
                     defaultMessage="Add Link"
                   />

--- a/src/app/components/team/SlackConfig/index.js
+++ b/src/app/components/team/SlackConfig/index.js
@@ -24,10 +24,6 @@ import {
 } from '../../../styles/js/shared';
 
 const messages = defineMessages({
-  title: {
-    id: 'slackConfig.title',
-    defaultMessage: 'Slack integration',
-  },
   menuTooltip: {
     id: 'slackConfig.menuTooltip',
     defaultMessage: 'Integration settings',


### PR DESCRIPTION
Replaced several instances of `props.intl.formatMessage` with `<FormattedMessage />` where a string is passed for the pages rendered by `UserInfoEdit.js` and `SlackConfig.js`
Helps to resolve meedan/check#20