### PR TITLE
Fix ecs deploy to QA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-ecs-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -44,7 +43,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-ecs-deploy
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-ecs-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -37,15 +36,14 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
+    - pip install awscli
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-ecs-deploy
 
 build_live:
   image: docker:latest
@@ -82,10 +80,10 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
+    - pip install awscli
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-ecs-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -37,11 +38,14 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy==1.7.0
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-ecs-deploy
 
 build_live:
   image: docker:latest
@@ -79,7 +83,9 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy==1.7.0
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,9 @@ deploy_qa:
   script:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli
-    - pip install ecs-deploy
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
@@ -81,7 +83,9 @@ deploy_live:
   script:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli
-    - pip install ecs-deploy
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,7 @@ build_qa:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.194
+    - pip install awscli
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/qa/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -38,9 +37,8 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.194
-    - pip install ecs-deploy==1.11.0
+    - pip install awscli
+    - pip install ecs-deploy
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
@@ -60,8 +58,7 @@ build_live:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.194
+    - pip install awscli
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/live/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -83,9 +80,8 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.194
-    - pip install ecs-deploy==1.11.0
+    - pip install awscli
+    - pip install ecs-deploy
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ build_qa:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/qa/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -23,6 +23,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-ecs-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -39,11 +40,11 @@ deploy_qa:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - pip install awscli
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-ecs-deploy
 
 build_live:
   image: docker:latest
@@ -58,7 +59,7 @@ build_live:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/live/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -83,7 +84,6 @@ deploy_live:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - pip install awscli
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,8 @@ build_qa:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.16.201
+    - pip install docutils==0.16
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/qa/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -39,7 +39,7 @@ deploy_qa:
   script:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
@@ -60,8 +60,8 @@ build_live:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.16.201
+    - pip install docutils==0.16
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/live/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
@@ -84,7 +84,7 @@ deploy_live:
   script:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"


### PR DESCRIPTION
This change updates the version pins for botocore and boto3 to resolve the errors encountered during deploy to QA.

E.g.
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in input: "registeredAt", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, tags, pidMode, ipcMode, proxyConfiguration, inferenceAccelerators

```

The proper version should be:
```
botocore==1.17.47
boto3==1.14.47
```