### PR TITLE
CHECK-1199: Quick item add

### DIFF
--- a/localization/react-intl/src/app/components/UploadFile.json
+++ b/localization/react-intl/src/app/components/UploadFile.json
@@ -12,7 +12,7 @@
     "defaultMessage": "Drop an audio file here, or click to upload a file (max size: {audio_max_size}, allowed extensions: {audio_extensions})"
   },
   {
-    "id": "uploadFile.fileMessage",
+    "id": "uploadFile.imageVideoAudioMessage",
     "defaultMessage": "Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
   },
   {

--- a/localization/react-intl/src/app/components/media/CreateMedia.json
+++ b/localization/react-intl/src/app/components/media/CreateMedia.json
@@ -9,6 +9,6 @@
   },
   {
     "id": "createMedia.addNewItem",
-    "defaultMessage": "Add new item"
+    "defaultMessage": "Add item"
   }
 ]

--- a/localization/react-intl/src/app/components/media/CreateMediaInput.json
+++ b/localization/react-intl/src/app/components/media/CreateMediaInput.json
@@ -1,30 +1,36 @@
 [
   {
-    "id": "createMedia.quoteInput",
-    "defaultMessage": "Paste or type a text"
+    "id": "createMedia.mediaClaimDescription",
+    "defaultMessage": "Claim description"
+  },
+  {
+    "id": "createMedia.mediaClaimDescriptionSubtitle",
+    "defaultMessage": "A description of the claim that needs to be reviewed."
+  },
+  {
+    "id": "createMedia.mediaClaim",
+    "defaultMessage": "Type something"
+  },
+  {
+    "id": "createMedia.media.media",
+    "defaultMessage": "Media"
+  },
+  {
+    "id": "createMedia.mediaMediaSubtitle",
+    "defaultMessage": "The media that contains the claim."
   },
   {
     "id": "createMedia.mediaInput",
-    "defaultMessage": "Paste or type"
+    "defaultMessage": "Add a URL to a social media post or webpage, or a block of text."
   },
   {
-    "id": "createMedia.link",
-    "defaultMessage": "Link"
+    "id": "createMedia.or",
+    "description": "This will appear between two mutually exclusive inputs. If the user fills in one, then the other will be disabled.",
+    "defaultMessage": "or"
   },
   {
-    "id": "createMedia.quote",
-    "defaultMessage": "Text"
-  },
-  {
-    "id": "createMedia.image",
-    "defaultMessage": "Photo"
-  },
-  {
-    "id": "createMedia.video",
-    "defaultMessage": "Video"
-  },
-  {
-    "id": "createMedia.audio",
-    "defaultMessage": "Audio"
+    "id": "createMedia.mediaRemoveFile",
+    "description": "Label on a button that the user clicks in order to return a file upload box back to its 'empty' state.",
+    "defaultMessage": "Remove file"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3125,9 +3125,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         }
       }
     },
@@ -13831,11 +13831,11 @@
       }
     },
     "react-dropzone": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-3.13.4.tgz",
