### PR TITLE
CHECK-1587: New claim context field

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaClaim.json
+++ b/localization/react-intl/src/app/components/media/MediaClaim.json
@@ -20,8 +20,8 @@
     "defaultMessage": "saved by {userName} {timeAgo}"
   },
   {
-    "id": "mediaClaim.description",
+    "id": "mediaClaim.placeholder",
     "description": "Placeholder for claim description field.",
-    "defaultMessage": "Type something"
+    "defaultMessage": "For example: The earth is flat"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaContext.json
+++ b/localization/react-intl/src/app/components/media/MediaContext.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "mediaContext.placeholder",
+    "description": "Placeholder for claim context field.",
+    "defaultMessage": "Type something"
+  },
+  {
+    "id": "mediaContext.title",
+    "description": "Title of claim context field.",
+    "defaultMessage": "Additional context"
+  }
+]

--- a/src/app/components/media/Media.js
+++ b/src/app/components/media/Media.js
@@ -39,6 +39,7 @@ const MediaContainer = Relay.createContainer(MediaComponent, {
           id
           dbid
           description
+          context
           updated_at
           user {
             name

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -88,7 +88,7 @@ const StyledThreeColumnLayout = styled.div`
 const AnalysisColumn = styled.div`
   width: 420px;
   flex-grow: 0;
-  padding: ${units(2)};
+  padding: 0 ${units(2)} ${units(2)} ${units(2)};
   border-right: 1px solid ${brandSecondary};
   max-height: calc(100vh - 64px);
   overflow-y: auto;

--- a/src/app/components/media/MediaCreatedBy.js
+++ b/src/app/components/media/MediaCreatedBy.js
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, FormattedMessage, intlShape } from 'react-intl';
 import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import CheckChannels from '../../CheckChannels';
+
+const useStyles = makeStyles(() => ({
+  createdBy: {
+    fontSize: '9px',
+  },
+}));
 
 const messages = defineMessages({
   import: {
@@ -33,13 +40,14 @@ const MediaCreatedBy = ({ projectMedia, intl }) => {
     user_id: userId,
     channel,
   } = projectMedia;
+  const classes = useStyles();
 
   const showUserName = [CheckChannels.MANUAL, CheckChannels.BROWSER_EXTENSION].indexOf(channel.toString()) !== -1;
   const channelNameKey = creatorName.replace(/[ _-]+/g, '').toLocaleLowerCase();
   const formattedChannelName = Object.keys(messages).includes(channelNameKey) ? intl.formatMessage(messages[channelNameKey]) : creatorName;
 
   return (
-    <Typography variant="body" component="div">
+    <Typography className={classes.createdBy} variant="body" component="div">
       <FormattedMessage
         id="mediaCreatedBy.createdBy"
         defaultMessage="Item created by {name}"

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -6,6 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import TimeBefore from '../TimeBefore';
 import { parseStringUnixTimestamp } from '../../helpers';
 import { can } from '../Can';
@@ -13,7 +14,14 @@ import { propsToData } from './ReportDesigner/reportDesignerHelpers';
 import MediaFactCheckField from './MediaFactCheckField';
 import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
 
+const useStyles = makeStyles(() => ({
+  title: {
+    fontSize: '16px',
+  },
+}));
+
 const MediaFactCheck = ({ projectMedia }) => {
+  const classes = useStyles();
   const claimDescription = projectMedia.claim_description;
   const factCheck = claimDescription ? claimDescription.fact_check : null;
 
@@ -212,7 +220,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   return (
     <Box id="media__fact-check">
       <Box id="media__fact-check-title" display="flex" alignItems="center" mb={2} justifyContent="space-between">
-        <Typography variant="body" component="div">
+        <Typography className={classes.title} variant="body" component="div">
           <strong>
             <FormattedMessage id="mediaFactCheck.factCheck" defaultMessage="Fact-check" description="Title of the media fact-check section." />
           </strong>

--- a/src/app/components/media/MediaSidebar.js
+++ b/src/app/components/media/MediaSidebar.js
@@ -13,7 +13,7 @@ const MediaSidebar = ({ projectMedia, onTimelineCommentOpen }) => (
       <MediaCreatedBy projectMedia={projectMedia} />
     </Box>
     <Box>
-      <Box my={2}>
+      <Box mt={2}>
         <MediaClaim projectMedia={projectMedia} />
       </Box>
       <MediaTags projectMedia={projectMedia} onTimelineCommentOpen={onTimelineCommentOpen} />

--- a/src/app/components/media/MediaTags.js
+++ b/src/app/components/media/MediaTags.js
@@ -25,11 +25,11 @@ const StyledMediaTagsContainer = styled.div`
     display: flex;
     flex-wrap: wrap;
     list-style: none;
-    padding: ${units(0.5)};
-    margin: 0;
+    padding: ${units(0.5)} ${units(0.5)} ${units(0.5)} 0;
+    margin: 0 0 0 ${units(-0.5)};
 
     li {
-      margin: ${units(0.5)};
+      margin: ${units(0.5)} ${units(0.5)} ${units(0.5)} 0;
     }
   }
 `;


### PR DESCRIPTION
I created a new `MediaContext` component, which acts like `MediaClaim` except it's a child of `MediaClaim` and shares the same save/error state (this made more sense than hoisting the save/error state up to the `MediaSidebar` component).

 * new `MediaContext` component is a child of `MediaClaim` so they both share the same save/error state
 * various styling changes
 * new placeholder text