### PR TITLE
Replace `props.intl.formatMessage` with `<FormattedMessage />`

### DIFF
--- a/localization/react-intl/src/app/components/source/UserInfoEdit.json
+++ b/localization/react-intl/src/app/components/source/UserInfoEdit.json
@@ -16,10 +16,6 @@
     "defaultMessage": "Receive email notifications"
   },
   {
-    "id": "userInfoEdit.addLink",
-    "defaultMessage": "Add Link"
-  },
-  {
     "id": "userInfoEdit.editError",
     "defaultMessage": "Sorry, an error occurred while updating your profile. Please try again and contact {supportEmail} if the condition persists."
   },
@@ -32,10 +28,6 @@
     "defaultMessage": "Add a link"
   },
   {
-    "id": "userInfoEdit.addLinkHelper",
-    "defaultMessage": "Add a link to a web page or social media profile. Note: this does not affect your login method."
-  },
-  {
     "id": "userInfoEdit.emailConfirmed",
     "defaultMessage": "✔ Address confirmed"
   },
@@ -46,5 +38,13 @@
   {
     "id": "userInfoEdit.invalidLink",
     "defaultMessage": "Please enter a valid URL"
+  },
+  {
+    "id": "userInfoEdit.addLinkHelper",
+    "defaultMessage": "Add a link to a web page or social media profile. Note: this does not affect your login method."
+  },
+  {
+    "id": "userInfoEdit.addLink",
+    "defaultMessage": "Add Link"
   }
 ]

