### PR TITLE
CHECK-1418: Add truncation to source in column view

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "lodash.merge": "^4.6.0",
     "lodash.mergewith": "^4.6.0",
     "lodash.sortby": "^4.7.0",
-    "lodash.truncate": "^4.4.2",
     "lodash.xor": "^4.5.0",
     "material-ui-popup-state": "1.5.4",
     "memoize-one": "^5.1.1",

--- a/src/app/components/search/SearchResultsTable/FolderCell.js
+++ b/src/app/components/search/SearchResultsTable/FolderCell.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
+import { truncateLength } from '../../../helpers';
 
 const useStyles = makeStyles({
   title: {
@@ -10,12 +11,6 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
   },
 });
-
-function truncate(str) {
-  const length = 32;
-  const dots = str.length > length ? '...' : '';
-  return `${str.substring(0, length)}${dots}`;
-}
 
 export default function FolderCell({ projectMedia }) {
   const classes = useStyles();
@@ -28,7 +23,7 @@ export default function FolderCell({ projectMedia }) {
   return (
     <TableCell>
       <div className={classes.title} title={title}>
-        {typeof title === 'string' ? truncate(title) : title}
+        {typeof title === 'string' ? truncateLength(title, 32) : title}
       </div>
     </TableCell>
   );

--- a/src/app/components/search/SearchResultsTable/MetadataCell.js
+++ b/src/app/components/search/SearchResultsTable/MetadataCell.js
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types';
 import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import ValueListCell from './ValueListCell';
-
-function truncate(str, length) {
-  const dots = str.length > length ? '...' : '';
-  return `${str.substring(0, length)}${dots}`;
-}
+import { truncateLength } from '../../../helpers';
 
 const useStyles = makeStyles({
   number: {
@@ -32,7 +28,7 @@ export default function MetadataCell({ projectMedia, field, type }) {
   if (value) {
     switch (type) {
     case 'free_text':
-      value = typeof value === 'string' ? truncate(value, 32) : value;
+      value = typeof value === 'string' ? truncateLength(value, 32) : value;
       break;
     case 'number':
       value = <span className={classes.number}>{value}</span>;
@@ -55,7 +51,7 @@ export default function MetadataCell({ projectMedia, field, type }) {
           rel="noopener noreferrer"
           onClick={e => e.stopPropagation()}
         >
-          {truncate(item.title || item.url, 22)}
+          {truncateLength(item.title || item.url, 22)}
         </a>
       ));
       break;

--- a/src/app/components/search/SearchResultsTable/SourcesCell.js
+++ b/src/app/components/search/SearchResultsTable/SourcesCell.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import ValueListCell from './ValueListCell';
 import { urlFromSearchQuery } from '../../search/Search';
-import { safelyParseJSON } from '../../../helpers';
+import { safelyParseJSON, truncateLength } from '../../../helpers';
 import { checkBlue } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
@@ -34,7 +34,7 @@ export default function SourcesCell({ projectMedia }) {
     <ValueListCell
       onClick={searchBySource}
       values={Object.values(sources).map(source => (
-        <div className={classes.source}>{source}</div>
+        <div className={classes.source}>{truncateLength(source, 25)}</div>
       ))}
       noValueLabel="-"
     />

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -1,4 +1,3 @@
-import truncate from 'lodash.truncate';
 import LinkifyIt from 'linkify-it';
 import { toArray } from 'react-emoji-render';
 
@@ -58,9 +57,11 @@ function getStatusStyle(status, property) {
 /**
  * Truncate a string and append ellipsis.
  */
-function truncateLength(text, length = 70) {
-  return truncate(text, { length, separator: /,? +/, ellipsis: '…' });
+function truncateLength(str, length = 70) {
+  const dots = str.length > length ? '...' : '';
+  return `${str.substring(0, length)}${dots}`;
 }
+
 
 /**
  * Convert human-readable file size to bytes


### PR DESCRIPTION
When "Source" is shown in search results, we now truncate to 25 characters and put `'...'` after the text.

This commit also removes our dependency on `lodash.truncate` in `helpers.js`, replacing it with a couple lines of plain JS. I've also found locations where we use a custom truncate in the code and updated so we use the helper function instead.