### PR TITLE
CHECK-937: conditional annotation "save all" and "required" fields

### DIFF
--- a/localization/react-intl/src/app/components/task/Tasks.json
+++ b/localization/react-intl/src/app/components/task/Tasks.json
@@ -10,5 +10,25 @@
   {
     "id": "tasks.goToSettings",
     "defaultMessage": "Go to settings"
+  },
+  {
+    "id": "metadata.couldNotSave",
+    "description": "Error message displayed when it's not possible to save metadata due to a required field not being filled in.",
+    "defaultMessage": "Could not save, missing required field"
+  },
+  {
+    "id": "metadata.form.save",
+    "description": "This is a label on a button at the top of a form. The label indicates that if the user presses this button, the user will save the changes they have been making in the form.",
+    "defaultMessage": "Save"
+  },
+  {
+    "id": "metadata.form.cancel",
+    "description": "This is a label on a button that the user presses in order to revert/cancel any changes made to an unsaved form.",
+    "defaultMessage": "Cancel changes"
+  },
+  {
+    "id": "metadata.form.edit",
+    "description": "This is a label on a button that the user presses in order to edit the items in the attached form.",
+    "defaultMessage": "Edit"
   }
 ]

--- a/localization/react-intl/src/app/components/team/TeamTaskCard.json
+++ b/localization/react-intl/src/app/components/team/TeamTaskCard.json
@@ -5,6 +5,11 @@
     "defaultMessage": "Field {number}"
   },
   {
+    "id": "teamTaskCard.required",
+    "description": "Toggle switch to make field required",
+    "defaultMessage": "Required"
+  },
+  {
     "id": "teamTaskCard.showInBrowserExtension",
     "description": "Toggle switch to make field visible in the browser extension",
     "defaultMessage": "Show in browser extension"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2125,9 +2125,9 @@
       }
     },
     "@meedan/check-ui": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@meedan/check-ui/-/check-ui-0.1.17.tgz",
