### PR TITLE
Support check web configuration via SSM parameter store

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ build_qa:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - d=configurator/check/qa/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
     - docker build  -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ deploy_qa:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA --timeout 3600
+    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
@@ -80,7 +80,7 @@ deploy_live:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA --timeout 3600
+    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ deploy_qa:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/CheckWebSSMReadOnlyAccess --timeout 3600
+    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
@@ -80,7 +80,7 @@ deploy_live:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/CheckWebSSMReadOnlyAccess --timeout 3600
+    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ build_qa:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
     - d=configurator/check/qa/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
     - docker build  -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
@@ -59,8 +58,6 @@ build_live:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ./configurator
-    - d=configurator/check/live/check-web/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
     - docker build  -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - ssm-config
 
 deploy_qa:
   image: python:3-alpine
@@ -42,7 +41,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - ssm-config
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ deploy_qa:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
+    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/CheckWebSSMReadOnlyAccess --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
@@ -80,7 +80,7 @@ deploy_live:
     - pip install botocore==1.17.47
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
+    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/CheckWebSSMReadOnlyAccess --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - ssm-config
 
 deploy_qa:
   image: python:3-alpine
@@ -41,6 +42,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - ssm-config
 
 build_live:
   image: docker:latest

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get install -y dirmngr gnupg \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7 \
     && apt-get install -y apt-transport-https ca-certificates \
     && echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
-    && apt-get update -qq && apt-get install -y graphicsmagick passenger
+    && apt-get update -qq && apt-get install -y graphicsmagick passenger \
+    && apt-get install -y awscli jq
 
 # deployment scripts
 COPY production/bin /opt/bin

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -46,8 +46,9 @@ COPY . ${DEPLOYDIR}/latest
 RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/develop/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
-# Trigger the config download here prior to build.
-RUN /opt/bin/create_configs.sh
+# Create stub configs for build to succeed
+COPY /dev/null ${DEPLOYDIR}/latest/config.js
+COPY /dev/null ${DEPLOYDIR}/latest/config-server.js
 
 # build all assets, js, css, transifex
 RUN npm run build

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -19,7 +19,8 @@ ENV DEPLOYUSER=checkdeploy \
     MAX_POOL_SIZE=12 \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    LANGUAGE=C.UTF-8
+    LANGUAGE=C.UTF-8 \
+    AWS_DEFAULT_REGION=eu-west-1
 
 # user config
 RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -46,9 +46,9 @@ COPY . ${DEPLOYDIR}/latest
 RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/develop/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
-# Create stub configs for build to succeed
-RUN touch ${DEPLOYDIR}/latest/config.js
-RUN touch ${DEPLOYDIR}/latest/config-server.js
+# Create default configs for build to succeed
+COPY config.js.example ${DEPLOYDIR}/latest/config.js
+COPY config-server.js.example ${DEPLOYDIR}/latest/config-server.js
 
 # build all assets, js, css, transifex
 RUN npm run build

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -47,8 +47,8 @@ RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/develop/pub
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create stub configs for build to succeed
-COPY /dev/null ${DEPLOYDIR}/latest/config.js
-COPY /dev/null ${DEPLOYDIR}/latest/config-server.js
+RUN touch ${DEPLOYDIR}/latest/config.js
+RUN touch ${DEPLOYDIR}/latest/config-server.js
 
 # build all assets, js, css, transifex
 RUN npm run build

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -45,6 +45,8 @@ COPY . ${DEPLOYDIR}/latest
 RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/develop/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
+# Trigger the config download here prior to build.
+RUN /opt/bin/create_configs.sh
 
 # build all assets, js, css, transifex
 RUN npm run build

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -3,11 +3,6 @@
 # This script generates json configuration files for check-web using values
 # from the SSM parameter store.
 
-# For the build stage, use QA configs. These will be replaced for Live environment.
-if [[ -z ${DEPLOY_ENV+x} ]]; then
-  export DEPLOY_ENV=qa
-fi
-
 # The following environment variables must be set:
 if [[ -z ${DEPLOY_ENV+x} || -z ${DEPLOYDIR+x} || -z ${AWS_DEFAULT_REGION+x} ]]; then
   echo "DEPLOY_ENV, DEPLOYDIR, and AWS_DEFAULT_REGION must be in the environment. Exiting."

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -16,7 +16,7 @@ if (( $? != 0 )); then
   exit 1
 fi
 
-SSM_PREFIX="${DEPLOY_ENV}/check-web"
+SSM_PREFIX="/${DEPLOY_ENV}/check-web"
 WORKTMP=$(mktemp)
 
 # Create user config.js from SSM parameter value:

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -9,13 +9,6 @@ if [[ -z ${DEPLOY_ENV+x} || -z ${DEPLOYDIR+x} || -z ${AWS_DEFAULT_REGION+x} ]]; 
   exit 1
 fi
 
