### PR TITLE
Updated Social Network Colors in shared.js

### DIFF
--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -46,10 +46,14 @@ export const opaqueBlack02 = '#fafafa';
 
 // Social network colors
 //
-export const facebookBlue = '#3b5999';
-export const twitterBlue = '#0095ff';
-export const googleOrange = '#db4437';
-export const slackGreen = '#2ab27b';
+// https://facebookbrand.com/facebookapp/advertisers-and-partners/
+export const facebookBlue = '#1877f2';
+// https://about.twitter.com/content/dam/about-twitter/company/brand-resources/en_us/Twitter_Brand_Guidelines_V2_0.pdf
+export const twitterBlue = '#1da1f2';
+// https://designguidelines.withgoogle.com/ads-branding/assets/1McJDbBKmuQAv35pVV9vY3A5CQiRY5hRv/visual-guidelines-google-ads.pdf
+export const googleOrange = '#ea4335';
+// https://slack.com/intl/en-it/marketing/img/media-kit/slack_brand_guidelines_september2020.pdf
+export const slackGreen = '#2eb67d';
 // https://www.youtube.com/about/brand-resources/#logos-icons-colors
 export const youTubeRed = '#ff0000';
 // https://whatsappbrand.com/#color

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -50,8 +50,6 @@ export const opaqueBlack02 = '#fafafa';
 export const facebookBlue = '#1877f2';
 // https://about.twitter.com/content/dam/about-twitter/company/brand-resources/en_us/Twitter_Brand_Guidelines_V2_0.pdf
 export const twitterBlue = '#1da1f2';
-// https://designguidelines.withgoogle.com/ads-branding/assets/1McJDbBKmuQAv35pVV9vY3A5CQiRY5hRv/visual-guidelines-google-ads.pdf
-export const googleOrange = '#ea4335';
 // https://slack.com/intl/en-it/marketing/img/media-kit/slack_brand_guidelines_september2020.pdf
 export const slackGreen = '#2eb67d';
 // https://www.youtube.com/about/brand-resources/#logos-icons-colors


### PR DESCRIPTION
Updated social network colors and added reference links in shared.js
I also think that googleOrange should be called googleRed but I haven't seen reference where the color is used