### PR TITLE
CHECK-1069: Fix annotation fields margin right

### DIFF
--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -15,9 +15,7 @@ import { withSetFlashMessage } from '../FlashMessage';
 
 const StyledMetadataContainer = styled.div`
   .tasks__list > li {
-    margin-bottom: ${units(2)};
-    margin-left: ${units(2)};
-    margin-top: ${units(2)};
+    margin: ${units(2)};
   }
 `;
 


### PR DESCRIPTION
It seems that this was intentionally without margin on the right side. 
 @dariusk can you please review and offer some insight as I'm not sure I'd be breaking the layout somewhere else?