### PR TITLE
Remove several lodash dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11723,20 +11723,10 @@
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
     },
-    "lodash.capitalize": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
-      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.escape": {
       "version": "3.2.0",
@@ -11745,11 +11735,6 @@
       "requires": {
         "lodash._root": "^3.0.0"
       }
-    },
-    "lodash.findkey": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
-      "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg="
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -11761,11 +11746,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -11780,7 +11760,8 @@
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+      "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -11820,7 +11801,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lodash.template": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "@calm/eslint-plugin-react-intl": "^1.4.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.2",
     "enzyme": "^3.3.0",
-    "jest": "^25.4.0"
+    "jest": "^25.4.0",
+    "lodash.isempty": "^4.4.0"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",
@@ -127,15 +128,9 @@
     "jss": "^10.2.0",
     "jss-rtl": "^0.3.0",
     "leaflet": "^1.6.0",
-    "lodash.capitalize": "^4.2.1",
-    "lodash.difference": "^4.5.0",
-    "lodash.findkey": "^4.6.0",
-    "lodash.intersection": "^4.4.0",
-    "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.0",
     "lodash.mergewith": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
     "lodash.xor": "^4.5.0",
     "material-ui-popup-state": "1.5.4",
     "memoize-one": "^5.1.1",

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -41,10 +41,13 @@ class ProjectHeaderComponent extends React.PureComponent {
       pageTitle = <FormattedMessage id="projectHeader.allItems" defaultMessage="All items" />;
     }
 
+    // Get current team for trends page
+    const currentTeam = this.props.root ? this.props.root.current_team.slug : '';
+
     return (
       <div style={{ display: 'flex', alignItems: 'center', overflow: 'hidden' }}>
         <Row>
-          <IconButton onClick={() => isTrendsPage ? browserHistory.goBack() : browserHistory.push(listUrl)} className="project-header__back-button">
+          <IconButton onClick={() => isTrendsPage ? browserHistory.push(`/${currentTeam}/trends`) : browserHistory.push(listUrl)} className="project-header__back-button">
             <ArrowBackIcon />
           </IconButton>
           <HeaderTitle className="project-header__title" style={{ maxWidth: 300 }} title={pageTitle}>
@@ -76,6 +79,8 @@ const ProjectPlaceholder = { title: '' };
 
 const ProjectHeader = ({ location, params }) => {
   const commonProps = { location, params };
+  const isTrendsPage = /\/trends\/cluster\/[0-9]+/.test(location.pathname);
+
   let query = null;
 
   if (params.projectId) {
@@ -94,9 +99,19 @@ const ProjectHeader = ({ location, params }) => {
         }
       }
     `;
+  } else if (isTrendsPage) {
+    query = graphql`
+      query ProjectHeaderCurrentTeamQuery {
+        root {
+          current_team {
+            slug
+          }
+        }
+      }
+    `;
   }
 
-  if (params.projectId || params.listId) {
+  if (params.projectId || params.listId || isTrendsPage) {
     return (
       <QueryRenderer
         environment={Relay.Store}

--- a/src/app/components/source/UserInfoEdit.js
+++ b/src/app/components/source/UserInfoEdit.js
@@ -7,7 +7,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import TextField from '@material-ui/core/TextField';
 import CancelIcon from '@material-ui/icons/Cancel';
-import capitalize from 'lodash.capitalize';
 import LinkifyIt from 'linkify-it';
 import SourcePicture from './SourcePicture';
 import Message from '../Message';
@@ -17,7 +16,7 @@ import UpdateSourceMutation from '../../relay/mutations/UpdateSourceMutation';
 import { updateUserNameEmail } from '../../relay/mutations/UpdateUserNameEmailMutation';
 import CreateAccountSourceMutation from '../../relay/mutations/CreateAccountSourceMutation';
 import DeleteAccountSourceMutation from '../../relay/mutations/DeleteAccountSourceMutation';
-import { getErrorMessage } from '../../helpers';
+import { getErrorMessage, capitalize } from '../../helpers';
 import {
   StyledIconButton,
   Row,

--- a/src/app/components/team/TeamTasksRender.js
+++ b/src/app/components/team/TeamTasksRender.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import intersection from 'lodash.intersection';
 import Box from '@material-ui/core/Box';
 import TeamTasksProject from './TeamTasksProject';
 import SettingsHeader from './SettingsHeader';
@@ -10,6 +9,7 @@ import ProjectSelector from '../project/ProjectSelector';
 import TaskTypeSelector from '../task/TaskTypeSelector';
 import BlankState from '../layout/BlankState';
 import FilterPopup from '../layout/FilterPopup';
+import { intersection } from '../../helpers';
 
 function TeamTasksRender({ team, about }) {
   const [projFilter, setProjFilter] = React.useState([]);

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -62,6 +62,19 @@ function truncateLength(str, length = 70) {
   return `${str.substring(0, length)}${dots}`;
 }
 
+/**
+ * Uppercase the first character of a string, lowercase the remaining
+ */
+function capitalize(str) {
+  return `${str.substring(0, 1).toUpperCase()}${str.substr(1).toLowerCase()}`;
+}
+
+/**
+ * Return an array of unique values that are in all arrays passed as arguments
+ */
+function intersection(array, ...args) {
+  return array.filter(item => args.every(arr => arr.includes(item)));
+}
 
 /**
  * Convert human-readable file size to bytes
@@ -253,6 +266,8 @@ export { // eslint-disable-line import/no-unused-modules
   getStatus,
   getStatusStyle,
   truncateLength,
+  capitalize,
+  intersection,
   unhumanizeSize,
   convertNumbers2English,
   encodeSvgDataUri,


### PR DESCRIPTION
* `lodash.difference`, `lodash.findkey`, and `lodash.sortby` were simply not required anywhere in our dependency tree at all and are now completely removed from the project
* `lodash.capitalize` and `lodash.intersection` have been replaced with simple functions in `helpers.js`
* `lodash.isEmpty` is only used in webpack and so is moved to `devDependencies`

All six of these packages are now no longer shipped to end users in our javascript payload.