-      "integrity": "sha1-hNomgVxAM5aRxJtFRMLvehaRLMw=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.3.0.tgz",
+      "integrity": "sha512-ULfrLaTSsd8BDa9KVAGCueuq1AN3L14dtMsGGqtP0UwYyjG4Vhf158f/ITSHuSPYkZXbvfcIiOlZsH+e3QWm+Q==",
       "requires": {
-        "attr-accept": "^1.0.3",
+        "attr-accept": "^1.1.3",
         "prop-types": "^15.5.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "react-copy-to-clipboard": "^5.0.0",
     "react-document-title": "^2.0.2",
     "react-dom": "^17.0.2",
-    "react-dropzone": "^3.5.3",
+    "react-dropzone": "^4.3.0",
     "react-emoji-render": "^0.4.5",
     "react-favicon": "0.0.8",
     "react-ga": "^2.1.2",

--- a/src/app/components/Home.js
+++ b/src/app/components/Home.js
@@ -350,6 +350,7 @@ const HomeContainer = Relay.createContainer(ConnectedHomeComponent, {
           name
           slug
           get_data_report_url
+          verification_statuses
           team_bot_installation(bot_identifier: "smooch") {
             smooch_enabled_integrations
           }

--- a/src/app/components/UploadFile.js
+++ b/src/app/components/UploadFile.js
@@ -100,13 +100,16 @@ const UploadMessage = ({ type, about }) => {
       }}
     />
   );
-  case 'file': return (
+  case 'image+video+audio': return (
     <FormattedMessage
-      id="uploadFile.fileMessage"
+      id="uploadFile.imageVideoAudioMessage"
       defaultMessage="Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
       values={{
         file_max_size: about.file_max_size,
-        file_extensions: about.file_extensions.join(', '),
+        file_extensions: about.upload_extensions
+          .concat(about.video_extensions)
+          .concat(about.audio_extensions)
+          .join(', '),
       }}
     />
   );
@@ -153,6 +156,11 @@ class UploadFileComponent extends React.PureComponent {
     } else if (type === 'file') {
       extensions = about.file_extensions;
       maxSize = about.file_max_size;
+    } else if (type === 'image+video+audio') {
+      extensions = about.upload_extensions
+        .concat(about.video_extensions)
+        .concat(about.audio_extensions);
+      maxSize = about.upload_max_size;
     }
     const valid_extensions = extensions.map(ext => ext.toLowerCase());
     const extension = file.name.substr(file.name.lastIndexOf('.') + 1).toLowerCase();
@@ -202,7 +210,12 @@ class UploadFileComponent extends React.PureComponent {
   }
 
   render() {
-    const { about, value, type } = this.props;
+    const {
+      about,
+      value,
+      type,
+      disabled,
+    } = this.props;
     return (
       <StyledUploader>
         {this.maybePreview()}
@@ -210,6 +223,7 @@ class UploadFileComponent extends React.PureComponent {
           onDrop={this.onDrop}
           multiple={false}
           className={value ? 'with-file' : 'without-file'}
+          disabled={disabled}
         >
           <div>
             {value ? (
@@ -261,13 +275,15 @@ const UploadFile = childProps => (
 UploadFile.defaultProps = {
   value: null,
   noPreview: false,
+  disabled: false,
 };
 UploadFile.propTypes = {
   value: PropTypes.object, // or null
-  type: PropTypes.oneOf(['image', 'video', 'audio', 'file']).isRequired,
+  type: PropTypes.oneOf(['image', 'video', 'audio', 'image+video+audio']).isRequired,
   noPreview: PropTypes.bool,
   onChange: PropTypes.func.isRequired, // func(Image) => undefined
   onError: PropTypes.func.isRequired, // func(Image?, <FormattedMessage ...>) => undefined
+  disabled: PropTypes.bool,
 };
 
 export default UploadFile;

--- a/src/app/components/media/BlankMediaButton.js
+++ b/src/app/components/media/BlankMediaButton.js
@@ -103,6 +103,7 @@ const BlankMediaButton = ({
               defaultMessage="Add to imported report"
             /> : null
         }
+        team={team}
         open={showItemDialog}
         onDismiss={handleCloseItemDialog}
         onSubmit={handleSubmitNew}

--- a/src/app/components/media/CreateMedia.js
+++ b/src/app/components/media/CreateMedia.js
@@ -93,6 +93,7 @@ class CreateProjectMedia extends React.Component {
           open={this.state.dialogOpen}
           onDismiss={this.handleCloseDialog}
           onSubmit={this.handleSubmit}
+          team={this.props.team}
         />
       </React.Fragment>
     );

--- a/src/app/components/media/CreateMedia.js
+++ b/src/app/components/media/CreateMedia.js
@@ -6,6 +6,8 @@ import Relay from 'react-relay/classic';
 import Button from '@material-ui/core/Button';
 import CreateMediaDialog from './CreateMediaDialog';
 import CreateProjectMediaMutation from '../../relay/mutations/CreateProjectMediaMutation';
+import CreateStatusMutation from '../../relay/mutations/CreateStatusMutation';
+import UpdateStatusMutation from '../../relay/mutations/UpdateStatusMutation';
 import { stringHelper } from '../../customHelpers';
 import { getErrorObjects, getFilters } from '../../helpers';
 import CheckError from '../../CheckError';
@@ -38,7 +40,7 @@ class CreateProjectMedia extends React.Component {
     this.props.setFlashMessage(message, 'error');
   };
 
-  submitMedia(value) {
+  submitMedia(value, status) {
     let prefix = null;
     if (this.props.project) {
       prefix = `/${this.props.team.slug}/project/${this.props.project.dbid}/media/`;
@@ -51,9 +53,30 @@ class CreateProjectMedia extends React.Component {
     }
 
     const onSuccess = (response) => {
-      if (getFilters() !== '{}') {
-        const rid = response.createProjectMedia.project_media.dbid;
-        browserHistory.push(prefix + rid);
+      const media = response.createProjectMedia.project_media;
+      const status_id = media.last_status_obj ? media.last_status_obj.id : '';
+      const status_attr = {
+        parent_type: 'project_media',
+        annotated: media,
+        annotation: {
+          status,
+          annotated_type: 'ProjectMedia',
+          annotated_id: media.dbid,
+          status_id,
+        },
+      };
+      const statusSuccess = () => {
+        if (getFilters() !== '{}') {
+          const rid = response.createProjectMedia.project_media.dbid;
+          browserHistory.push(prefix + rid);
+        }
+      };
+
+      // Add or update status
+      if (status_id && status_id.length) {
+        Relay.Store.commitUpdate(new UpdateStatusMutation(status_attr), { onSuccess: statusSuccess, onFailure: this.fail });
+      } else {
+        Relay.Store.commitUpdate(new CreateStatusMutation(status_attr), { onSuccess: statusSuccess, onFailure: this.fail });
       }
     };
 
@@ -78,8 +101,8 @@ class CreateProjectMedia extends React.Component {
     this.setState({ dialogOpen: false });
   };
 
-  handleSubmit = (value) => {
-    this.submitMedia(value);
+  handleSubmit = (value, status) => {
+    this.submitMedia(value, status);
   };
 
   render() {
@@ -89,7 +112,7 @@ class CreateProjectMedia extends React.Component {
           <FormattedMessage id="createMedia.addItem" defaultMessage="Add Item" />
         </Button>
         <CreateMediaDialog
-          title={<FormattedMessage id="createMedia.addNewItem" defaultMessage="Add new item" />}
+          title={<FormattedMessage id="createMedia.addNewItem" defaultMessage="Add item" />}
           open={this.state.dialogOpen}
           onDismiss={this.handleCloseDialog}
           onSubmit={this.handleSubmit}

--- a/src/app/components/media/CreateMediaDialog.js
+++ b/src/app/components/media/CreateMediaDialog.js
@@ -6,17 +6,27 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import { makeStyles } from '@material-ui/core/styles';
 import CreateMediaInput from './CreateMediaInput';
 import globalStrings from '../../globalStrings';
+
+const useStyles = makeStyles({
+  title: {
+    '& h2': {
+      fontSize: '20px',
+    },
+  },
+});
 
 export default function CreateMediaDialog({
   open, title, onSubmit, onDismiss, team,
 }) {
+  const classes = useStyles();
   const formId = 'create-media-dialog-form';
 
   return (
     <Dialog open={open} fullWidth>
-      <DialogTitle>{title}</DialogTitle>
+      <DialogTitle className={classes.title}>{title}</DialogTitle>
       <DialogContent>
         <CreateMediaInput formId={formId} onSubmit={onSubmit} team={team} />
       </DialogContent>

--- a/src/app/components/media/CreateMediaDialog.js
+++ b/src/app/components/media/CreateMediaDialog.js
@@ -10,7 +10,7 @@ import CreateMediaInput from './CreateMediaInput';
 import globalStrings from '../../globalStrings';
 
 export default function CreateMediaDialog({
-  open, title, onSubmit, onDismiss,
+  open, title, onSubmit, onDismiss, team,
 }) {
   const formId = 'create-media-dialog-form';
 
@@ -18,7 +18,7 @@ export default function CreateMediaDialog({
     <Dialog open={open} fullWidth>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <CreateMediaInput formId={formId} onSubmit={onSubmit} />
+        <CreateMediaInput formId={formId} onSubmit={onSubmit} team={team} />
       </DialogContent>
       <DialogActions>
         <Button id="create-media-dialog__dismiss-button" onClick={onDismiss}>

--- a/src/app/components/media/CreateMediaInput.js
+++ b/src/app/components/media/CreateMediaInput.js
@@ -1,56 +1,72 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import InsertPhotoIcon from '@material-ui/icons/InsertPhoto';
-import MovieIcon from '@material-ui/icons/Movie';
-import VolumeUpIcon from '@material-ui/icons/VolumeUp';
-import FormatQuoteIcon from '@material-ui/icons/FormatQuote';
-import LinkIcon from '@material-ui/icons/Link';
-import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import ClearIcon from '@material-ui/icons/Clear';
 import urlRegex from 'url-regex';
+import styled from 'styled-components';
 import MediaStatusCommon from './MediaStatusCommon';
 import Message from '../Message';
 import UploadFile from '../UploadFile';
 import {
   Row,
   units,
-  caption,
-  black38,
-  black54,
-  black87,
-  mediaQuery,
 } from '../../styles/js/shared';
 
-const StyledTabLabelText = styled.span`
-  ${mediaQuery.handheld`
-    display: none;
-  `}
+const StyledHeader = styled.span`
+  & > h6 {
+    font-size: 15px;
+    margin-top: ${units(1)};
+  }
 `;
 
-const StyledTabLabel = styled.span`
-  display: flex;
-  align-items: center;
-  color: ${props => props.active ? black87 : black54} !important;
-  font: ${caption};
-  svg {
-    padding: 0 ${units(0.5)};
-    color: ${props => props.active ? black87 : black38} !important;
+const StyledSubtitle = styled.span`
+  & > h6 {
+    font-size: 11px;
+  }
+`;
+
+const StyledTextField = styled.span`
+  & > div > div {
+    font-size: 13px;
+    padding: ${units(1)};
+  }
+`;
+
+const StyledButton = styled.span`
+  & > .MuiButtonBase-root {
+    color: black;
+    margin-top: ${units(-2)};
+  }
+  & > .MuiButtonBase-root > span > span {
+    margin-top: -1px;
+    margin-right: 3px;
   }
 `;
 
 class CreateMediaInput extends React.Component {
   state = {
-    mode: 'link',
     textValue: '',
     mediaFile: null,
     mediaMessage: null,
-    status: 'undetermined',
-    // claimText: '',
+    status: this.props.team?.verification_statuses?.default,
+    claimText: '',
   };
 
   getMediaInputValue = () => {
-    const { mode, mediaFile, textValue } = this.state;
+    const { mediaFile, textValue, claimText } = this.state;
+    const inferMediaTypeFromMimeType = (mimeType) => {
+      if (mimeType.match(/^audio/)) {
+        return 'UploadedAudio';
+      } else if (mimeType.match(/^image/)) {
+        return 'UploadedImage';
+      } else if (mimeType.match(/^video/)) {
+        return 'UploadedVideo';
+      }
+      return null;
+    };
+
     let mediaType = '';
     let file = '';
     let inputValue = '';
@@ -58,24 +74,12 @@ class CreateMediaInput extends React.Component {
     let url = '';
     let quote = '';
 
-    if (['image', 'video', 'audio'].indexOf(mode) > -1) {
+    if (mediaFile) {
       file = mediaFile;
-      if (mode === 'image') {
-        mediaType = 'UploadedImage';
-      } else if (mode === 'video') {
-        mediaType = 'UploadedVideo';
-      } else if (mode === 'audio') {
-        mediaType = 'UploadedAudio';
-      }
       if (!file) {
         return null;
       }
-    } else if (mode === 'quote') {
-      quote = textValue.trim();
-      if (!quote) {
-        return null;
-      }
-      mediaType = 'Claim';
+      mediaType = inferMediaTypeFromMimeType(file.type);
     } else {
       inputValue = textValue.trim();
       urls = inputValue.match(urlRegex());
@@ -108,8 +112,8 @@ class CreateMediaInput extends React.Component {
         quote,
         file,
         title,
-        mode: this.state.mode,
         mediaType,
+        claimDescription: claimText,
       });
     }
 
@@ -117,11 +121,7 @@ class CreateMediaInput extends React.Component {
   };
 
   get currentErrorMessageOrNull() {
-    const { mode, mediaMessage } = this.state;
-    if (['video', 'audio', 'image'].indexOf(mode) > -1) {
-      return mediaMessage;
-    }
-    return this.props.message; // hopefully null
+    return this.state.mediaMessage || null;
   }
 
   setStatus = (context, store, media, newStatus) => {
@@ -129,7 +129,7 @@ class CreateMediaInput extends React.Component {
   };
 
   handleKeyPress = (ev) => {
-    if (ev.key === 'Enter' && !ev.shiftKey) {
+    if (ev.key === 'Enter' && ev.shiftKey) {
       ev.preventDefault();
       this.callOnSubmit();
     }
@@ -150,16 +150,15 @@ class CreateMediaInput extends React.Component {
     this.resetForm();
 
     if (this.props.onSubmit) {
-      this.props.onSubmit(value);
+      this.props.onSubmit(value, this.state.status);
     }
   }
 
-  handleTabChange = (e, mode) => {
-    this.setState({ mode });
-    if (this.props.onTabChange) {
-      this.props.onTabChange(mode);
-    }
-    this.resetForm();
+  clearFile = () => {
+    this.setState({
+      mediaFile: null,
+      mediaMessage: null,
+    });
   }
 
   handleFileChange = (file) => {
@@ -175,6 +174,11 @@ class CreateMediaInput extends React.Component {
     this.setState({ textValue });
   };
 
+  handleClaimChange = (ev) => {
+    const claimText = ev.target.value;
+    this.setState({ claimText });
+  };
+
   resetForm() {
     this.setState({
       textValue: '',
@@ -187,73 +191,109 @@ class CreateMediaInput extends React.Component {
     const defaultInputProps = {
       fullWidth: true,
       multiline: true,
-      onKeyPress: this.handleKeyPress,
-      onChange: this.handleChange,
       margin: 'normal',
+      variant: 'outlined',
+      rowsMax: 5,
     };
 
-    switch (this.state.mode) {
-    case 'image': return (
-      <UploadFile
-        key="createMedia.image.upload"
-        type="image"
-        onChange={this.handleFileChange}
-        onError={this.handleFileError}
-        value={this.state.mediaFile}
-      />
+    return (
+      <>
+        <StyledHeader>
+          <Typography variant="h6">
+            <FormattedMessage id="createMedia.mediaClaimDescription" defaultMessage="Claim description" />
+          </Typography>
+        </StyledHeader>
+        <StyledSubtitle>
+          <Typography variant="subtitle1">
+            <FormattedMessage id="createMedia.mediaClaimDescriptionSubtitle" defaultMessage="A description of the claim that needs to be reviewed." />
+          </Typography>
+        </StyledSubtitle>
+        <FormattedMessage id="createMedia.mediaClaim" defaultMessage="Type something">
+          {placeholder => (
+            <StyledTextField>
+              <TextField
+                key="createMedia.media.claim"
+                rows={3}
+                placeholder={placeholder}
+                name="claim"
+                id="create-media-claim"
+                value={this.state.claimText}
+                onChange={this.handleClaimChange}
+                autoFocus
+                {...defaultInputProps}
+              />
+            </StyledTextField>
+          )}
+        </FormattedMessage>
+        <StyledHeader>
+          <Typography variant="h6">
+            <FormattedMessage id="createMedia.media.media" defaultMessage="Media" />
+          </Typography>
+        </StyledHeader>
+        <StyledSubtitle>
+          <Typography variant="subtitle1">
+            <FormattedMessage id="createMedia.mediaMediaSubtitle" defaultMessage="The media that contains the claim." />
+          </Typography>
+        </StyledSubtitle>
+        {
+          this.state.mediaFile === null ? (
+            <FormattedMessage id="createMedia.mediaInput" defaultMessage="Add a URL to a social media post or webpage, or a block of text.">
+              {placeholder => (
+                <StyledTextField>
+                  <TextField
+                    key="createMedia.media.input"
+                    placeholder={placeholder}
+                    name="text"
+                    id="create-media-input"
+                    value={this.state.textValue}
+                    onChange={this.handleChange}
+                    onKeyPress={this.handleKeyPress}
+                    disabled={this.state.mediaFile}
+                    {...defaultInputProps}
+                  />
+                </StyledTextField>
+              )}
+            </FormattedMessage>
+          ) : null
+        }
+        {
+          (this.state.mediaFile === null && this.state.textValue.length === 0) ? (
+            <FormattedMessage id="createMedia.or" defaultMessage="or" description="This will appear between two mutually exclusive inputs. If the user fills in one, then the other will be disabled." />
+          ) : null
+        }
+        {
+          this.state.textValue.length === 0 ? (
+            <div>
+              <UploadFile
+                key="createMedia.image.upload"
+                type="image+video+audio"
+                onChange={this.handleFileChange}
+                onError={this.handleFileError}
+                value={this.state.mediaFile}
+                disabled={this.state.textValue.length > 0}
+                hidden={this.state.textValue.length > 0}
+              />
+              {
+                this.state.mediaFile ? (
+                  <StyledButton>
+                    <Button
+                      className="clear-button"
+                      size="small"
+                      color="secondary"
+                      variant="text"
+                      startIcon={<ClearIcon />}
+                      onClick={this.clearFile}
+                    >
+                      <FormattedMessage id="createMedia.mediaRemoveFile" defaultMessage="Remove file" description="Label on a button that the user clicks in order to return a file upload box back to its 'empty' state." />
+                    </Button>
+                  </StyledButton>
+                ) : null
+              }
+            </div>
+          ) : null
+        }
+      </>
     );
-    case 'video': return (
-      <UploadFile
-        key="createMedia.video.upload"
-        type="video"
-        onChange={this.handleFileChange}
-        onError={this.handleFileError}
-        value={this.state.mediaFile}
-        noPreview
-      />
-    );
-    case 'audio': return (
-      <UploadFile
-        key="createMedia.audio.upload"
-        type="audio"
-        onChange={this.handleFileChange}
-        onError={this.handleFileError}
-        value={this.state.mediaFile}
-        noPreview
-      />
-    );
-    case 'quote': return (
-      <FormattedMessage id="createMedia.quoteInput" defaultMessage="Paste or type a text">
-        {placeholder => (
-          <TextField
-            key="createMedia.quote.input"
-            placeholder={placeholder}
-            name="quote"
-            id="create-media-quote-input"
-            value={this.state.textValue}
-            autoFocus
-            {...defaultInputProps}
-          />
-        )}
-      </FormattedMessage>
-    );
-    case 'link':
-    default: return (
-      <FormattedMessage id="createMedia.mediaInput" defaultMessage="Paste or type">
-        {placeholder => (
-          <TextField
-            key="createMedia.media.input"
-            placeholder={placeholder}
-            name="url"
-            id="create-media-input"
-            value={this.state.textValue}
-            autoFocus
-            {...defaultInputProps}
-          />
-        )}
-      </FormattedMessage>
-    );
-    }
   }
 
   render() {
@@ -273,63 +313,6 @@ class CreateMediaInput extends React.Component {
           </div>
 
           <div style={{ marginTop: units(2) }}>
-            <Row>
-              <Button
-                id="create-media__link"
-                onClick={e => this.handleTabChange(e, 'link')}
-              >
-                <StyledTabLabel active={this.state.mode === 'link'}>
-                  <LinkIcon />
-                  <StyledTabLabelText>
-                    <FormattedMessage id="createMedia.link" defaultMessage="Link" />
-                  </StyledTabLabelText>
-                </StyledTabLabel>
-              </Button>
-              <Button
-                id="create-media__quote"
-                onClick={e => this.handleTabChange(e, 'quote')}
-              >
-                <StyledTabLabel active={this.state.mode === 'quote'}>
-                  <FormatQuoteIcon />
-                  <StyledTabLabelText>
-                    <FormattedMessage id="createMedia.quote" defaultMessage="Text" />
-                  </StyledTabLabelText>
-                </StyledTabLabel>
-              </Button>
-              <Button
-                id="create-media__image"
-                onClick={e => this.handleTabChange(e, 'image')}
-              >
-                <StyledTabLabel active={this.state.mode === 'image'}>
-                  <InsertPhotoIcon />
-                  <StyledTabLabelText>
-                    <FormattedMessage id="createMedia.image" defaultMessage="Photo" />
-                  </StyledTabLabelText>
-                </StyledTabLabel>
-              </Button>
-              <Button
-                id="create-media__video"
-                onClick={e => this.handleTabChange(e, 'video')}
-              >
-                <StyledTabLabel active={this.state.mode === 'video'}>
-                  <MovieIcon />
-                  <StyledTabLabelText>
-                    <FormattedMessage id="createMedia.video" defaultMessage="Video" />
-                  </StyledTabLabelText>
-                </StyledTabLabel>
-              </Button>
-              <Button
-                id="create-media__audio"
-                onClick={e => this.handleTabChange(e, 'audio')}
-              >
-                <StyledTabLabel active={this.state.mode === 'audio'}>
-                  <VolumeUpIcon />
-                  <StyledTabLabelText>
-                    <FormattedMessage id="createMedia.audio" defaultMessage="Audio" />
-                  </StyledTabLabelText>
-                </StyledTabLabel>
-              </Button>
-            </Row>
             <Row>
               <MediaStatusCommon
                 media={{

--- a/src/app/components/media/CreateMediaInput.js
+++ b/src/app/components/media/CreateMediaInput.js
@@ -9,6 +9,7 @@ import FormatQuoteIcon from '@material-ui/icons/FormatQuote';
 import LinkIcon from '@material-ui/icons/Link';
 import styled from 'styled-components';
 import urlRegex from 'url-regex';
+import MediaStatusCommon from './MediaStatusCommon';
 import Message from '../Message';
 import UploadFile from '../UploadFile';
 import {
@@ -44,6 +45,8 @@ class CreateMediaInput extends React.Component {
     textValue: '',
     mediaFile: null,
     mediaMessage: null,
+    status: 'undetermined',
+    // claimText: '',
   };
 
   getMediaInputValue = () => {
@@ -120,6 +123,10 @@ class CreateMediaInput extends React.Component {
     }
     return this.props.message; // hopefully null
   }
+
+  setStatus = (context, store, media, newStatus) => {
+    this.setState({ status: newStatus });
+  };
 
   handleKeyPress = (ev) => {
     if (ev.key === 'Enter' && !ev.shiftKey) {
@@ -322,6 +329,16 @@ class CreateMediaInput extends React.Component {
                   </StyledTabLabelText>
                 </StyledTabLabel>
               </Button>
+            </Row>
+            <Row>
+              <MediaStatusCommon
+                media={{
+                  team: this.props.team,
+                }}
+                setStatus={this.setStatus}
+                quickAdd
+                currentStatus={this.state.status}
+              />
             </Row>
           </div>
         </form>

--- a/src/app/components/media/CreateMediaInput.test.js
+++ b/src/app/components/media/CreateMediaInput.test.js
@@ -20,8 +20,8 @@ describe('<CreateMediaInput />', () => {
             color: '#518FFF',
           },
         },
-      ]
-    }
+      ],
+    },
   };
 
   it('should render input fields', () => {

--- a/src/app/components/media/CreateMediaInput.test.js
+++ b/src/app/components/media/CreateMediaInput.test.js
@@ -4,19 +4,30 @@ import CreateMediaInput from './CreateMediaInput';
 import UploadFile from '../UploadFile';
 
 describe('<CreateMediaInput />', () => {
-  it('should render all input tabs buttons', () => {
-    const wrapper = mountWithIntlProvider(<CreateMediaInput />);
-    expect(wrapper.find('#create-media__link').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('#create-media__quote').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('#create-media__image').hostNodes()).toHaveLength(1);
-  });
+  const team = {
+    slug: 'test',
+    verification_statuses: {
+      label: 'Status',
+      default: 'undetermined',
+      active: 'in_progress',
+      statuses: [
+        {
+          description: 'Default, just added, no work has started',
+          id: 'undetermined',
+          label: 'Unstarted',
+          style: {
+            backgroundColor: '#518FFF',
+            color: '#518FFF',
+          },
+        },
+      ]
+    }
+  };
 
   it('should render input fields', () => {
-    const wrapper = mountWithIntlProvider(<CreateMediaInput />);
+    const wrapper = mountWithIntlProvider(<CreateMediaInput team={team} />);
     expect(wrapper.find('#create-media-input').hostNodes()).toHaveLength(1);
-    wrapper.find('#create-media__quote').hostNodes().simulate('click');
-    expect(wrapper.find('#create-media-quote-input').hostNodes()).toHaveLength(1);
-    wrapper.find('#create-media__image').hostNodes().simulate('click');
+    expect(wrapper.find('#create-media-claim').hostNodes()).toHaveLength(1);
     expect(wrapper.find(UploadFile)).toHaveLength(1);
   });
 });

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -110,6 +110,7 @@ class CreateRelatedMediaDialog extends React.Component {
                 formId={formId}
                 isSubmitting={this.props.isSubmitting}
                 onSubmit={this.props.onSubmit}
+                team={this.props.team}
                 noSource
               />
             }

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -47,7 +47,7 @@ class MediaStatusCommon extends Component {
   state = {};
 
   canUpdate() {
-    return (!this.props.readonly && can(this.props.media.permissions, 'update Status'))
+    return (!this.props.readonly && can(this.props.media.permissions || '{}', 'update Status'))
       || this.props.quickAdd;
   }
 

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -47,7 +47,8 @@ class MediaStatusCommon extends Component {
   state = {};
 
   canUpdate() {
-    return !this.props.readonly && can(this.props.media.permissions, 'update Status');
+    return (!this.props.readonly && can(this.props.media.permissions, 'update Status'))
+      || this.props.quickAdd;
   }
 
   handleCloseMenu = () => {
@@ -92,12 +93,12 @@ class MediaStatusCommon extends Component {
   render() {
     const { media } = this.props;
     const { statuses } = media.team.verification_statuses;
-    const currentStatus = getStatus(media.team.verification_statuses, media.last_status);
+    const currentStatus = getStatus(media.team.verification_statuses, media.last_status || this.props.currentStatus);
 
     return (
       <StyledMediaStatus className="media-status">
         <Button
-          className={`media-status__label media-status__current ${MediaStatusCommon.currentStatusToClass(media.last_status)}`}
+          className={`media-status__label media-status__current ${MediaStatusCommon.currentStatusToClass(media.last_status || this.props.currentStatus)}`}
           style={{ backgroundColor: currentStatus.style.color, color: 'white', minHeight: 41 }}
           variant="contained"
           disableElevation
@@ -119,7 +120,7 @@ class MediaStatusCommon extends Component {
               key={status.id}
               className={`${bemClass(
                 'media-status__menu-item',
-                media.last_status === status.id,
+                media.last_status === status.id || this.props.currentStatus === status.id,
                 '--current',
               )} media-status__menu-item--${status.id.replace('_', '-')}`}
               onClick={() => this.handleStatusClick(status.id)}
@@ -140,6 +141,13 @@ class MediaStatusCommon extends Component {
 
 MediaStatusCommon.propTypes = {
   setFlashMessage: PropTypes.func.isRequired,
+  quickAdd: PropTypes.bool,
+  currentStatus: PropTypes.string,
+};
+
+MediaStatusCommon.defaultProps = {
+  quickAdd: false,
+  currentStatus: 'undetermined',
 };
 
 MediaStatusCommon.contextTypes = {

--- a/src/app/relay/mutations/CreateProjectMediaMutation.js
+++ b/src/app/relay/mutations/CreateProjectMediaMutation.js
@@ -47,6 +47,7 @@ class CreateProjectMediaMutation extends Relay.Mutation {
   getVariables() {
     const vars = {
       media_type: this.props.mediaType,
+      set_claim_description: this.props.claimDescription,
       url: this.props.url,
       quote: this.props.quote,
       quote_attributions: this.props.quoteAttributions,
@@ -105,6 +106,11 @@ class CreateProjectMediaMutation extends Relay.Mutation {
           project_media {
             dbid
             title
+            claim_description
+            last_status_obj {
+              id
+            }
+            last_status
           },
           project {
             id

--- a/test/spec/app_spec_helpers.rb
+++ b/test/spec/app_spec_helpers.rb
@@ -143,7 +143,6 @@ module AppSpecHelpers
 
   def create_image(file)
     wait_for_selector('#create-media__add-item').click
-    wait_for_selector('#create-media__image').click
     wait_for_selector('.without-file')
     wait_for_selector('input[type=file]').send_keys(File.join(File.dirname(__FILE__), file.to_s))
     wait_for_selector('.with-file')

--- a/test/spec/media_actions_spec.rb
+++ b/test/spec/media_actions_spec.rb
@@ -130,7 +130,6 @@ shared_examples 'media actions' do
     wait_for_selector('.search__results')
     wait_for_selector('.medias__item')
     wait_for_selector('#create-media__add-item').click
-    wait_for_selector('#create-media__link')
     fill_field('#create-media-input', url)
     wait_for_selector('#create-media-dialog__submit-button').click
     wait_for_selector('.media-detail')


### PR DESCRIPTION
This PR changes the way "Add Item" works in both the instance where a user "normally" adds an item, and in the case where a blank media is imported from Fetch and a user needs to add an item to it.

The way the new flow works is: the modal opens up, and the user enters an optional claim, along with either an attachment __or__ a text/url. When the user hits "submit", a new item is created exactly as it used to be by this feature, but with `set_claim_description` added to the payload if there is a claim. The item is set to whatever the default verification status is int he workplace, but then if the user has picked a different verification status on the form, a second GraphQL mutation kicks off on the success of the first, which updates the status to the user-selected one.

Change list:

- Add `verification_statuses` to the `team` query on `Home` component
- pass the `team` object down from `CreateMedia` -> `CreateMediaDialog` -> `CreateMediaInput`
- create a new state `status` on `CreateMediaInput` which stores a mock string like `'undetermined'` or `'verified'` to represent the current state of the status dropdown. these strings match the verification_status strings set on the server, the only one locally hard coded is the default `'undetermined'`, the rest is populated from the `verification_statuses` portion of the `team` query in `Home`
- update `MediaStatusCommon` component to take a `quickAdd` boolean prop that, when true, overrides the "lock" state of the status dropdown (this way the component doesn't have to know anything about the media item to be set)
- update `MediaStatusCommon` component to take a `currentStatus` string prop that acts as an alternative to the `media.last_status` for indicating the current state of the dropdown. this enables us to update the local state of the dropdown before making any graphql mutations (since the user will be changing these values in the UX before the item exists in the db)
- updating `react-dropzone` dependency so it supports `disabled` prop
- add a new `image+video+audio` type to the `UploadFile` component so it shows relevant information about those three mime-types combined
- update the `BlankMediaButton` (which shows when a blank media item is imported from fetch) to accept the `team` object and pass it on to `CreateRelatedMediaDialog` -> `CreateMediaInput` (since the latter component now requires `team` as a prop)
- claim text is now set at the same time as the item is created via the `set_claim_description` variable
- in `CreateMedia` we now have a cascade of mutations where a mutation is first done to create the item, and then on success, the item's status is updated to whatever the user picked in the `CreateMediaInput` dialog (I left in the option for creating a new status whole-cloth (`CreateStatusMutation`) just in case there was an edge case where no default status is defined in a workspace
- styles of `CreateMediaInput` updated to match the design
- clear button created to clear out the file dropzone
- `CreateProjectMediaMutation` now returns some extra fields needed by the second mutation for setting status, and also returns `claim_description` for cache update reasons (probably not needed but better safe than sorry)
- some unit tests, fix integration tests