### PR TITLE
CHECK-1089 Sticky annotation header

### DIFF
--- a/src/app/components/media/MediaExpanded.js
+++ b/src/app/components/media/MediaExpanded.js
@@ -14,6 +14,7 @@ import MediaExpandedArchives from './MediaExpandedArchives';
 import MediaExpandedMetadata from './MediaExpandedMetadata';
 import MediaExpandedSecondRow from './MediaExpandedSecondRow';
 import MediaExpandedUrl from './MediaExpandedUrl';
+import MediaLanguageChip from './MediaLanguageChip';
 import MoreLess from '../layout/MoreLess';
 import ParsedText from '../ParsedText';
 import QuoteMediaCard from './QuoteMediaCard';
@@ -245,6 +246,7 @@ class MediaExpandedComponent extends Component {
               </Typography>
             </MoreLess>
           </Box>
+          <MediaLanguageChip projectMedia={media} />
           <MediaExpandedUrl url={media.media.url} />
           <MediaExpandedArchives projectMedia={media} />
           <MediaExpandedMetadata projectMedia={media} />

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -158,10 +158,6 @@ class MediaTasksComponent extends Component {
 
     return (
       <StyledAnnotationRow>
-        { fieldset === 'metadata' ?
-          <div className="annotation-header-row metadata-row">
-            <MediaLanguageChip projectMedia={media} />
-          </div> : null }
         { fieldset === 'tasks' && !isBrowserExtension ?
           <div className="annotation-header-row task-row">
             { itemTasks.edges.length ?

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { browserHistory } from 'react-router';
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
-import Divider from '@material-ui/core/Divider';
+import {
+  Box,
+  Typography,
+  Button,
+  Divider,
+} from '@material-ui/core';
 import styled from 'styled-components';
 import moment from 'moment';
 import Task from './Task';
@@ -21,10 +23,18 @@ const StyledMetadataContainer = styled.div`
 
 const StyledFormControls = styled.div`
   padding-left: ${units(2)};
-  padding-top: ${units(2)};
   button {
     margin-right: ${units(1)};
   }
+  display: flex;
+  align-items: center;
+  height: 63px;
+  position: sticky;
+  top: 0px;
+  z-index: 10000;
+  background-color: white;
+  box-shadow: 0 0 8px 4px rgba(170, 170, 170, 0.25);
+  clip-path: polygon(0% 0%, 100% 0%, 100.94% 107.30%, 0% 120%);
 `;
 
 const StyledAnnotatorInformation = styled.span`
@@ -197,7 +207,15 @@ const Tasks = ({
     setIsEditing(false);
   }
 
+  // returns -1 when no annotations yet exist, null when in a loading state, and an object otherwise
   function getLatestEditInfo() {
+    const noAnnotationsExist = tasks
+      .filter(task => (!isBrowserExtension || task.node.show_in_browser_extension))
+      .filter(showMetadataItem)
+      .every(task => task.node.first_response_value === null);
+    if (noAnnotationsExist) {
+      return -1;
+    }
     const latestDate = Math.max(...tasks
       .filter(task => (!isBrowserExtension || task.node.show_in_browser_extension))
       .filter(showMetadataItem)
@@ -234,6 +252,26 @@ const Tasks = ({
 
   const latestEditInfo = getLatestEditInfo();
 
+  const LastEditedBy = () => {
+    if (latestEditInfo === -1) {
+      return null;
+    } else if (latestEditInfo === null) {
+      return <span>...</span>;
+    }
+    return (
+      <StyledAnnotatorInformation>
+        <Typography variant="body1">
+          Saved {moment(latestEditInfo.latestDate).fromNow()} by{' '}
+          <a
+            href={`/check/user/${latestEditInfo.latestAuthorDbid}`}
+          >
+            {latestEditInfo.latestAuthorName}
+          </a>
+        </Typography>
+      </StyledAnnotatorInformation>
+    );
+  };
+
   if (isMetadata) {
     output = (
       <StyledMetadataContainer>
@@ -253,22 +291,7 @@ const Tasks = ({
                 <FormattedMessage id="metadata.form.edit" defaultMessage="Edit" description="This is a label on a button that the user presses in order to edit the items in the attached form." />
               </Button>
           }
-          <p>
-            {
-              latestEditInfo ? (
-                <StyledAnnotatorInformation>
-                  <Typography variant="body1">
-                    Saved {moment(latestEditInfo.latestDate).fromNow()} by{' '}
-                    <a
-                      href={`/check/user/${latestEditInfo.latestAuthorDbid}`}
-                    >
-                      {latestEditInfo.latestAuthorName}
-                    </a>
-                  </Typography>
-                </StyledAnnotatorInformation>
-              ) : '...'
-            }
-          </p>
+          <LastEditedBy />
         </StyledFormControls>
         <Divider />
         <ul className="tasks__list">


### PR DESCRIPTION
- Media language chip has been moved from `Tasks` to `MediaExpanded`
- Attribution only shows `...` on loading data (not using a spinner because it would be unusual in such a small area), on clean load with no attributions it's blank
- Attribution appears to the right of the buttons in the annotation header instead of below
- Drop shadow appears below the sticky "floating" header. Note that I did not implement something to change the CSS (removing the shadow) when the scroll is at the top -- this would add a new listener/observer to the page (specifically an `IntersectionObserver`) and I'd rather have as smooth scrolling as possible here.