### PR TITLE
Do not JSON parse if object doesn't exist

### DIFF
--- a/src/app/components/annotations/TiplineRequest.js
+++ b/src/app/components/annotations/TiplineRequest.js
@@ -126,6 +126,9 @@ const TiplineRequest = ({
   annotated: projectMedia,
   intl,
 }) => {
+  if (!activity) {
+    return null;
+  }
   const object = JSON.parse(activity.object_after);
   const objectValue = JSON.parse(object.value);
   const messageType = objectValue.source.type;


### PR DESCRIPTION
I'm running into a case on production where the `activity` here is `undefined`. We should bail from this function if it's not defined, otherwise we render a blank page.