### PR TITLE
CHECK-1115: annotations being sent without id field

### DIFF
--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -323,7 +323,7 @@ class Task extends Component {
     this.props.setLocalResponses([...mutatedLocalResponses]);
   };
 
-  handleUpdateResponse = (edited_response, file) => {
+  handleUpdateResponse = (edited_response, file, responseObj) => {
     const { media, task } = this.props;
     this.setState({ isSaving: true });
 
@@ -349,7 +349,8 @@ class Task extends Component {
         parent_type: 'task',
         file,
         dynamic: {
-          id: this.state.editingResponse.id,
+          // in some legacy data cases we can lack an 'editingResponse' id, but in those cases there's always a responseObj id
+          id: this.state.editingResponse.id || responseObj.id,
           fields,
         },
       }),
@@ -629,16 +630,23 @@ class Task extends Component {
               } else {
                 tempTextValue = this.state.textValue;
               }
+              // in the case of multiple/single choice we need to set the textTempValue of an empty annotation to null rather than empty string, so it matches the state of first_response_value
+              if (task.type === 'multiple_choice' || task.type === 'single_choice') {
+                if (tempTextValue === '') {
+                  tempTextValue = null;
+                }
+              }
               // if there's a blank submission, and an existing submission exists, treat as a delete action
               if (!payload && !this.state.textValue && task.first_response_value) {
                 this.submitDeleteTaskResponse(task.first_response.id);
-              } else if (task?.first_response && tempTextValue === task?.first_response_value) {
+              } else if (tempTextValue === task?.first_response_value) {
                 // if the current submission hasn't changed at all, do nothing
-
               } else if (responseObj) {
+                // if there is a pre-existing response, we must be updating a record
                 this.handleUpdateResponse(
                   payload || this.state.textValue,
                   uploadables ? uploadables['file[]'] : null,
+                  responseObj,
                 );
               } else {
                 this.handleSubmitResponse(


### PR DESCRIPTION
This fixes two problems. One, there were cases where empty multiple choice or file upload fields were being submitted to relay as a mutation of a non-existent existing record. This was due to an error in the logic flow for determining whether something is a "create" or an "update" or an "ignore". That logic has been fixed. Two, this provides a backup for legacy data where an item was updated without an original item existing -- we were missing an `id` field needed for the graphql update to work, so now if that field doesn't exist where we expect it, we look for it in the place where it must be, in the legacy data.

Basically there is a logic path that allowed single and multiple choice annotation items that are not filled out (which use an entirely different data structure in the DB with different default assumptions from “normal” items) to be submitted as “blank” items instead of simply ignored and not sent to the DB. This results in the DB being in a state where it’s missing certain data that the code assumes will be there.

This PR fixes things so that:

1. this “blank” submission can’t happen anymore
2. if we run into any legacy data created by this bug, there is a safe alternative where we can find the correct id to send to the API and the POST succeeds