### PR TITLE
Passenger repo fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - passenger-repo-fix
 
 deploy_qa:
   image: python:3-alpine
@@ -41,6 +42,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - passenger-repo-fix
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - passenger-repo-fix
 
 deploy_qa:
   image: python:3-alpine
@@ -42,7 +41,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - passenger-repo-fix
 
 build_live:
   image: docker:latest

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -32,9 +32,11 @@ RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest
 RUN apt-get install -y dirmngr gnupg \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7 \
     && apt-get install -y apt-transport-https ca-certificates libgnutls-openssl27 libgnutls30 \
+    && apt-get update -qq \
     && update-ca-certificates \
     && echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
-    && apt-get update -qq && apt-get install -y graphicsmagick passenger \
+    && apt-get update -qq \
+    && apt-get install -y graphicsmagick passenger \
     && apt-get install -y awscli jq
 
 # deployment scripts

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -31,7 +31,8 @@ ENV DEPLOYUSER=checkdeploy \
 RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest
 RUN apt-get install -y dirmngr gnupg \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7 \
-    && apt-get install -y apt-transport-https ca-certificates \
+    && apt-get install -y apt-transport-https ca-certificates libgnutls-openssl27 libgnutls30 \
+    && update-ca-certificates \
     && echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
     && apt-get update -qq && apt-get install -y graphicsmagick passenger \
     && apt-get install -y awscli jq

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -29,15 +29,16 @@ ENV DEPLOYUSER=checkdeploy \
 
 # user config
 RUN useradd ${DEPLOYUSER} -s /bin/bash -d ${DEPLOYDIR}/latest
+RUN apt-get update -qq 
 RUN apt-get install -y dirmngr gnupg \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7 \
-    && apt-get install -y apt-transport-https ca-certificates libgnutls-openssl27 libgnutls30 \
-    && apt-get update -qq \
-    && update-ca-certificates 
-RUN echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
-    && apt-get update -qq 
-RUN apt-get install -y graphicsmagick passenger \
-    && apt-get install -y awscli jq
+    && apt-get install -y apt-transport-https ca-certificates 
+RUN apt-get install -y graphicsmagick awscli jq
+RUN apt-get install -y libgnutls-openssl27 libgnutls30
+RUN update-ca-certificates
+RUN echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list 
+RUN apt-get update -oDebug::pkgAcquire::Worker=1 
+RUN apt-get install -y passenger 
 
 # deployment scripts
 COPY production/bin /opt/bin

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -33,10 +33,10 @@ RUN apt-get install -y dirmngr gnupg \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7 \
     && apt-get install -y apt-transport-https ca-certificates libgnutls-openssl27 libgnutls30 \
     && apt-get update -qq \
-    && update-ca-certificates \
-    && echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
-    && apt-get update -qq \
-    && apt-get install -y graphicsmagick passenger \
+    && update-ca-certificates 
+RUN echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list \
+    && apt-get update -qq 
+RUN apt-get install -y graphicsmagick passenger \
     && apt-get install -y awscli jq
 
 # deployment scripts

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -y graphicsmagick awscli jq
 RUN apt-get install -y libgnutls-openssl27 libgnutls30
 RUN update-ca-certificates
 RUN echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger buster main' > /etc/apt/sources.list.d/passenger.list 
-RUN apt-get update -oDebug::pkgAcquire::Worker=1 
+RUN apt-get update -qq
 RUN apt-get install -y passenger 
 
 # deployment scripts


### PR DESCRIPTION
As per discussion in Slack, there are issues with LetsEncrypt certificate verification on the passenger repo site.
This change includes gnutls and changes the apt update order to ensure that LetsEncrypt certificates are trusted for the passenger site during installation.