### PR TITLE
CHECK-1651: Friendly error messages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "globals": {
         "describe": true,
         "it": true,
+        "Intercom": "readonly",
     },
     "plugins": [
         "require-path-exists",

--- a/localization/react-intl/src/app/CheckError.json
+++ b/localization/react-intl/src/app/CheckError.json
@@ -53,5 +53,10 @@
     "id": "check.error.conflict",
     "description": "This is a message that displays in an error popup if the server returns an error involving some kind of conflicting data.",
     "defaultMessage": "There was a database conflict."
+  },
+  {
+    "id": "check.error.published",
+    "description": "This is a message that displays in an error popup if the user manages to ask the server to change the status on an item that has already been published.",
+    "defaultMessage": "You can't change the status of a published item."
   }
 ]

--- a/localization/react-intl/src/app/CheckError.json
+++ b/localization/react-intl/src/app/CheckError.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "check.error.unauthorized",
+    "description": "This is a message that displays in an error popup if the user tries to access data that they do not have permission to access.",
+    "defaultMessage": "You are not authorized to see this content. Please contact your workspace administrator if you need permission."
+  },
+  {
+    "id": "check.error.missing_parameters",
+    "description": "This is a message that displays in an error popup if the client sent a request to the server that was missing URL parameters.",
+    "defaultMessage": "The API call was missing parameters."
+  },
+  {
+    "id": "check.error.id_not_found",
+    "description": "This is a message that displays in an error popup if the client sent a request to the server with an identifying number that was not found in the database.",
+    "defaultMessage": "A requested ID was not found."
+  },
+  {
+    "id": "check.error.invalid_value",
+    "description": "This is a message that displays in an error popup if the client sent a request to the server with an invalid value of some kind, such as a malformed email address.",
+    "defaultMessage": "An invalid value was sent to the server."
+  },
+  {
+    "id": "check.error.unknown",
+    "description": "This is a message that displays in an error popup if the server returns an error that we haven't previously classified. This is the default error shown if we can't figure out what sort of error to show the user.",
+    "defaultMessage": "There was an error we can't identify."
+  },
+  {
+    "id": "check.error.auth",
+    "description": "This is a message that displays in an error popup if the client is unable to authenticate (log in).",
+    "defaultMessage": "An authentication error occurred."
+  },
+  {
+    "id": "check.error.warning",
+    "description": "This is a message that displays in an error popup if the server sends it some kind of non-critical warning message (user is approaching their API call limit, for example).",
+    "defaultMessage": "The server returned a warning."
+  },
+  {
+    "id": "check.error.missing_object",
+    "description": "This is a message that displays in an error popup if the server cannot find an object that was requested by the client.",
+    "defaultMessage": "There is an object missing in the database."
+  },
+  {
+    "id": "check.error.duplicated",
+    "description": "This is a message that displays in an error popup if the client tries to create an item but the database already has a record of it.",
+    "defaultMessage": "You're trying to create a record that already exists."
+  },
+  {
+    "id": "check.error.two_factor_auth",
+    "description": "This is a message that displays in an error popup if the client tries to access the application, but they are not yet authenticated by two factor authentication.",
+    "defaultMessage": "You need to log in using two factor authentication."
+  },
+  {
+    "id": "check.error.conflict",
+    "description": "This is a message that displays in an error popup if the server returns an error involving some kind of conflicting data.",
+    "defaultMessage": "There was a database conflict."
+  }
+]

