### PR TITLE
CHECK-1589: Locale-safe team sorting

### DIFF
--- a/src/app/components/team/SwitchTeamsComponent.js
+++ b/src/app/components/team/SwitchTeamsComponent.js
@@ -137,7 +137,7 @@ class SwitchTeamsComponent extends Component {
         />
         { (joinedTeams.length + pendingTeams.length) ?
           <List className="teams">
-            {joinedTeams.map(team => (
+            {joinedTeams.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' })).map(team => (
               <ListItem
                 key={team.slug}
                 className="switch-teams__joined-team"


### PR DESCRIPTION
We use `localeCompare` with `sensitivity: 'base'` to sort case-insensitive (so we correctly sort `['apple', 'Banana']` instead of `['Banana', 'apple']`), and `numeric: true` (so that we sort `['200-banana', '1000-banana']` instead of `['1000-banana', '200-banana'])`. Basically we are human sorting instead of lexical/ASCII sorting.