-# We also require access to SSM via the awscli.
-aws sts get-caller-identity >/dev/null 2>&1
-if (( $? != 0 )); then
-  echo "Error calling AWS get-caller-identity. Valid credentials required. Exiting."
-  exit 1
-fi
-
 SSM_PREFIX="/${DEPLOY_ENV}/check-web"
 WORKTMP=$(mktemp)
 

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# This script generates json configuration files for check-web using values
+# from the SSM parameter store.
+
+# The following environment variables must be set: DEPLOYDIR and
+if [[ -z ${DEPLOY_ENV+x} || -z ${DEPLOYDIR+x} || -z ${AWS_DEFAULT_REGION+x} ]]; then
+        echo "DEPLOY_ENV, DEPLOYDIR, and AWS_DEFAULT_REGION must be in the environment. Exiting."
+        exit 1
+fi
+
+# We also require access to SSM via the awscli.
+aws sts get-caller-identity >/dev/null 2>&1
+if (( $? != 0 )); then
+  echo "Error calling AWS get-caller-identity. Valid credentials required. Exiting."
+  exit 1
+fi
+
+# We create a full template, and then exclude specific elements depending
+# on which environment we are configuring.
+export TEMPLATEFILE=$(mktemp)
+export DESTFILE="${DEPLOYDIR}/latest/config.js"
+cat << TEMPLATEEOF > $TEMPLATEFILE
+window.config = {
+  appName: 'check',
+  selfHost: '##self_host##',
+  restBaseUrl: '##rest_base_url##',
+  relayPath: '##relay_path##',
+  relayHeaders: {
+    'X-Check-Token': '##check_header_token##'
+  },
+  penderUrl: '##pender_url##',
+  pusherKey: '##pusher_key##',
+  pusherCluster: '##pusher_cluster##',
+  pusherDebug: ##pusher_debug##,
+  googleAnalyticsCode: '##google_analytics_code##',
+  googleStaticMapsKey: '##google_static_maps_key##',
+  mapboxApiKey: '##mapbox_api_key##',
+  opencageApiKey: '##opencage_api_key##',
+  googleMapsApiKey: '##google_maps_api_key##',
+  extensionUrls: ['chrome-extension://afafaiilokmpfmkfjjgfenfneoafojie', 'moz-extension://baeeb55c-c744-4ffc-bddd-64199b73f77b'],
+  intercomAppId: '##intercom_app_id##',
+};
+TEMPLATEEOF
+
+# Because of differences in configuration between environments, we use
+# different template files for each environment.
+if [[ "$DEPLOY_ENV" == "live" ]]; then
+    export WORKTMP=$(mktemp)
+    # Iterate over keys in SSM and replace corresponding values in template.
+    PARAMNAMES=$(aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-web/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-web/##')
+    echo "Setting parameters: $PARAMNAMES"
+    for PNAME in $PARAMNAMES; do
+        export PVAL=$(aws ssm get-parameters --region $AWS_DEFAULT_REGION --name "/live/check-web/${PNAME}" | jq .Parameters[].Value|sed 's/["]//g')
+        cat $TEMPLATEFILE | sed "s,##${PNAME}##,${PVAL}," > $WORKTMP && mv $WORKTMP $TEMPLATEFILE
+    done
+    mv $TEMPLATEFILE $DESTFILE
+
+# QA environment:
+elif [[ "$DEPLOY_ENV" == "qa" ]]; then
+    export WORKTMP=$(mktemp)
+    # QA environment does not set some elements. Exclude them below...
+    cat $TEMPLATEFILE | grep -v extensionUrls | grep -v intercomAppId > $WORKTMP && mv $WORKTMP $TEMPLATEFILE
+    # Iterate over keys in SSM and replace corresponding values in template.
+    PARAMNAMES=$(aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-web/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-web/##')
+    echo "Setting parameters: $PARAMNAMES"
+    for PNAME in $PARAMNAMES; do
+        export PVAL=$(aws ssm get-parameters --region $AWS_DEFAULT_REGION --name "/qa/check-web/${PNAME}" | jq .Parameters[].Value|sed 's/["]//g')
+        cat $TEMPLATEFILE | sed "s,##${PNAME}##,${PVAL}," > $WORKTMP && mv $WORKTMP $TEMPLATEFILE
+    done
+    mv $TEMPLATEFILE $DESTFILE
+
+# Test environments:
+else
+    export WORKTMP=$(mktemp)
+    # For test environments, we omit a number of elements.
+    cat $TEMPLATEFILE | grep -v googleAnalyticsCode | grep -v googleStaticMapsKey | grep -v mapboxApiKey | grep -v extensionUrls | grep -v intercomAppId > $WORKTMP && mv $WORKTMP $TEMPLATEFILE
+    # Iterate over keys in SSM and replace corresponding values in template.
+    PARAMNAMES=$(aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-web/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-web/##')
+    echo "Setting parameters: $PARAMNAMES"
+    for PNAME in $PARAMNAMES; do
+        export PVAL=$(aws ssm get-parameters --region $AWS_DEFAULT_REGION --name "/qa/check-web/${PNAME}" | jq .Parameters[].Value|sed 's/["]//g')
+        cat $TEMPLATEFILE | sed "s,##${PNAME}##,${PVAL}," > $WORKTMP && mv $WORKTMP $TEMPLATEFILE
+    done
+    mv $TEMPLATEFILE $DESTFILE
+fi
+
+echo "Configuration for env $DEPLOY_ENV complete."
+exit 0

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -3,10 +3,15 @@
 # This script generates json configuration files for check-web using values
 # from the SSM parameter store.
 
+# For the build stage, use QA configs. These will be replaced for Live environment.
+if [[ -z ${DEPLOY_ENV+x} ]]; then
+  export DEPLOY_ENV=qa
+fi
+
 # The following environment variables must be set:
 if [[ -z ${DEPLOY_ENV+x} || -z ${DEPLOYDIR+x} || -z ${AWS_DEFAULT_REGION+x} ]]; then
-        echo "DEPLOY_ENV, DEPLOYDIR, and AWS_DEFAULT_REGION must be in the environment. Exiting."
-        exit 1
+  echo "DEPLOY_ENV, DEPLOYDIR, and AWS_DEFAULT_REGION must be in the environment. Exiting."
+  exit 1
 fi
 
 # We also require access to SSM via the awscli.

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -7,8 +7,8 @@ if [[ -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
 	exit 1
 fi
 
-# Always put config into place when starting service. This is because
-# build stage includes the QA configs which Live must replace.
+# Always put config into place when starting service. This is because the
+# build stage includes the sample configs which real deployments must replace.
 /opt/bin/create_configs.sh
 if (( $? != 0 )); then
 	echo "Error creating configuration files. Exiting."

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -2,15 +2,20 @@
 # start.sh
 # the Dockerfile CMD
 
-if [[ -z ${GITHUB_TOKEN+x} || -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
-	echo "GITHUB_TOKEN, DEPLOY_ENV, and APP must be in the environment. Exiting."
+if [[ -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
+	echo "DEPLOY_ENV, and APP must be in the environment. Exiting."
 	exit 1
 fi
 
-rm -rf ${DEPLOYDIR}/latest/configurator && git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/meedan/configurator ${DEPLOYDIR}/latest/configurator
-d=configurator/check/${DEPLOY_ENV}/${APP}/; for f in $(find $d -type f); do cp "$f" "${f/$d/}"; done
+# Put config into place if not yet created
+if [ ! -f ${DEPLOYDIR}/latest/config.js ]; then
+	/opt/bin/create_configs.sh ${DEPLOYDIR}
+	if (( $? != 0 )); then
+		echo "Error creating configuration files. Exiting."
+		exit 1
+	fi
+fi	
 
-# Put config into place
 cp ${DEPLOYDIR}/latest/config.js ${DEPLOYDIR}/latest/build/web/js/config.js
 
 passenger start

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -7,14 +7,13 @@ if [[ -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
 	exit 1
 fi
 
-# Put config into place if not yet created
-if [ ! -f ${DEPLOYDIR}/latest/config.js ]; then
-	/opt/bin/create_configs.sh
-	if (( $? != 0 )); then
-		echo "Error creating configuration files. Exiting."
-		exit 1
-	fi
-fi	
+# Always put config into place when starting service. This is because
+# build stage includes the QA configs which Live must replace.
+/opt/bin/create_configs.sh
+if (( $? != 0 )); then
+	echo "Error creating configuration files. Exiting."
+	exit 1
+fi
 
 cp ${DEPLOYDIR}/latest/config.js ${DEPLOYDIR}/latest/build/web/js/config.js
 

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -9,7 +9,7 @@ fi
 
 # Put config into place if not yet created
 if [ ! -f ${DEPLOYDIR}/latest/config.js ]; then
-	/opt/bin/create_configs.sh ${DEPLOYDIR}
+	/opt/bin/create_configs.sh
 	if (( $? != 0 )); then
 		echo "Error creating configuration files. Exiting."
 		exit 1


### PR DESCRIPTION
This change adds support for check-web configuration via SSM parameter store values. Each of the config.js and config-server.js files are base64 encoded and stored in SSM. See the [check-web section of the ssm-migration README](https://github.com/meedan/configurator/tree/ssm-migration/ssm_import#check-web) for more information.