--- a/localization/react-intl/src/app/components/task/EditTaskDialog.json
+++ b/localization/react-intl/src/app/components/task/EditTaskDialog.json
@@ -1,19 +1,19 @@
 [
   {
-    "id": "singleChoiceTask.addValue",
-    "defaultMessage": "Add Option"
-  },
-  {
     "id": "singleChoiceTask.value",
     "defaultMessage": "Value"
   },
   {
-    "id": "singleChoiceTask.addOther",
-    "defaultMessage": "Add \"Other\""
-  },
-  {
     "id": "singleChoiceTask.other",
     "defaultMessage": "Other"
+  },
+  {
+    "id": "singleChoiceTask.addValue",
+    "defaultMessage": "Add Option"
+  },
+  {
+    "id": "singleChoiceTask.addOther",
+    "defaultMessage": "Add \"Other\""
   },
   {
     "id": "editTaskDialog.editTask",

--- a/localization/react-intl/src/app/components/team/TeamInviteMembers.json
+++ b/localization/react-intl/src/app/components/team/TeamInviteMembers.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "TeamInviteMembers.newInvite",
-    "defaultMessage": "Invite members"
-  },
-  {
     "id": "TeamInviteMembers.emailInput",
     "defaultMessage": "Email address"
   },
@@ -50,6 +46,10 @@
   {
     "id": "teamInviteMembers.inviteMember",
     "defaultMessage": "Invite"
+  },
+  {
+    "id": "TeamInviteMembers.newInvite",
+    "defaultMessage": "Invite members"
   },
   {
     "id": "teamInviteMembers.customInvitation",

--- a/localization/react-intl/src/app/components/user/UserEmail.json
+++ b/localization/react-intl/src/app/components/user/UserEmail.json
@@ -8,19 +8,19 @@
     "defaultMessage": "email@example.com"
   },
   {
-    "id": "userEmail.submit",
-    "defaultMessage": "Submit"
-  },
-  {
-    "id": "userEmail.skip",
-    "defaultMessage": "Skip"
-  },
-  {
     "id": "userEmail.text",
     "defaultMessage": "To send you notifications, we need your email address. If you'd like to receive notifications, please enter your email address. Otherwise, click \"Skip\""
   },
   {
     "id": "userEmail.emailInputLabel",
     "defaultMessage": "Email"
+  },
+  {
+    "id": "userEmail.skip",
+    "defaultMessage": "Skip"
+  },
+  {
+    "id": "userEmail.submit",
+    "defaultMessage": "Submit"
   }
 ]

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -106,7 +106,7 @@ class CreateRelatedMediaDialog extends React.Component {
         </DialogContent>
         <DialogActions>
           <Button id="create-media-dialog__dismiss-button" onClick={this.props.onDismiss}>
-            {this.props.intl.formatMessage(globalStrings.cancel)}
+            <FormattedMessage {...globalStrings.cancel} />
           </Button>
           { mode === 'new' &&
             <Button
@@ -139,4 +139,4 @@ class CreateRelatedMediaDialog extends React.Component {
   }
 }
 
-export default injectIntl(CreateRelatedMediaDialog);
+export default CreateRelatedMediaDialog;

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -42,17 +42,9 @@ const StyledTaskAssignment = styled.div`
 `;
 
 const messages = defineMessages({
-  addValue: {
-    id: 'singleChoiceTask.addValue',
-    defaultMessage: 'Add Option',
-  },
   value: {
     id: 'singleChoiceTask.value',
     defaultMessage: 'Value',
-  },
-  addOther: {
-    id: 'singleChoiceTask.addOther',
-    defaultMessage: 'Add "Other"',
   },
   other: {
     id: 'singleChoiceTask.other',
@@ -238,13 +230,19 @@ class EditTaskDialog extends React.Component {
         ))}
         <div style={{ marginTop: units(1) }}>
           <Button onClick={this.handleAddValue.bind(this)}>
-            {this.props.intl.formatMessage(messages.addValue)}
+            <FormattedMessage
+              id="singleChoiceTask.addValue"
+              defaultMessage="Add Option"
+            />
           </Button>
           <Button
             onClick={this.handleAddOther.bind(this)}
             disabled={this.state.hasOther}
           >
-            {this.props.intl.formatMessage(messages.addOther)}
+            <FormattedMessage
+              id="singleChoiceTask.addOther"
+              defaultMessage='Add "Other"'
+            />
           </Button>
         </div>
       </div>

--- a/src/app/components/team/TeamInviteMembers.js
+++ b/src/app/components/team/TeamInviteMembers.js
@@ -23,10 +23,6 @@ import {
 } from '../../styles/js/shared';
 
 const messages = defineMessages({
-  inviteMembers: {
-    id: 'TeamInviteMembers.newInvite',
-    defaultMessage: 'Invite members',
-  },
   inviteEmailInput: {
     id: 'TeamInviteMembers.emailInput',
     defaultMessage: 'Email address',
@@ -331,7 +327,7 @@ class TeamInviteMembers extends Component {
           scroll="paper"
           fullWidth
         >
-          <DialogTitle>{this.props.intl.formatMessage(messages.inviteMembers)}</DialogTitle>
+          <DialogTitle><FormattedMessage id="TeamInviteMembers.newInvite" defaultMessage="Invite members" /></DialogTitle>
           <DialogContent>
             <TextField
               id="invite-msg-input"

--- a/src/app/components/user/AttributionDialog.js
+++ b/src/app/components/user/AttributionDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -47,14 +47,14 @@ class AttributionDialog extends React.Component {
             className="attribution-dialog__cancel"
             onClick={this.props.onDismiss}
           >
-            {this.props.intl.formatMessage(globalStrings.cancel)}
+            <FormattedMessage {...globalStrings.cancel} />
           </Button>
           <Button
             color="primary"
             className="attribution-dialog__save"
             onClick={this.handleSubmit}
           >
-            {this.props.intl.formatMessage(globalStrings.submit)}
+            <FormattedMessage {...globalStrings.submit} />
           </Button>
         </DialogActions>
       </Dialog>
@@ -66,4 +66,4 @@ AttributionDialog.propTypes = {
   taskType: PropTypes.string.isRequired,
 };
 
-export default injectIntl(AttributionDialog);
+export default AttributionDialog;

--- a/src/app/components/user/UserEmail.js
+++ b/src/app/components/user/UserEmail.js
@@ -24,14 +24,6 @@ const messages = defineMessages({
     id: 'userEmail.emailInputHint',
     defaultMessage: 'email@example.com',
   },
-  submit: {
-    id: 'userEmail.submit',
-    defaultMessage: 'Submit',
-  },
-  skip: {
-    id: 'userEmail.skip',
-    defaultMessage: 'Skip',
-  },
 });
 
 class UserEmail extends React.Component {
@@ -114,10 +106,10 @@ class UserEmail extends React.Component {
           </CardContent>
           <CardActions>
             <Button onClick={this.handleClickSkip}>
-              {this.props.intl.formatMessage(messages.skip)}
+              <FormattedMessage id="userEmail.skip" defaultMessage="Skip" />
             </Button>
             <Button onClick={this.handleSubmit} color="primary">
-              {this.props.intl.formatMessage(messages.submit)}
+              <FormattedMessage id="userEmail.submit" defaultMessage="Submit" />
             </Button>
           </CardActions>
         </Card>


### PR DESCRIPTION
Replace in-JSX occurrences of the `props.intl.formatMessage` expression with the `<FormattedMessage />` component.

The following conventions have been used for consistency with the existing code:
- Messages defined in `globalStrings` are passed using spread operator.
- Local messages props are passed inline to the `FormattedMessage` component and the key removed from the `messages` object.

Generated react-intl localizations have been updated.

Fixes meedan/check#20