### PR TITLE
CHECK-1117: Speed up next/prev media navigation

### DIFF
--- a/src/app/components/media/MediaPage.js
+++ b/src/app/components/media/MediaPage.js
@@ -36,6 +36,8 @@ export default function MediaPage({ route, routeParams, location }) {
       listId={listId}
       projectMediaId={projectMediaId}
       view={currentView}
+      mediaNavList={location?.state?.mediaNavList}
+      count={location?.state?.count}
     />
   );
 }

--- a/src/app/components/media/MediaPageLayout.js
+++ b/src/app/components/media/MediaPageLayout.js
@@ -21,7 +21,7 @@ const StyledTopBar = styled.div`
 `;
 
 export default function MediaPageLayout({
-  listUrl, buildSiblingUrl, listQuery, listIndex, projectId, projectMediaId, view,
+  listUrl, buildSiblingUrl, listQuery, listIndex, projectId, projectMediaId, view, mediaNavList, count,
 }) {
   return (
     <div>
@@ -31,6 +31,8 @@ export default function MediaPageLayout({
           listQuery={listQuery}
           listIndex={listIndex}
           objectType="media"
+          mediaNavList={mediaNavList}
+          count={count}
         />
       ) : null}
       <StyledTopBar className="media-search__actions-bar">

--- a/src/app/components/media/NextOrPreviousButton.js
+++ b/src/app/components/media/NextOrPreviousButton.js
@@ -12,7 +12,7 @@ import MediaSearchRedirect from './MediaSearchRedirect';
  * to unmount the component if any of its props are going to change.
  */
 export default function NextOrPreviousButton({
-  children, className, disabled, tooltipTitle, buildSiblingUrl, listQuery, listIndex, objectType,
+  children, className, disabled, tooltipTitle, buildSiblingUrl, listQuery, listIndex, objectType, type, searchIndex,
 }) {
   const [loading, setLoading] = React.useState(false);
   const handleClick = React.useCallback(() => {
@@ -30,7 +30,9 @@ export default function NextOrPreviousButton({
           buildSiblingUrl={buildSiblingUrl}
           listQuery={listQuery}
           listIndex={listIndex}
+          searchIndex={searchIndex}
           objectType={objectType}
+          type={type}
         />
       ) : (
         <Tooltip title={tooltipTitle}>
@@ -52,4 +54,6 @@ NextOrPreviousButton.propTypes = {
   tooltipTitle: PropTypes.node.isRequired, // <FormattedMessage>
   listQuery: PropTypes.object.isRequired,
   listIndex: PropTypes.number.isRequired,
+  type: PropTypes.string.isRequired,
+  searchIndex: PropTypes.number.isRequired,
 };

--- a/src/app/components/media/NextPreviousLinks.js
+++ b/src/app/components/media/NextPreviousLinks.js
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 import NextIcon from '@material-ui/icons/KeyboardArrowRight';
 import PrevIcon from '@material-ui/icons/KeyboardArrowLeft';
 import NextOrPreviousButton from './NextOrPreviousButton';
 import { units, black54 } from '../../styles/js/shared';
+import { getPathnameAndSearch, pageSize } from '../../urlHelpers';
 
 const StyledPager = styled.div`
   position: absolute;
@@ -51,7 +55,9 @@ function NextPreviousLinksComponent({
         buildSiblingUrl={buildSiblingUrl}
         listQuery={listQuery}
         listIndex={listIndex - 1}
+        searchIndex={(listIndex - 1) - ((listIndex - 1) % pageSize)}
         objectType={objectType}
+        type="prev"
       >
         <PrevIcon />
       </NextOrPreviousButton>
@@ -72,7 +78,9 @@ function NextPreviousLinksComponent({
         buildSiblingUrl={buildSiblingUrl}
         listQuery={listQuery}
         listIndex={listIndex + 1}
+        searchIndex={(listIndex + 1) - ((listIndex + 1) % pageSize)}
         objectType={objectType}
+        type="next"
       >
         <NextIcon />
       </NextOrPreviousButton>
@@ -86,13 +94,116 @@ NextPreviousLinksComponent.propTypes = {
   nTotal: PropTypes.number.isRequired,
 };
 
+function NextPreviousLinksFastComponent({
+  listIndex, mediaNavList, count, listQuery, buildSiblingUrl, objectType,
+}) {
+  const localIndex = listIndex % pageSize;
+
+  const handlePrevClick = () => {
+    const prevItemUrl = buildSiblingUrl(mediaNavList[localIndex - 1], listIndex - 1);
+    const { pathname, search } = getPathnameAndSearch(prevItemUrl);
+    browserHistory.push({ pathname, search, state: { mediaNavList, count } });
+  };
+
+  const handleNextClick = () => {
+    const nextItemUrl = buildSiblingUrl(mediaNavList[localIndex + 1], listIndex + 1);
+    const { pathname, search } = getPathnameAndSearch(nextItemUrl);
+    browserHistory.push({ pathname, search, state: { mediaNavList, count } });
+  };
+  return (
+    <StyledPager>
+      { localIndex === 0 && listIndex !== 0 ? (
+        <NextOrPreviousButton
+          className="media-search__previous-item"
+          key={listIndex - 1}
+          tooltipTitle={
+            <FormattedMessage id="mediaSearch.previousItem" defaultMessage="Previous item" />
+          }
+          buildSiblingUrl={buildSiblingUrl}
+          listQuery={listQuery}
+          listIndex={listIndex - 1}
+          searchIndex={(listIndex - 1) - ((listIndex - 1) % pageSize)}
+          objectType={objectType}
+          type="prev"
+        >
+          <PrevIcon />
+        </NextOrPreviousButton>
+      ) : (
+        <Button
+          disabled={listIndex === 0}
+          className="media-search__previous-item"
+          onClick={handlePrevClick}
+        >
+          <Tooltip
+            title={<FormattedMessage id="mediaSearch.previousItem" defaultMessage="Previous item" />}
+          >
+            <PrevIcon />
+          </Tooltip>
+        </Button>
+      )}
+      <span id="media-search__current-item">
+        <FormattedMessage
+          id="mediaSearch.xOfY"
+          defaultMessage="{current} of {total}"
+          values={{ current: listIndex + 1, total: count }}
+        />
+      </span>
+      { localIndex === pageSize - 1 && listIndex !== count - 1 ? (
+        <NextOrPreviousButton
+          className="media-search__previous-item"
+          key={listIndex + 1}
+          tooltipTitle={
+            <FormattedMessage id="mediaSearch.nextItem" defaultMessage="Next item" />
+          }
+          buildSiblingUrl={buildSiblingUrl}
+          listQuery={listQuery}
+          listIndex={listIndex + 1}
+          searchIndex={(listIndex + 1) - ((listIndex + 1) % pageSize)}
+          objectType={objectType}
+          type="next"
+        >
+          <NextIcon />
+        </NextOrPreviousButton>
+      ) : (
+        <Button
+          disabled={listIndex === count - 1}
+          className="media-search__next-item"
+          onClick={handleNextClick}
+        >
+          <Tooltip
+            title={<FormattedMessage id="mediaSearch.nextItem" defaultMessage="Next item" />}
+          >
+            <NextIcon />
+          </Tooltip>
+        </Button>
+      )}
+    </StyledPager>
+  );
+}
+
 export default function NextPreviousLinks({
   buildSiblingUrl,
   listQuery,
   listIndex,
   annotationState,
   objectType,
+  mediaNavList,
+  count,
 }) {
+  // if we have a navigation list passed down to us, and we know the overall count, then render our new, faster component. This should happen in every single case except where a user is linked directly to a media item from outside the app
+  if (mediaNavList && count) {
+    return (
+      <NextPreviousLinksFastComponent
+        listIndex={listIndex}
+        count={count}
+        mediaNavList={mediaNavList}
+        listQuery={listQuery}
+        buildSiblingUrl={buildSiblingUrl}
+        objectType={objectType}
+      />
+    );
+  }
+  // if the user is linked directly to a media item outside the app, we need to prerender some query information and use the "slow" next/prev button format temporarily
   return (
     <QueryRenderer
       environment={Relay.Store}

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -22,8 +22,7 @@ import ProjectBlankState from '../project/ProjectBlankState';
 import { black87, black54, headline, units, Row } from '../../styles/js/shared';
 import SearchResultsTable from './SearchResultsTable';
 import SearchRoute from '../../relay/SearchRoute';
-
-const pageSize = 50;
+import { pageSize } from '../../urlHelpers';
 
 const StyledListHeader = styled.div`
   margin: ${units(2)};
@@ -411,6 +410,7 @@ function SearchResultsComponent({
         buildProjectMediaUrl={buildProjectMediaUrl}
         resultType={resultType}
         viewMode={viewMode}
+        count={count}
       />
     );
   }

--- a/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
+++ b/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
@@ -6,6 +6,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import { makeStyles } from '@material-ui/core/styles';
 import { opaqueBlack03 } from '../../../styles/js/shared';
+import { getPathnameAndSearch } from '../../../urlHelpers';
 
 const isTrendsPage = /\/trends$/.test(window.location.pathname);
 
@@ -30,7 +31,7 @@ const useStyles = makeStyles({
 });
 
 export default function SearchResultsTableRow({
-  projectMedia, projectMediaUrl, checked, columnDefs, onChangeChecked, resultType, viewMode,
+  projectMedia, projectMediaUrl, checked, columnDefs, onChangeChecked, resultType, viewMode, mediaNavList, count,
 }) {
   const { dbid, is_read: isRead } = projectMedia;
   const classes = useStyles({ dbid, isRead });
@@ -38,12 +39,13 @@ export default function SearchResultsTableRow({
   // This is why we don't get a listIndex in our trends item url
   // We are forcing the url instead of getting it from `projectMediaUrl` which is built from `buildProjectMediaUrl`
   const projectMediaOrTrendsUrl = projectMediaUrl;
+  const { pathname, search } = getPathnameAndSearch(projectMediaOrTrendsUrl);
 
   const handleClick = React.useCallback(() => {
     if (!projectMediaOrTrendsUrl) {
       return;
     }
-    browserHistory.push(projectMediaOrTrendsUrl);
+    browserHistory.push({ pathname, search, state: { mediaNavList, count } });
   }, [projectMediaUrl]);
 
   const handleChangeChecked = React.useCallback((ev) => {

--- a/src/app/components/search/SearchResultsTable/index.js
+++ b/src/app/components/search/SearchResultsTable/index.js
@@ -252,8 +252,10 @@ export default function SearchResultsTable({
   onChangeSortParams,
   resultType,
   viewMode,
+  count,
 }) {
   const columnDefs = React.useMemo(() => buildColumnDefs(team, resultType), [team]);
+  const mediaNavList = projectMedias.map(media => media.dbid);
 
   const handleChangeProjectMediaChecked = React.useCallback((ev, projectMedia) => {
     const { id } = projectMedia;
@@ -301,6 +303,8 @@ export default function SearchResultsTable({
               onChangeChecked={handleChangeProjectMediaChecked}
               resultType={resultType}
               viewMode={viewMode}
+              mediaNavList={mediaNavList}
+              count={count}
             />
           ))}
         </TableBody>

--- a/src/app/urlHelpers.js
+++ b/src/app/urlHelpers.js
@@ -1,6 +1,13 @@
 import { safelyParseJSON } from './helpers';
 
-const pageSize = 20;
+const pageSize = 50;
+
+function getPathnameAndSearch(url) {
+  const pathnameMatch = url.match(/(.*)\?/);
+  const pathname = pathnameMatch ? pathnameMatch[1] : null;
+  const search = url.match(/\?.*/)[0];
+  return { pathname, search };
+}
 
 /**
  * Return { listUrl, listQuery, listIndex, buildSiblingUrl } that are valid.
@@ -113,4 +120,4 @@ function getListUrlQueryAndIndex(routeParams, locationQuery, locationPathname) {
   };
 }
 
-export { getListUrlQueryAndIndex }; // eslint-disable-line import/prefer-default-export
+export { getListUrlQueryAndIndex, getPathnameAndSearch, pageSize }; // eslint-disable-line import/prefer-default-export


### PR DESCRIPTION
The problem was that we do a database query every time the user hits "next" or "previous" while viewing an individual item just to find the url we need to redirect to, then we redirect to it. This commit fixes the issue and makes navigating using the prev/next icons much faster.

* When a user navigates into a media item directly from a search view, a `mediaNavList` of `dbid` values for the (maximum) 50 locally rendered search items is passed down into the media item. This is now used to render the next/prev item indicators, which means we no longer have to run a query every time the user clicks a next/prev item indicator. The only time a query is now run is when we are transitioning out of a window of previously-calculated search items. So for example, if we are on item 50 in a list 1 to 50, and we hit "next", then a single query will fire off and pull down items 51 to 100, which are then passed as a new `mediaNavList`. If the user hits "next" from there, it will not fire a query. But if the user hits "previous" from there, it WILL fire off a query and re-fetch items 1 to 50. So basically: we only do the extra query when going out of bounds of our pre-fetched list.
* The `mediaNavList` and `count` (total search item count) values are passed into new items via the `browserHistory.push` function, which in addition to accepting a path, will also accept an object containing `pathname`, `search`, and an arbitrary `state`. The `state` contains the `mediaNavList` and `count` values, and is basically a way of passing props via `browserHistory`.
* In the case where a user enters a hyperlink directly to an item that came from a search (such as typing it in the url bar or being linked from outside the application), we default to the old "slow" behavior where we re-run the query and do a query for both the previous and next buttons. However, once a user hits previous or next, it will then pass the new query in and use the fast component.
* Also fixed is a nasty bug where `pageSize` was defined as `50` in `SearchResults.js` but as `20` in `urlHelpers`. I made `urlHelpers` the canonical value and `SearchResults` now imports it. This fixes a bug where rounding errors resulted in a user's place being lost if they clicked into an item while on a second page of a search list and then hit the "back" button, due to rounding math errors because of the conflicting `pageSize` values.