### PR TITLE
Feature/1034 item page

### DIFF
--- a/localization/react-intl/src/app/components/project/ProjectHeader.json
+++ b/localization/react-intl/src/app/components/project/ProjectHeader.json
@@ -16,6 +16,10 @@
     "defaultMessage": "Imported reports"
   },
   {
+    "id": "projectHeader.trends",
+    "defaultMessage": "Trends"
+  },
+  {
     "id": "projectHeader.allItems",
     "defaultMessage": "All items"
   }

--- a/localization/react-intl/src/app/components/trends/TrendsItem.json
+++ b/localization/react-intl/src/app/components/trends/TrendsItem.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "trendItem.lastSubmitted",
+    "description": "A label indicating that the following date is when an item was last submitted to the tip line",
+    "defaultMessage": "Last submitted"
+  },
+  {
+    "id": "trendItem.request",
+    "description": "A label that appears alongside a number showing the number of requests an item has received. This is the singular noun for use when it is a single request, appearing in English as '1 request'.",
+    "defaultMessage": "Request"
+  },
+  {
+    "id": "trendItem.requests",
+    "description": "A label that appears alongside a number showing the number of requests an item has received. This is the plural noun for use when there are zero or more than one requests, appearing in English as '10 requests' or '0 requests'.",
+    "defaultMessage": "Requests"
+  },
+  {
+    "id": "trendItem.main",
+    "description": "This is a header that indicates there is a primary claim the user is viewing, to distinguish it from secondary, similar claims",
+    "defaultMessage": "Main claim"
+  },
+  {
+    "id": "trendItem.media",
+    "defaultMessage": "Media"
+  },
+  {
+    "id": "trendItem.sortBy",
+    "defaultMessage": "Sort by"
+  }
+]

