### PR TITLE
Vary build by branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - vary-build-by-branch
 
 deploy_qa:
   image: python:3-alpine
@@ -42,7 +41,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - vary-build-by-branch
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - vary-build-by-branch
 
 deploy_qa:
   image: python:3-alpine
@@ -41,6 +42,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - vary-build-by-branch
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ build_qa:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build  -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
+    - docker build --build-arg deploy_branch=develop -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
@@ -57,7 +57,7 @@ build_live:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build  -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"  .
+    - docker build --build-arg deploy_branch=master -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ build_qa:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build --build-arg deploy_branch=develop -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
+    - docker build --build-arg DEPLOY_BRANCH=develop -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
@@ -57,7 +57,7 @@ build_live:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build --build-arg deploy_branch=master -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"  .
+    - docker build --build-arg DEPLOY_BRANCH=master -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
   only:
     - master

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -6,6 +6,8 @@ MAINTAINER sysops@meedan.com
 #
 # SYSTEM CONFIG
 #
+ARG DEPLOY_BRANCH
+ENV DEPLOYBRANCH=$DEPLOY_BRANCH
 
 # consolidate ENV for one cache layer
 ENV DEPLOYUSER=checkdeploy \
@@ -20,8 +22,7 @@ ENV DEPLOYUSER=checkdeploy \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
     LANGUAGE=C.UTF-8 \
-    AWS_DEFAULT_REGION=eu-west-1 \
-    DEPLOY_BRANCH=${DEPLOY_BRANCH}
+    AWS_DEFAULT_REGION=eu-west-1 
 
 # user config
 RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest
@@ -45,11 +46,8 @@ RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
 # get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
-#RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
-#    && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
-RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json 
+RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOYBRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json 
 RUN ls -l ${DEPLOYDIR}/latest/relay.json
-RUN cat ${DEPLOYDIR}/latest/relay.json
 RUN sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -49,6 +49,7 @@ COPY . ${DEPLOYDIR}/latest
 #    && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json 
 RUN ls -l ${DEPLOYDIR}/latest/relay.json
+RUN cat ${DEPLOYDIR}/latest/relay.json
 RUN sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -45,9 +45,8 @@ COPY package-lock.json ${DEPLOYDIR}/latest
 RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
-# get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
+# get the relay.json file from github.com/meedan/check-api that corresponds to the DEPLOY_BRANCH passed to build.
 RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOYBRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json 
-RUN ls -l ${DEPLOYDIR}/latest/relay.json
 RUN sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -44,7 +44,7 @@ RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
 # get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
-RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/develop/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
+RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/$deploy_branch/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -45,8 +45,11 @@ RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
 # get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
-RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
-    && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
+#RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
+#    && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
+RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json 
+RUN ls -l ${DEPLOYDIR}/latest/relay.json
+RUN sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed
 COPY config.js.example ${DEPLOYDIR}/latest/config.js

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -44,7 +44,7 @@ RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
 # get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
-RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/$deploy_branch/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
+RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/$DEPLOY_BRANCH/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -20,7 +20,8 @@ ENV DEPLOYUSER=checkdeploy \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
     LANGUAGE=C.UTF-8 \
-    AWS_DEFAULT_REGION=eu-west-1
+    AWS_DEFAULT_REGION=eu-west-1 \
+    DEPLOY_BRANCH=${DEPLOY_BRANCH}
 
 # user config
 RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest
@@ -44,7 +45,7 @@ RUN npm install
 COPY . ${DEPLOYDIR}/latest
 
 # get the relay.json file from github.com/meedan/check-api that corresponds to the current local git branch (defaults to 'develop')
-RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/$DEPLOY_BRANCH/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
+RUN curl --silent https://raw.githubusercontent.com/meedan/check-api/${DEPLOY_BRANCH}/public/relay.json -o ${DEPLOYDIR}/latest/relay.json \
     && sed "s|/api/public/relay.json|${DEPLOYDIR}/latest/relay.json|" < config-build.js.example > ${DEPLOYDIR}/latest/config-build.js
 
 # Create default configs for build to succeed


### PR DESCRIPTION
This change updates the GitLab CI deploy script and the `production/Dockerfile` to accept a new DEPLOY_BRANCH argument which is used to pull in the relay.json configuration from the appropriate upstream branch. (E.g. `develop` or `master` for QA and Live, respectively.)

Resolves ticket DEVOPS-106