### PR TITLE
Simplify HTML5 boolean attributes

### DIFF
--- a/src/web/views/index.js
+++ b/src/web/views/index.js
@@ -70,8 +70,8 @@ module.exports = ({ config, metadata, url }) => `
         <title>${metadata ? metadata.title : capitalize(config.appName)}</title>
         ${socialTags(metadata, config, url)}
         <link href="/images/logo/${config.appName || 'favicon'}.ico" rel="icon">
-        <script src="/js/config.js" defer="defer"></script>
-        <script src="/js/vendor.bundle.js" defer="defer"></script>
+        <script src="/js/config.js" defer></script>
+        <script src="/js/vendor.bundle.js" defer></script>
         <script src="https://js.pusher.com/4.4/pusher.min.js"></script>
         <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.css" />
@@ -80,6 +80,6 @@ module.exports = ({ config, metadata, url }) => `
       <body>
         <div id="root"></div>
       </body>
-      <script src="/js/index.bundle.js" defer="defer"></script>
+      <script src="/js/index.bundle.js" defer></script>
     </html>
   `;


### PR DESCRIPTION
Because the `defer` attribute is a boolean attribute an explicit value is not needed.