--- a/src/app/components/Header.js
+++ b/src/app/components/Header.js
@@ -40,8 +40,9 @@ function HeaderComponent(props) {
   const tasksPage = /^\/[^/]+\/project\/[0-9]+\/media\/[0-9]+\/tasks$/.test(path);
   const mediaPage = /^\/[^/]+\/((project|list)\/[0-9]+\/)?media\/[0-9]+(\/suggested-matches|\/similar-media)?$/.test(path);
   const sourcePage = /^\/[^/]+\/project\/[0-9]+\/source\/[0-9]+$/.test(path);
+  const trendsPage = /\/trends\/media\/[0-9]+/.test(path);
 
-  if (tasksPage || (!mediaPage && !sourcePage)) {
+  if (tasksPage || (!mediaPage && !sourcePage && !trendsPage)) {
     return null;
   }
 

--- a/src/app/components/Home.js
+++ b/src/app/components/Home.js
@@ -114,6 +114,9 @@ class HomeComponent extends Component {
     if (!(children && children.props.route)) {
       return null;
     }
+    if (/\/trends\/media\/:mediaId/.test(children.props.route.path)) {
+      return 'trend-item';
+    }
     if (/\/media\/:mediaId/.test(children.props.route.path)) {
       return 'media';
     }

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -19,6 +19,7 @@ import TiplineInbox from './team/TiplineInbox';
 import ImportedReports from './team/ImportedReports';
 import Trash from './team/Trash';
 import Trends from './trends/Trends';
+import TrendsItem from './trends/TrendsItem';
 import Unconfirmed from './team/Unconfirmed';
 import MediaPage from './media/MediaPage';
 import ReportDesigner from './media/ReportDesigner';
@@ -97,6 +98,7 @@ class Root extends Component {
                 <Route path=":team/tipline-inbox(/:query)" component={TiplineInbox} />
                 <Route path=":team/imported-reports(/:query)" component={ImportedReports} />
                 <Route path=":team/trends(/:query)" component={Trends} />
+                <Route path=":team/trends/media/:mediaId" component={TrendsItem} />
                 <Route path=":team/trash(/:query)" component={Trash} />
                 <Route path=":team/unconfirmed(/:query)" component={Unconfirmed} />
                 <Route path=":team/settings(/:tab)" action="settings" component={Team} />

--- a/src/app/components/media/MediaExpanded.js
+++ b/src/app/components/media/MediaExpanded.js
@@ -108,7 +108,7 @@ class MediaExpandedComponent extends Component {
   render() {
     const { classes } = this.props;
     const {
-      media, playing, start, end, gaps, seekTo, scrubTo, setPlayerState, onPlayerReady,
+      media, playing, start, end, gaps, seekTo, scrubTo, setPlayerState, onPlayerReady, isTrends,
     } = this.props;
 
     const {
@@ -213,7 +213,7 @@ class MediaExpandedComponent extends Component {
           }
         />
         <CardContent style={{ padding: `0 ${units(2)}` }}>
-          <MediaExpandedSecondRow projectMedia={media} />
+          <MediaExpandedSecondRow projectMedia={media} isTrends={isTrends} />
           { isImage ?
             <Box mb={2}>
               <TypographyBlack54 variant="body2" color={black54}>
@@ -248,14 +248,18 @@ class MediaExpandedComponent extends Component {
           <MediaExpandedMetadata projectMedia={media} />
           {embedCard}
         </CardContent>
-        <CardActions>
-          <MediaExpandedActions
-            onTimelineCommentOpen={onTimelineCommentOpen}
-            onVideoAnnoToggle={onVideoAnnoToggle}
-            showVideoAnnotation={showVideoAnnotation}
-            projectMedia={media}
-          />
-        </CardActions>
+        {
+          isTrends ? null : (
+            <CardActions>
+              <MediaExpandedActions
+                onTimelineCommentOpen={onTimelineCommentOpen}
+                onVideoAnnoToggle={onVideoAnnoToggle}
+                showVideoAnnotation={showVideoAnnotation}
+                projectMedia={media}
+              />
+            </CardActions>
+          )
+        }
       </React.Fragment>
     );
   }

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -17,7 +17,7 @@ class ProjectHeaderComponent extends React.PureComponent {
       saved_search,
       location,
     } = this.props;
-    const { listUrl } = getListUrlQueryAndIndex(params, location.query);
+    const { listUrl } = getListUrlQueryAndIndex(params, location.query, location.pathname);
 
     let pageTitle;
     if (/\/trash(\/|$)/.test(listUrl)) {
@@ -28,6 +28,8 @@ class ProjectHeaderComponent extends React.PureComponent {
       pageTitle = <FormattedMessage id="projectHeader.tiplineInbox" defaultMessage="Tipline inbox" />;
     } else if (/\/imported-reports(\/|$)/.test(listUrl)) {
       pageTitle = <FormattedMessage id="projectHeader.importedReports" defaultMessage="Imported reports" />;
+    } else if (/\/trends(\/|$)/.test(listUrl)) {
+      pageTitle = <FormattedMessage id="projectHeader.trends" defaultMessage="Trends" />;
     } else if (project) {
       pageTitle = project.title;
     } else if (saved_search) {

--- a/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
+++ b/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
@@ -33,11 +33,13 @@ export default function SearchResultsTableRow({
   const { dbid, is_read: isRead } = projectMedia;
   const classes = useStyles({ dbid, isRead });
 
+  const projectMediaOrTrendsUrl = resultType === 'trends' ? `/${projectMedia.team?.slug}/trends/media/${projectMedia.dbid}` : projectMediaUrl;
+
   const handleClick = React.useCallback(() => {
-    if (!projectMediaUrl) {
+    if (!projectMediaOrTrendsUrl) {
       return;
     }
-    browserHistory.push(projectMediaUrl);
+    browserHistory.push(projectMediaOrTrendsUrl);
   }, [projectMediaUrl]);
 
   const handleChangeChecked = React.useCallback((ev) => {
@@ -74,7 +76,7 @@ export default function SearchResultsTableRow({
           field={field}
           type={type}
           projectMedia={projectMedia}
-          projectMediaUrl={projectMediaUrl}
+          projectMediaUrl={projectMediaOrTrendsUrl}
         />
       ))}
     </TableRow>

--- a/src/app/components/trends/TrendsItem.js
+++ b/src/app/components/trends/TrendsItem.js
@@ -119,8 +119,7 @@ const useStyles = makeStyles(theme => ({
 
 const TrendsItemComponent = ({ project_media }) => {
   const classes = useStyles();
-  // eslint-disable-next-line
-  const similarItems = project_media.confirmed_similar_relationships?.edges?.map(item => item.node?.target);
+  const similarItems = project_media.similar_items?.edges.map(item => item.node);
   const mainItem = project_media;
   // value of -1 means the main claim, 0+ are indexes to similar items
   const [selectedItemIndex, setSelectedItemIndex] = React.useState(project_media.id);
@@ -279,54 +278,48 @@ const TrendsItem = props => (
             file_path
             thumbnail_path
           }
-          confirmed_similar_relationships(first: 10000) {
+          similar_items(first: 1000) {
             edges {
               node {
                 id
-                target {
+                title
+                type
+                description
+                requests_count
+                updated_at
+                last_seen
+                created_at
+                picture
+                language_code
+                pusher_channel
+                dbid
+                project_id
+                domain
+                team {
                   id
-                  title
-                  type
-                  description
-                  requests_count
-                  updated_at
-                  last_seen
-                  created_at
-                  picture
-                  language_code
-                  pusher_channel
                   dbid
-                  project_id
-                  domain
-                  team {
-                    id
-                    dbid
-                    slug
-                    name
-                    get_language
-                    get_report
-                    get_tasks_enabled
-                    team_bots(first: 10000) {
-                      edges {
-                        node {
-                          login
-                        }
+                  slug
+                  name
+                  get_language
+                  get_report
+                  get_tasks_enabled
+                  team_bots(first: 10000) {
+                    edges {
+                      node {
+                        login
                       }
                     }
                   }
-                  media {
-                    url
-                    quote
-                    embed_path
-                    metadata
-                    type
-                    picture
-                    file_path
-                    thumbnail_path
-                  }
                 }
-                source {
-                  id
+                media {
+                  url
+                  quote
+                  embed_path
+                  metadata
+                  type
+                  picture
+                  file_path
+                  thumbnail_path
                 }
               }
             }

--- a/src/app/components/trends/TrendsItem.js
+++ b/src/app/components/trends/TrendsItem.js
@@ -1,0 +1,351 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { QueryRenderer, graphql } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  Card,
+  Grid,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  Typography,
+} from '@material-ui/core';
+import MediaTypeDisplayName from '../media/MediaTypeDisplayName';
+import MediaExpanded from '../media/MediaExpanded';
+import { parseStringUnixTimestamp } from '../../helpers';
+import TimeBefore from '../TimeBefore';
+import {
+  backgroundMain,
+  brandSecondary,
+  opaqueBlack54,
+  Column,
+} from '../../styles/js/shared';
+import {
+  StyledTwoColumns,
+  StyledBigColumn,
+} from '../../styles/js/HeaderCard';
+
+const defaultImage = '/images/image_placeholder.svg';
+const useStyles = makeStyles(theme => ({
+  main: {
+    backgroundColor: backgroundMain,
+    padding: theme.spacing(2),
+  },
+  image: {
+    height: 80,
+    width: 80,
+    objectFit: 'cover',
+    border: `1px solid ${brandSecondary}`,
+    float: 'left',
+    marginRight: theme.spacing(1),
+  },
+  cardMain: {
+    boxShadow: 'none',
+    border: `1px solid ${brandSecondary}`,
+    borderRadius: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    padding: theme.spacing(2),
+    cursor: 'pointer',
+  },
+  cardDetail: {
+    boxShadow: 'none',
+    border: `1px solid ${brandSecondary}`,
+    borderRadius: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    padding: theme.spacing(2),
+  },
+  cardTitle: {
+    fontSize: '1.0em',
+    fontWeight: 900,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  columnTitle: {
+    fontSize: '1.0em',
+    fontWeight: 900,
+    marginBottom: theme.spacing(1),
+    padding: theme.spacing(1),
+  },
+  sortBy: {
+    float: 'right',
+    height: '50px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  selectSort: {
+    marginLeft: theme.spacing(1),
+    fontSize: '1.0em',
+    minWidth: '150px',
+  },
+  cardSubhead: {
+    color: opaqueBlack54,
+    fontSize: '0.85em',
+    fontWeight: 500,
+  },
+  cardDescription: {
+    fontSize: '14px',
+    lineHeight: '1.3em',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    marginTop: theme.spacing(0.5),
+  },
+  selected: {
+    backgroundColor: brandSecondary,
+    border: '1px solid #ced3e2',
+  },
+  detailTitle: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    textDecoration: 'none',
+    lineClamp: '2',
+    display: '-webkit-box',
+    boxOrient: 'vertical',
+  },
+  detailDescription: {
+    fontSize: '14px',
+    lineHeight: '1.3em',
+  },
+  detailSubhead: {
+    fontSize: '1.0em',
+    fontWeight: 900,
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+const TrendsItemComponent = ({ project_media }) => {
+  const classes = useStyles();
+  // eslint-disable-next-line
+  const similarItems = project_media.confirmed_similar_relationships?.edges?.map(item => item.node?.target);
+  const mainItem = project_media;
+  // value of -1 means the main claim, 0+ are indexes to similar items
+  const [selectedItemIndex, setSelectedItemIndex] = React.useState(project_media.id);
+  const [sortBy, setSortBy] = React.useState('mostRequests');
+
+  const sortOptions = {
+    mostRequests: (a, b) => (b.requests_count - a.requests_count),
+    leastRequests: (a, b) => (a.requests_count - b.requests_count),
+    oldest: (a, b) => (b.last_seen - a.last_seen),
+    newest: (a, b) => (a.last_seen - b.last_seen),
+  };
+
+  const handleClick = (e) => {
+    setSelectedItemIndex(e.currentTarget.dataset.id);
+  };
+
+  const handleChange = (e) => {
+    setSortBy(e.target.value);
+  };
+
+  const selectedItem = selectedItemIndex === project_media.id ? project_media : similarItems.find(item => item.id === selectedItemIndex);
+
+  const ItemCard = ({ item, index }) => {
+    const selectedItemClass = selectedItemIndex === index ? classes.selected : '';
+    return (
+      <Card
+        className={`${classes.cardMain} ${selectedItemClass}`}
+        data-id={index}
+        onClick={handleClick}
+      >
+        {
+          item.picture ?
+            <img
+              alt=""
+              className={classes.image}
+              onError={(e) => { e.target.onerror = null; e.target.src = defaultImage; }}
+              src={item.picture}
+            /> : null
+        }
+        <Typography className={classes.cardTitle}>
+          {item.title}
+        </Typography>
+        <Typography className={classes.cardSubhead}>
+          <MediaTypeDisplayName mediaType={item.type} /> - <FormattedMessage id="trendItem.lastSubmitted" defaultMessage="Last submitted" description="A label indicating that the following date is when an item was last submitted to the tip line" /> - <TimeBefore date={parseStringUnixTimestamp(item.last_seen)} /> - {item.requests_count} {item.requests_count === 1 ? <FormattedMessage id="trendItem.request" defaultMessage="Request" description="A label that appears alongside a number showing the number of requests an item has received. This is the singular noun for use when it is a single request, appearing in English as '1 request'." /> : <FormattedMessage id="trendItem.requests" defaultMessage="Requests" description="A label that appears alongside a number showing the number of requests an item has received. This is the plural noun for use when there are zero or more than one requests, appearing in English as '10 requests' or '0 requests'." />}
+        </Typography>
+        <Typography className={classes.cardDescription} variant="body1">
+          {item.description}
+        </Typography>
+      </Card>
+    );
+  };
+
+  return (
+    <StyledTwoColumns className={classes.main}>
+      <StyledBigColumn className="media__column">
+        <Column>
+          <Typography className={classes.columnTitle}>
+            <FormattedMessage id="trendItem.main" defaultMessage="Main claim" description="This is a header that indicates there is a primary claim the user is viewing, to distinguish it from secondary, similar claims" />
+          </Typography>
+          <ItemCard item={mainItem} index={mainItem.id} />
+          <Grid container alignItems="center">
+            <Grid item xs={6}>
+              <Typography className={classes.columnTitle}>
+                <FormattedMessage id="trendItem.media" defaultMessage="Media" />
+              </Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <Typography className={`${classes.columnTitle} ${classes.sortBy}`} component="div">
+                <FormattedMessage id="trendItem.sortBy" defaultMessage="Sort by" />
+                <Select
+                  value={sortBy}
+                  onChange={handleChange}
+                  input={<OutlinedInput name="sort-select" margin="dense" />}
+                  className={classes.selectSort}
+                >
+                  <MenuItem value="mostRequests">Most requests</MenuItem>
+                  <MenuItem value="leastRequests">Least requests</MenuItem>
+                  <MenuItem value="oldest">Newest</MenuItem>
+                  <MenuItem value="newest">Oldest</MenuItem>
+                </Select>
+              </Typography>
+            </Grid>
+          </Grid>
+          {
+            similarItems
+              .sort(sortOptions[sortBy])
+              .map(item => <ItemCard item={item} index={item.id} />)
+          }
+        </Column>
+      </StyledBigColumn>
+      <StyledBigColumn className="media__column">
+        <Column>
+          <Card className={classes.cardDetail}>
+            <MediaExpanded
+              media={selectedItem}
+              mediaUrl="foo"
+              isTrends
+            />
+          </Card>
+        </Column>
+      </StyledBigColumn>
+    </StyledTwoColumns>
+  );
+};
+
+const renderQuery = ({ error, props }) => {
+  if (!error && props) {
+    return <TrendsItemComponent {...props} />;
+  }
+  return null;
+};
+
+const TrendsItem = props => (
+  <QueryRenderer
+    environment={Relay.Store}
+    query={graphql`
+      query TrendsItemQuery($ids_0: String!) {
+        project_media(ids: $ids_0) {
+          id
+          title
+          type
+          description
+          requests_count
+          updated_at
+          last_seen
+          created_at
+          picture
+          language_code
+          pusher_channel
+          dbid
+          project_id
+          domain
+          team {
+            id
+            dbid
+            slug
+            name
+            get_language
+            get_report
+            get_tasks_enabled
+            team_bots(first: 10000) {
+              edges {
+                node {
+                  login
+                }
+              }
+            }
+          }
+          media {
+            url
+            quote
+            embed_path
+            metadata
+            type
+            picture
+            file_path
+            thumbnail_path
+          }
+          confirmed_similar_relationships(first: 10000) {
+            edges {
+              node {
+                id
+                target {
+                  id
+                  title
+                  type
+                  description
+                  requests_count
+                  updated_at
+                  last_seen
+                  created_at
+                  picture
+                  language_code
+                  pusher_channel
+                  dbid
+                  project_id
+                  domain
+                  team {
+                    id
+                    dbid
+                    slug
+                    name
+                    get_language
+                    get_report
+                    get_tasks_enabled
+                    team_bots(first: 10000) {
+                      edges {
+                        node {
+                          login
+                        }
+                      }
+                    }
+                  }
+                  media {
+                    url
+                    quote
+                    embed_path
+                    metadata
+                    type
+                    picture
+                    file_path
+                    thumbnail_path
+                  }
+                }
+                source {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    `}
+    variables={{
+      ids_0: props.routeParams.mediaId,
+    }}
+    render={renderQuery}
+  />
+);
+
+TrendsItem.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    mediaId: PropTypes.string,
+  }).isRequired,
+};
+
+export default TrendsItem;

--- a/src/app/urlHelpers.js
+++ b/src/app/urlHelpers.js
@@ -29,13 +29,15 @@ const pageSize = 20;
  * `listQuery` entirely. (Callers may also omit `listPath` if it can be inferred
  * from the `routeParams`.)
  */
-function getListUrlQueryAndIndex(routeParams, locationQuery) {
+function getListUrlQueryAndIndex(routeParams, locationQuery, locationPathname) {
   let { listPath } = locationQuery;
   if (!listPath) {
     if (routeParams.projectId) {
       listPath = `/${routeParams.team}/project/${routeParams.projectId}`;
     } else if (routeParams.listId) {
       listPath = `/${routeParams.team}/list/${routeParams.listId}`;
+    } else if (/\/trends\/media\/[0-9]+/.test(locationPathname)) {
+      listPath = `/${routeParams.team}/trends`;
     } else {
       listPath = `/${routeParams.team}/all-items`;
     }


### PR DESCRIPTION
 - new route for `:team/trends/:mediaId` to look at trend item detail
 - `MediaExpanded` component now accepts an `isTrends` switch in order to not display the action bar for transcription etc
 - `urlHelpers` has been updated to account for the new potential back button behavior (moving from a trend detail back to the trends index)
 - using new `similar_items` gql field