### PR TITLE
CHECK-729: Datetime field needs default time zone in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2125,9 +2125,9 @@
       }
     },
     "@meedan/check-ui": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@meedan/check-ui/-/check-ui-0.1.2.tgz",
-      "integrity": "sha512-/x9ULeDE8IzSUdVFxpAV7xT4FbRCsQaIa4gqpH1O2S9HJ4ofgkc3ClmcAm61MZC8JGwbJ9hw8CnbvJHXxhe4IA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@meedan/check-ui/-/check-ui-0.1.4.tgz",
+      "integrity": "sha512-8w8HJYmhho3ryCkmeYk1N1UtJnpXahMJwxlOQU7BAd6v6LOELz2ST89UgxnwVoN3Ez1pdGT5359yHeTwOxr4WA==",
       "requires": {
         "@date-io/dayjs": "^1.3.13",
         "@react-google-maps/api": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.52",
     "@material-ui/pickers": "^3.2.10",
-    "@meedan/check-ui": "0.1.2",
+    "@meedan/check-ui": "0.1.4",
     "@meedan/react-jsonschema-form-material-ui-v1": "^99.0.0",
     "@react-google-maps/api": "1.8.7",
     "babel-loader": "^8.1.0",

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -395,6 +395,13 @@ class SearchResultsComponent extends React.PureComponent {
     delete unsortedQuery.sort;
     delete unsortedQuery.sort_type;
 
+    let showSimilarAction = false;
+
+    if (team.alegre_bot) {
+      const { alegre_settings: settings } = team.alegre_bot;
+      showSimilarAction = settings.master_similarity_enabled;
+    }
+
     return (
       <React.Fragment>
         <StyledListHeader>
@@ -447,7 +454,7 @@ class SearchResultsComponent extends React.PureComponent {
         <StyledSearchResultsWrapper className="search__results results">
           <Toolbar
             team={team}
-            similarAction={
+            similarAction={showSimilarAction ?
               <FormControlLabel
                 classes={{ labelPlacementStart: classes.similarSwitch }}
                 control={
@@ -467,7 +474,7 @@ class SearchResultsComponent extends React.PureComponent {
                   />
                 }
                 labelPlacement="start"
-              />
+              /> : null
             }
             actions={projectMedias.length && selectedProjectMediaDbids.length ?
               <BulkActions
@@ -600,16 +607,9 @@ const SearchResultsContainer = Relay.createContainer(withStyles(Styles)(withPush
           verification_statuses,
           list_columns,
           medias_count,
-          team_bot_installations(first: 10000) {
-            edges {
-              node {
-                id
-                team_bot: bot_user {
-                  id
-                  identifier
-                }
-              }
-            }
+          alegre_bot: team_bot_installation(bot_identifier: "alegre") {
+            id
+            alegre_settings
           }
         }
         medias(first: $pageSize) {

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -61,7 +61,7 @@ class EditTaskDialog extends React.Component {
 
     let defaultOptions = [{ label: '' }, { label: '' }];
     if (props.taskType === 'datetime') {
-      defaultOptions = [];
+      defaultOptions = [{ code: 'UTC', label: 'UTC (0 GMT)', offset: 0 }];
     }
 
     this.state = {
@@ -138,6 +138,8 @@ class EditTaskDialog extends React.Component {
     if (this.props.taskType === 'single_choice' ||
         this.props.taskType === 'multiple_choice') {
       valid = !!(label && label.trim()) && options.filter(item => item.label.trim() !== '').length > 1;
+    } else if (this.props.taskType === 'datetime') {
+      valid = !!(label && label.trim()) && options.length > 0;
     } else {
       valid = !!(label && label.trim());
     }

--- a/test/spec/metadata_spec.rb
+++ b/test/spec/metadata_spec.rb
@@ -18,10 +18,10 @@ shared_examples 'metadata' do
     wait_for_selector("//span[contains(text(), 'Edited')]", :xpath)
     expect(@driver.page_source.include?('my metadata - Edited')).to be(true)
 
-    # create 'data and time' metadata
-    expect(@driver.page_source.include?('my data time metadata')).to be(false)
-    create_team_data_field(task_type_class: '.create-task__add-datetime', task_name: 'my data time metadata')
-    expect(@driver.page_source.include?('my data time metadata')).to be(true)
+    # create 'date and time' metadata
+    expect(@driver.page_source.include?('my date time metadata')).to be(false)
+    create_team_data_field(task_type_class: '.create-task__add-datetime', task_name: 'my date time metadata')
+    expect(@driver.page_source.include?('my date time metadata')).to be(true)
 
     # change the metadata order
     task = wait_for_selector('.team-tasks__task-label > span > span') # first metadata
@@ -30,11 +30,11 @@ shared_examples 'metadata' do
     wait_for_selector('.reorder__button-down').click
     wait_for_text_change('my metadata - Edited', '.team-tasks__task-label > span > span', :css)
     task = wait_for_selector('.team-tasks__task-label > span > span') # the second becomes the first
-    expect(task.text).to eq 'my data time metadata'
+    expect(task.text).to eq 'my date time metadata'
 
     # delete metadata
     delete_team_data_field
-    expect(@driver.page_source.include?('my data time metadata')).to be(false)
+    expect(@driver.page_source.include?('my date time metadata')).to be(false)
   end
 
   it 'should add, edit and delete a metadata response', bin5: true do

--- a/test/spec/task_spec.rb
+++ b/test/spec/task_spec.rb
@@ -79,8 +79,10 @@ shared_examples 'task' do
     task = wait_for_selector('.task__label-container > div > span') # first task
     expect(task.text).to eq 'Task 1'
     wait_for_selector('.reorder__button-down').click
-    task2 = wait_for_selector('.task__label-container > div > span') # the second becomes the first
-    expect(task2.text).to eq 'Task 2'
+    wait_for_text_change('Task 1', '.task__label-container > div > span', :css)
+    task = wait_for_selector('.task__label-container > div > span') # the second becomes the first
+    puts @driver.page_source
+    expect(task.text).to eq 'Task 2'
   end
 
   it 'should add, edit, answer, update answer and delete datetime task', bin3: true do


### PR DESCRIPTION
User is now no longer be able to create a datetime metadata field without providing at least one default time zone.

When creating a datetime metadata field, the application now puts in a default timezone of UTC, which the user can remove or add additional timezones to. This gives the user a reasonable default while also requiring an explicit time zone.

Also: Bumping check-ui dependency version