### PR TITLE
Ticket CHECK-601: The text from a destroyed comment is available only…

### DIFF
--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -480,7 +480,14 @@ class Annotation extends Component {
         );
       }
       break;
-    case 'destroy_comment':
+    case 'destroy_comment': {
+      let commentRemoved = null;
+      if (content === null) {
+        const changes = JSON.parse(activity.object_changes_json);
+        commentRemoved = changes.data[0].text;
+      } else {
+        commentRemoved = content.text;
+      }
       contentTemplate = (
         <em className="annotation__deleted">
           <FormattedMessage
@@ -488,11 +495,12 @@ class Annotation extends Component {
             defaultMessage="Comment deleted by {author}: {comment}"
             values={{
               author: authorName,
-              comment: <ParsedText text={content.text} block />,
+              comment: <ParsedText text={commentRemoved} block />,
             }}
           />
         </em>);
       break;
+    }
     case 'create_task':
       if (content.fieldset === 'tasks') {
         contentTemplate = (

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -40,6 +40,7 @@ import {
   getStatusStyle,
   emojify,
   parseStringUnixTimestamp,
+  safelyParseJSON,
 } from '../../helpers';
 import globalStrings from '../../globalStrings';
 import { stringHelper } from '../../customHelpers';

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -483,7 +483,7 @@ class Annotation extends Component {
     case 'destroy_comment': {
       let commentRemoved = null;
       if (content === null) {
-        const changes = JSON.parse(activity.object_changes_json);
+        const changes = safelyParseJSON(activity.object_changes_json);
         commentRemoved = changes.data[0].text;
       } else {
         commentRemoved = content.text;


### PR DESCRIPTION
… on object_changes

This change was included after paper_trail upgrade to version 10 on CheckAPI.
For comments deleted after the changes the `content` is null and need to get the text from the changes