### PR TITLE
Fix CHECK-1383

### DIFF
--- a/src/app/components/media/MediaExpandedMetadata.js
+++ b/src/app/components/media/MediaExpandedMetadata.js
@@ -8,12 +8,12 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
 function shouldDisplayMetrics(metrics) {
-  return metrics &&
-    (metrics.share_count !== 0 ||
-     metrics.reaction_count !== 0 ||
-     metrics.comment_count !== 0 ||
-     metrics.comment_plugin_count !== 0
-    );
+  return metrics && (
+    metrics.share_count > 0 ||
+    metrics.reaction_count > 0 ||
+    metrics.comment_count > 0 ||
+    metrics.comment_plugin_count > 0
+  );
 }
 
 const useStyles = makeStyles(theme => ({
@@ -53,20 +53,20 @@ const MediaExpandedMetadata = ({ projectMedia }) => {
               <Typography variant="button" component="div">
                 <FormattedMessage id="mediaExpandedMetadata.shares" defaultMessage="FB Shares" />
               </Typography>
-              <div><FormattedNumber value={metrics.share_count} /></div>
+              <div><FormattedNumber value={metrics.share_count || 0} /></div>
             </div>
             <div className={classes.metric}>
               <Typography variant="button" component="div">
                 <FormattedMessage id="mediaExpandedMetadata.reactions" defaultMessage="FB Reactions" />
               </Typography>
-              <div><FormattedNumber value={metrics.reaction_count} /></div>
+              <div><FormattedNumber value={metrics.reaction_count || 0} /></div>
             </div>
             <div className={classes.metric}>
               <Typography variant="button" component="div">
                 <FormattedMessage id="mediaExpandedMetadata.comments" defaultMessage="FB Comments" />
               </Typography>
               <div>
-                <FormattedNumber value={metrics.comment_count + metrics.comment_plugin_count} />
+                <FormattedNumber value={metrics.comment_count + metrics.comment_plugin_count || 0} />
               </div>
             </div>
           </Box>


### PR DESCRIPTION
Our logic for whether to display metrics on an item page was wrong on two counts.

1) `metrics.share_count !== 0` would evaluate as `true` if `metrics.share_count` was set to `undefined`. Clearly we don't want that, we want it to evaluate as true if it's a number greater than 0.
2) `shouldDisplayMetrics` would evaluate as `true` as long as one statistic was greater than 0. If other stats were `undefined`, it would get passed into `FormattedNumber`, resolving to `NaN` in the display output.

This changes the logic so `undefined` is not considered a valid trigger to display metrics, and also if one slips through it is rendered as `0`.