-      "integrity": "sha512-dj4mOupHQkkOAQpcfoUexgjR4nxksJC3XFEMI4HwrHsF2QJqDHriGobYXrWdC3IpIihnNf+k1Ffb77z6RzOFCA==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@meedan/check-ui/-/check-ui-0.1.19.tgz",
+      "integrity": "sha512-Z1/fLmlvfwgoOvRCQVay3WxwI+wDs+QGKgyX+9CuEbvhh4DS1F9geS6GdB/sDNY5CCDCWcfACxuj/QV8/npGzg==",
       "requires": {
         "@date-io/dayjs": "^1.3.13",
         "@material-ui/core": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.52",
     "@material-ui/pickers": "^3.2.10",
-    "@meedan/check-ui": "^0.1.17",
+    "@meedan/check-ui": "^0.1.19",
     "@meedan/react-jsonschema-form-material-ui-v1": "^99.0.0",
     "@react-google-maps/api": "1.8.7",
     "babel-loader": "^8.1.0",

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -266,8 +266,20 @@ const MediaMetadataContainer = Relay.createContainer(withPusher(MediaTasksCompon
               team_task {
                 conditional_info
                 options
+                required
               },
               first_response_value,
+              first_response {
+                id
+                content
+              },
+              annotator {
+                id
+                user {
+                  dbid
+                  name
+                }
+              }
               ${Task.getFragment('task')},
             }
           }

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -2,19 +2,38 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { browserHistory } from 'react-router';
 import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
 import styled from 'styled-components';
+import moment from 'moment';
 import Task from './Task';
 import ReorderTask from './ReorderTask';
 import BlankState from '../layout/BlankState';
 import { units } from '../../styles/js/shared';
+import { withSetFlashMessage } from '../FlashMessage';
 
 const StyledMetadataContainer = styled.div`
-  .tasks__list {
-    padding: ${units(4)};
-  }
   .tasks__list > li {
     margin-bottom: ${units(2)};
+    margin-left: ${units(2)};
+    margin-top: ${units(2)};
+  }
+`;
+
+const StyledFormControls = styled.div`
+  padding-left: ${units(2)};
+  padding-top: ${units(2)};
+  button {
+    margin-right: ${units(1)};
+  }
+`;
+
+const StyledAnnotatorInformation = styled.span`
+  display: inline-block;
+  p {
+    font-size: 9px;
+    color: #979797;
   }
 `;
 
@@ -23,12 +42,15 @@ const Tasks = ({
   tasks,
   media,
   about,
+  setFlashMessage,
 }) => {
   const teamSlug = /^\/([^/]+)/.test(window.location.pathname) ? window.location.pathname.match(/^\/([^/]+)/)[1] : null;
   const goToSettings = () => browserHistory.push(`/${teamSlug}/settings/metadata`);
 
   const isBrowserExtension = (window.parent !== window);
   const isMetadata = fieldset === 'metadata';
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [localResponses, setLocalResponses] = React.useState(tasks);
 
   if (tasks.length === 0) {
     return (
@@ -91,7 +113,7 @@ const Tasks = ({
         const parsedConditionalInfo = JSON.parse(conditional_info);
         const { selectedFieldId, selectedConditional } = parsedConditionalInfo;
         let { selectedCondition } = parsedConditionalInfo;
-        const matchingTask = tasks.find(item => item.node.team_task_id === selectedFieldId);
+        const matchingTask = localResponses.find(item => item.node.team_task_id === selectedFieldId);
 
         // check if there is an "Other" value by looking for the .other prop on options
         const hasOther = matchingTask.node.team_task?.options?.some(item => item.other);
@@ -130,23 +152,135 @@ const Tasks = ({
     return true;
   }
 
+  function isAnyRequiredFieldEmpty() {
+    // HTML data attributes cast booleans to strings, so we check for equality to
+    // the string "true" here
+    return Array.from(document.querySelectorAll('.metadata-save'))
+      .some(saveButton => saveButton.dataset.empty === 'true' && saveButton.dataset.required === 'true');
+  }
+
+  function handleEditAnnotations() {
+    document.querySelectorAll('.metadata-edit').forEach((editButton) => {
+      editButton.click();
+    });
+    setIsEditing(true);
+  }
+
+  function handleSaveAnnotations() {
+    if (isAnyRequiredFieldEmpty()) {
+      setFlashMessage((
+        <FormattedMessage
+          id="metadata.couldNotSave"
+          defaultMessage="Could not save, missing required field"
+          description="Error message displayed when it's not possible to save metadata due to a required field not being filled in."
+        />
+      ), 'error');
+      return;
+    }
+    document.querySelectorAll('.metadata-save').forEach((saveButton) => {
+      saveButton.click();
+    });
+    setIsEditing(false);
+  }
+
+  function handleCancelAnnotations() {
+    document.querySelectorAll('.metadata-cancel').forEach((cancelButton) => {
+      cancelButton.click();
+    });
+    setIsEditing(false);
+  }
+
+  function getLatestEditInfo() {
+    const latestDate = Math.max(...tasks
+      .filter(task => (!isBrowserExtension || task.node.show_in_browser_extension))
+      .filter(showMetadataItem)
+      .map((task) => {
+        let updated_at;
+        try {
+          updated_at = JSON.parse(task.node?.first_response?.content)[0]?.updated_at;
+        } catch (exception) {
+          updated_at = null;
+        }
+        return new Date(updated_at);
+      }));
+    if (!latestDate) {
+      return null;
+    }
+    const latestAuthor = tasks
+      .filter(task => (!isBrowserExtension || task.node.show_in_browser_extension))
+      .filter(showMetadataItem)
+      .find((task) => {
+        let updated_at;
+        try {
+          updated_at = JSON.parse(task.node?.first_response?.content)[0]?.updated_at;
+        } catch (exception) {
+          updated_at = null;
+        }
+        return new Date(updated_at).getTime() === latestDate;
+      });
+    return {
+      latestDate,
+      latestAuthorDbid: latestAuthor.node?.annotator?.user?.dbid,
+      latestAuthorName: latestAuthor.node?.annotator?.user?.name,
+    };
+  }
+
+  const latestEditInfo = getLatestEditInfo();
+
   if (isMetadata) {
     output = (
       <StyledMetadataContainer>
+        <StyledFormControls>
+          {
+            isEditing ? (
+              <div>
+                <Button variant="contained" onClick={handleSaveAnnotations} style={{ backgroundColor: '#1BB157', color: 'white' }}>
+                  <FormattedMessage id="metadata.form.save" defaultMessage="Save" description="This is a label on a button at the top of a form. The label indicates that if the user presses this button, the user will save the changes they have been making in the form." />
+                </Button>
+                <Button onClick={handleCancelAnnotations}>
+                  <FormattedMessage id="metadata.form.cancel" defaultMessage="Cancel changes" description="This is a label on a button that the user presses in order to revert/cancel any changes made to an unsaved form." />
+                </Button>
+              </div>
+            ) :
+              <Button variant="contained" onClick={handleEditAnnotations} color="primary">
+                <FormattedMessage id="metadata.form.edit" defaultMessage="Edit" description="This is a label on a button that the user presses in order to edit the items in the attached form." />
+              </Button>
+          }
+          <p>
+            {
+              latestEditInfo ? (
+                <StyledAnnotatorInformation>
+                  <Typography variant="body1">
+                    Saved {moment(latestEditInfo.latestDate).fromNow()} by{' '}
+                    <a
+                      href={`/check/user/${latestEditInfo.latestAuthorDbid}`}
+                    >
+                      {latestEditInfo.latestAuthorName}
+                    </a>
+                  </Typography>
+                </StyledAnnotatorInformation>
+              ) : '...'
+            }
+          </p>
+        </StyledFormControls>
+        <Divider />
         <ul className="tasks__list">
           {tasks
             .filter(task => (!isBrowserExtension || task.node.show_in_browser_extension))
             .filter(showMetadataItem)
             .map(task => (
-              <li key={task.node.dbid}>
-                { (isMetadata || isBrowserExtension) ? (
-                  <Task task={task.node} media={media} about={about} />
-                ) : (
-                  <ReorderTask fieldset={fieldset} task={task.node}>
-                    <Task task={task.node} media={media} />
-                  </ReorderTask>
-                )}
-              </li>
+              <>
+                <li key={task.node.dbid}>
+                  { (isMetadata || isBrowserExtension) ? (
+                    <Task task={task.node} media={media} about={about} isEditing={isEditing} localResponses={localResponses} setLocalResponses={setLocalResponses} />
+                  ) : (
+                    <ReorderTask fieldset={fieldset} task={task.node}>
+                      <Task task={task.node} media={media} />
+                    </ReorderTask>
+                  )}
+                </li>
+                <Divider />
+              </>
             ))
           }
         </ul>
@@ -157,4 +291,4 @@ const Tasks = ({
   return output;
 };
 
-export default Tasks;
+export default withSetFlashMessage(Tasks);

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -234,15 +234,15 @@ const Tasks = ({
           {
             isEditing ? (
               <div>
-                <Button variant="contained" onClick={handleSaveAnnotations} style={{ backgroundColor: '#1BB157', color: 'white' }}>
+                <Button className="form-save" variant="contained" onClick={handleSaveAnnotations} style={{ backgroundColor: '#1BB157', color: 'white' }}>
                   <FormattedMessage id="metadata.form.save" defaultMessage="Save" description="This is a label on a button at the top of a form. The label indicates that if the user presses this button, the user will save the changes they have been making in the form." />
                 </Button>
-                <Button onClick={handleCancelAnnotations}>
+                <Button className="form-cancel" onClick={handleCancelAnnotations}>
                   <FormattedMessage id="metadata.form.cancel" defaultMessage="Cancel changes" description="This is a label on a button that the user presses in order to revert/cancel any changes made to an unsaved form." />
                 </Button>
               </div>
             ) :
-              <Button variant="contained" onClick={handleEditAnnotations} color="primary">
+              <Button className="form-edit" variant="contained" onClick={handleEditAnnotations} color="primary">
                 <FormattedMessage id="metadata.form.edit" defaultMessage="Edit" description="This is a label on a button that the user presses in order to edit the items in the attached form." />
               </Button>
           }

--- a/src/app/components/team/TeamTaskCard.js
+++ b/src/app/components/team/TeamTaskCard.js
@@ -26,9 +26,8 @@ const TeamTaskCard = ({
   onDelete,
   showInBrowserExtension,
   setShowInBrowserExtension,
-  // TODO: Release on next sprint
-  // required,
-  // setRequired,
+  required,
+  setRequired,
 }) => {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [expanded, setExpanded] = React.useState(true);
@@ -74,19 +73,17 @@ const TeamTaskCard = ({
           />
         </Button>
         <Box display="flex">
-          { /* TODO: Release on next sprint
-            <Box mr={4}>
-              <Switch
-                onClick={() => setRequired(!required)}
-                checked={required}
-              />
-              <FormattedMessage
-                id="teamTaskCard.required"
-                defaultMessage="Required"
-                description="Toggle switch to make field required"
-              />
-            </Box>
-          */ }
+          <Box mr={4}>
+            <Switch
+              onClick={() => setRequired(!required)}
+              checked={required}
+            />
+            <FormattedMessage
+              id="teamTaskCard.required"
+              defaultMessage="Required"
+              description="Toggle switch to make field required"
+            />
+          </Box>
           <span>
             <Switch
               onClick={() => setShowInBrowserExtension(!showInBrowserExtension)}
@@ -145,9 +142,8 @@ TeamTaskCard.propTypes = {
   onDelete: PropTypes.func.isRequired,
   showInBrowserExtension: PropTypes.bool.isRequired,
   setShowInBrowserExtension: PropTypes.func.isRequired,
-  // TODO: Release on next sprint
-  // required: PropTypes.bool.isRequired,
-  // setRequired: PropTypes.func.isRequired,
+  required: PropTypes.bool.isRequired,
+  setRequired: PropTypes.func.isRequired,
   about: PropTypes.object.isRequired,
 };
 

--- a/test/spec/metadata_spec.rb
+++ b/test/spec/metadata_spec.rb
@@ -45,20 +45,24 @@ shared_examples 'metadata' do
     wait_for_selector('.media-tab__metadata').click
     wait_for_selector('.task__response-inputs')
     # answer the metadata
+    wait_for_selector('.form-edit').click
     wait_for_selector('#metadata-input').send_keys('answer')
-    wait_for_selector('.metadata-save').click
+    wait_for_selector('.form-save').click
+    wait_for_selector_none('.form-cancel', 2)
+    expect(@driver.page_source.include?('answer - edited')).to be(false)
 
     # edit response
-    expect(@driver.page_source.include?('answer - edited')).to be(false)
-    wait_for_selector('.metadata-edit').click
+    wait_for_selector('.form-edit').click
     wait_for_selector('#metadata-input').send_keys(' - edited')
-    wait_for_selector('.metadata-save').click
-    wait_for_selector_none('.metdata-cancel')
+    wait_for_selector('.form-save').click
+    wait_for_selector_none('.form-cancel', 2)
     expect(@driver.page_source.include?('answer - edited')).to be(true)
 
     # delete response
-    wait_for_selector('.metadata-delete').click
-    wait_for_selector_none('.metadata-delete')
+    wait_for_selector('.form-edit').click
+    wait_for_selector('.clear-button').click
+    wait_for_selector('.form-save').click
+    wait_for_selector_none('.form-cancel', 2)
     expect(@driver.page_source.include?('answer - edited')).to be(false)
   end
 end

--- a/test/spec/project_spec.rb
+++ b/test/spec/project_spec.rb
@@ -168,10 +168,11 @@ shared_examples 'project' do
     expect(@driver.page_source.include?('answer')).to be(false)
     wait_for_selector('.media__heading').click
     # answer the metadata
+    wait_for_selector('.form-edit').click
     wait_for_selector('.media-tab__metadata').click
     wait_for_selector('#metadata-input').send_keys('answer')
-    wait_for_selector('.metadata-save').click
-    wait_for_selector_none('#metadata-input')
+    wait_for_selector('.form-save').click
+    wait_for_selector_none('.form-cancel', 2)
     @driver.navigate.to "#{@config['self_url']}/#{get_team}/settings"
     wait_for_selector('.team')
     wait_for_selector('.team-settings__lists-tab').click


### PR DESCRIPTION
Overall this is a clientside implementation of "save all" which gets around the fact that we don't have that functionality on the graphql DB. We now hide the save/edit/delete buttons on the metadata fields, but they still exist in the DOM. We iterate over each hidden save button and check html data-elements in order to see whether a field is empty and whether it is required. If a field is required and empty, we don't allow the saves to happen. Otherwise, we simulate a click on each save button, thus saving all the fields.

- add a function that evaluates all metadata fields in the form and finds the most recently updated time and user who updated it
- use html data-elements to indicate on each Save button whether the fields are required or empty
- store a local copy of the overall metadata fields and mutate that for local display, applying those changes to the DB when we save (conditional display of fields uses this local copy)