### PR TITLE
Fixing metadata file upload error states

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.52",
     "@material-ui/pickers": "^3.2.10",
-    "@meedan/check-ui": "0.1.5",
+    "@meedan/check-ui": "0.1.7",
     "@meedan/react-jsonschema-form-material-ui-v1": "^99.0.0",
     "@react-google-maps/api": "1.8.7",
     "babel-loader": "^8.1.0",

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -246,6 +246,7 @@ const MediaMetadataContainer = Relay.createContainer(withPusher(MediaTasksCompon
         audio_max_size
         audio_extensions
         file_max_size
+        file_max_size_in_bytes
         file_extensions
         upload_max_dimensions
         upload_min_dimensions

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -848,6 +848,7 @@ class Task extends Component {
                   this.setState({ textValue });
                 }}
                 extensions={about.file_extensions}
+                fileSizeMax={about.file_max_size_in_bytes}
                 messages={messages.MetadataFile}
               />
             ) : null}
@@ -1084,6 +1085,7 @@ class Task extends Component {
               }}
               extensions={about.file_extensions}
               messages={messages.MetadataFile}
+              fileSizeMax={about.file_max_size_in_bytes}
             />
           </div>
         ) : null}


### PR DESCRIPTION
Bumping to a new version of `check-ui` which means file extensions are now case-inensitive, fixing CHECK-755.

Providing a `fileSizeMax` to the `MetadataFile` component from `check-ui` as defined by our API which fixes CHECK-754.