--- a/src/app/CheckError.js
+++ b/src/app/CheckError.js
@@ -14,6 +14,7 @@ const CheckError = {
     DUPLICATED: 9,
     LOGIN_2FA_REQUIRED: 10,
     CONFLICT: 11,
+    PUBLISHED_REPORT: 12,
   },
   messages: {
     UNAUTHORIZED: (<FormattedMessage
@@ -70,6 +71,11 @@ const CheckError = {
       id="check.error.conflict"
       defaultMessage="There was a database conflict."
       description="This is a message that displays in an error popup if the server returns an error involving some kind of conflicting data."
+    />),
+    PUBLISHED_REPORT: (<FormattedMessage
+      id="check.error.published"
+      defaultMessage="You can't change the status of a published item."
+      description="This is a message that displays in an error popup if the user manages to ask the server to change the status on an item that has already been published."
     />),
   },
   getMessageFromCode(code) {

--- a/src/app/CheckError.js
+++ b/src/app/CheckError.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
 const CheckError = {
   codes: {
     UNAUTHORIZED: 1,
@@ -10,6 +13,71 @@ const CheckError = {
     MISSING_OBJECT: 8,
     DUPLICATED: 9,
     LOGIN_2FA_REQUIRED: 10,
+    CONFLICT: 11,
+  },
+  messages: {
+    UNAUTHORIZED: (<FormattedMessage
+      id="check.error.unauthorized"
+      defaultMessage="You are not authorized to see this content. Please contact your workspace administrator if you need permission."
+      description="This is a message that displays in an error popup if the user tries to access data that they do not have permission to access."
+    />),
+    MISSING_PARAMETERS: (<FormattedMessage
+      id="check.error.missing_parameters"
+      defaultMessage="The API call was missing parameters."
+      description="This is a message that displays in an error popup if the client sent a request to the server that was missing URL parameters."
+    />),
+    ID_NOT_FOUND: (<FormattedMessage
+      id="check.error.id_not_found"
+      defaultMessage="A requested ID was not found."
+      description="This is a message that displays in an error popup if the client sent a request to the server with an identifying number that was not found in the database."
+    />),
+    INVALID_VALUE: (<FormattedMessage
+      id="check.error.invalid_value"
+      defaultMessage="An invalid value was sent to the server."
+      description="This is a message that displays in an error popup if the client sent a request to the server with an invalid value of some kind, such as a malformed email address."
+    />),
+    UNKNOWN: (<FormattedMessage
+      id="check.error.unknown"
+      defaultMessage="There was an error we can't identify."
+      description="This is a message that displays in an error popup if the server returns an error that we haven't previously classified. This is the default error shown if we can't figure out what sort of error to show the user."
+    />),
+    AUTH: (<FormattedMessage
+      id="check.error.auth"
+      defaultMessage="An authentication error occurred."
+      description="This is a message that displays in an error popup if the client is unable to authenticate (log in)."
+    />),
+    WARNING: (<FormattedMessage
+      id="check.error.warning"
+      defaultMessage="The server returned a warning."
+      description="This is a message that displays in an error popup if the server sends it some kind of non-critical warning message (user is approaching their API call limit, for example)."
+    />),
+    MISSING_OBJECT: (<FormattedMessage
+      id="check.error.missing_object"
+      defaultMessage="There is an object missing in the database."
+      description="This is a message that displays in an error popup if the server cannot find an object that was requested by the client."
+    />),
+    DUPLICATED: (<FormattedMessage
+      id="check.error.duplicated"
+      defaultMessage="You're trying to create a record that already exists."
+      description="This is a message that displays in an error popup if the client tries to create an item but the database already has a record of it."
+    />),
+    LOGIN_2FA_REQUIRED: (<FormattedMessage
+      id="check.error.two_factor_auth"
+      defaultMessage="You need to log in using two factor authentication."
+      description="This is a message that displays in an error popup if the client tries to access the application, but they are not yet authenticated by two factor authentication."
+    />),
+    CONFLICT: (<FormattedMessage
+      id="check.error.conflict"
+      defaultMessage="There was a database conflict."
+      description="This is a message that displays in an error popup if the server returns an error involving some kind of conflicting data."
+    />),
+  },
+  getMessageFromCode(code) {
+    const codeName = Object.keys(this.codes).find(key => this.codes[key] === code);
+    if (codeName) {
+      return this.messages[codeName];
+    }
+    return this.messages.UNKNOWN;
   },
 };
 

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
 import IconClose from '@material-ui/icons/Close';
+import ErrorIcon from '@material-ui/icons/Error';
 import IconButton from '@material-ui/core/IconButton';
 import { SnackbarProvider, withSnackbar } from 'notistack';
 import reactStringReplace from 'react-string-replace';
 import Message from './Message';
 import { withClientSessionId } from '../ClientSessionId';
-import { safelyParseJSON } from '../helpers';
+import { safelyParseJSON, createFriendlyErrorMessage } from '../helpers';
 import { checkBlue, white, black54 } from '../styles/js/shared';
 
 /**
@@ -49,6 +50,8 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
     if (variant === 'error' && typeof message === 'string') {
       // Split into multiple message in case we have a multiple validation errors
       message.split('<br />').forEach(msg => enqueueSnackbar(msg, { variant, persist, anchorOrigin }));
+    } else if (variant === 'error' && typeof message === 'object' && message.length) {
+      message.forEach(msg => enqueueSnackbar(createFriendlyErrorMessage(msg), { variant, persist, anchorOrigin }));
     } else {
       enqueueSnackbar(message, { variant, persist, anchorOrigin });
     }
@@ -68,12 +71,17 @@ const useSnackBarStyles = makeStyles({
     backgroundColor: `${checkBlue} !important`,
   },
   icon: {
-    color: white,
+    color: 'white !important',
+    marginTop: '8px !important',
+    paddingTop: '0px !important',
     '&:hover': {
-      color: white,
+      color: 'white !important',
     },
   },
   root: {
+    '& div': {
+      alignItems: 'flex-start',
+    },
     '& a': {
       color: white,
       textDecoration: 'underline',
@@ -108,6 +116,9 @@ const FlashMessageProvider = ({ children }) => {
     <SnackbarProvider
       maxSnack={10}
       ref={notistackRef}
+      iconVariant={{
+        error: <ErrorIcon />,
+      }}
       action={key => (
         <IconButton
           className={`message message__dismiss-button ${classes.icon}`}

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Button from '@material-ui/core/Button';
+import { FormattedMessage } from 'react-intl';
 import LinkifyIt from 'linkify-it';
 import { toArray } from 'react-emoji-render';
+import styled from 'styled-components';
 import CheckError from './CheckError';
-import { stringHelper } from './customHelpers';
+import { units } from './styles/js/shared';
 
 /**
  * TODO
@@ -167,25 +170,71 @@ function getErrorObjectsForRelayModernProblem(errorOrErrors) {
 
 // Requires an CheckNetworkLayer c. 2019 object with the `code` and `message` properties
 function createFriendlyErrorMessage(error) {
+  const StyledContainer = styled.div`
+    margin: 0 0 0 ${units(2)};
+    max-width: 500px;
+  `;
+  const StyledSummary = styled.summary`
+    cursor: pointer;
+    margin-bottom: 8px;
+    user-select: none;
+  `;
+  const StyledTextarea = styled.textarea`
+    width: 100%;
+  `;
+  const StyledButton = styled.span`
+    & > .MuiButtonBase-root {
+      text-transform: uppercase;
+      color: #d32f2f;
+      background-color: white;
+    }
+  `;
+  const friendlyMessage = CheckError.getMessageFromCode(error.code);
   return (
-    <div id="snack-flex" style={{ maxWidth: '500px', margin: '0 0 0 16px' }}>
+    <StyledContainer id="snack-flex">
       <p>
         <strong>
-          {CheckError.getMessageFromCode(error.code)}
+          {friendlyMessage}
         </strong>
-        {' '}Please contact <a href={`mailto:${stringHelper('SUPPORT_EMAIL')}`}>{stringHelper('SUPPORT_EMAIL')}</a> if this condition persists.
+        {' '}Please report this issue to Meedan to help us fix it.
+      </p>
+      <p>
+        <StyledButton>
+          <FormattedMessage
+            id="check.helpers.intercom_help"
+            defaultMessage="Press the 'send' arrow to the right to send the report."
+            description="This is text that will appear when the user opens the third-party application to file a bug report with our customer service. The arrow will be to the right side of the text regardless of whether this is a left-to-right or a right-to-left language."
+          >
+            {help_text => (
+              <Button
+                variant="contained"
+                onClick={() => Intercom('showNewMessage', `(${help_text})\nReport: ${friendlyMessage.props.defaultMessage}\nCode: ${error.code}\nURL: ${window.location}\nDetails: ${error.message}`)}
+              >
+                <FormattedMessage
+                  id="check.helpers.report_issue"
+                  defaultMessage="Report issue"
+                  description="This is a label on a button that appears in an error popup. When the user presses the button, another popup opens that allows the user to report an issue to customer service."
+                />
+              </Button>
+            )}
+          </FormattedMessage>
+        </StyledButton>
       </p>
       <p>
         <details>
-          <summary style={{ cursor: 'pointer', marginBottom: '8px', userSelect: 'none' }}>
-            More info...
-          </summary>
-          <textarea id="error-message" name="error-message" rows="5" style={{ width: '100%' }}>
+          <StyledSummary>
+            <FormattedMessage
+              id="check.helpers.more_info"
+              defaultMessage="More info..."
+              description="This is a label on a button that users press in order to get more info related to an error message."
+            />
+          </StyledSummary>
+          <StyledTextarea id="error-message" name="error-message" rows="5">
             {error.message}
-          </textarea>
+          </StyledTextarea>
         </details>
       </p>
-    </div>
+    </StyledContainer>
   );
 }
 

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -1,5 +1,8 @@
+import React from 'react';
 import LinkifyIt from 'linkify-it';
 import { toArray } from 'react-emoji-render';
+import CheckError from './CheckError';
+import { stringHelper } from './customHelpers';
 
 /**
  * TODO
@@ -154,6 +157,38 @@ function getErrorMessage(transactionOrError, fallbackMessage) {
   return message;
 }
 
+function getErrorObjectsForRelayModernProblem(errorOrErrors) {
+  if (errorOrErrors.source) {
+    const json = safelyParseJSON(errorOrErrors.source);
+    return json && json.errors && json.errors.length > 0 ? json.errors : null;
+  }
+  return null;
+}
+
+// Requires an CheckNetworkLayer c. 2019 object with the `code` and `message` properties
+function createFriendlyErrorMessage(error) {
+  return (
+    <div id="snack-flex" style={{ maxWidth: '500px', margin: '0 0 0 16px' }}>
+      <p>
+        <strong>
+          {CheckError.getMessageFromCode(error.code)}
+        </strong>
+        {' '}Please contact <a href={`mailto:${stringHelper('SUPPORT_EMAIL')}`}>{stringHelper('SUPPORT_EMAIL')}</a> if this condition persists.
+      </p>
+      <p>
+        <details>
+          <summary style={{ cursor: 'pointer', marginBottom: '8px', userSelect: 'none' }}>
+            More info...
+          </summary>
+          <textarea id="error-message" name="error-message" rows="5" style={{ width: '100%' }}>
+            {error.message}
+          </textarea>
+        </details>
+      </p>
+    </div>
+  );
+}
+
 /**
  * Extract an error message from a Relay Modern error(s) or return `null` if
  * not possible.
@@ -198,8 +233,11 @@ function getErrorMessage(transactionOrError, fallbackMessage) {
  * ```
  */
 function getErrorMessageForRelayModernProblem(errorOrErrors) {
+  // TODO: make this grab the code in addition to the message. Map the code to a localized string. return an object from this function, not just a string, and the object is ultimately passed to FlashMessage.js. Then that parses out message plus the mapped friendly message, hides message behind a `<details>`.
+  // TODO: make sure every single place that calls getErrorMessageForRelayModernProblem is simply passing things along to FlashMessage. SourceInfo is one such place
   if (errorOrErrors.source) { // Error was thrown from CheckNetworkLayer, c. 2019
-    return getErrorMessage(errorOrErrors, null);
+    // return getErrorMessage(errorOrErrors, null);
+    return getErrorObjectsForRelayModernProblem(errorOrErrors);
   }
   if (errorOrErrors.length) { // Error is an Array the API returned, alongside null data
     return errorOrErrors.map(({ message }) => message).filter(m => Boolean(m))[0] || null;
@@ -213,15 +251,6 @@ function getErrorMessageForRelayModernProblem(errorOrErrors) {
   console.warn('Unhandled error from Relay Modern', errorOrErrors);
   return null;
 }
-
-function getErrorObjectsForRelayModernProblem(errorOrErrors) {
-  if (errorOrErrors.source) {
-    const json = safelyParseJSON(errorOrErrors.source);
-    return json && json.errors && json.errors.length > 0 ? json.errors : null;
-  }
-  return null;
-}
-
 
 /**
  * Safely extract an error object from a transaction
@@ -278,6 +307,7 @@ export { // eslint-disable-line import/no-unused-modules
   getErrorMessageForRelayModernProblem,
   getErrorObjectsForRelayModernProblem,
   getErrorObjects,
+  createFriendlyErrorMessage,
   emojify,
   parseStringUnixTimestamp,
   botName,


### PR DESCRIPTION
The error message popup now has various improvements:

 * better styling overall
 * a user-friendly and localized one-sentence summary of what kind of error occurred, along with the support email address
 * technical data hidden behind a "more info" cut, revealing a `<textarea>` containing easily copy-able technical text
 * a "Report issue" button that auto-fills an Intercom message with brief instructions, a summary, the error code, the URL where it occurred, and the full error message

`CheckError.js` has been updated to inlcude the `CONFLICT` and `PUBLISHED_REPORT` type errors, and all errors now have localized text mappings to user-friendly strings. There is a new `createFriendlyErrorMessage` function in `helpers.js` that generates the summary/details error.

![image](https://user-images.githubusercontent.com/266454/160015338-40d37ca1-ccd2-42df-892d-c41ec749d80f.png)
