### PR TITLE
Keep track of number of in-progress mutation requests

### DIFF
--- a/src/app/CheckNetworkLayer.js
+++ b/src/app/CheckNetworkLayer.js
@@ -56,6 +56,8 @@ class CheckNetworkLayer extends Relay.DefaultNetworkLayer {
     const { setFlashMessage, ...otherOptions } = options;
     super(path, otherOptions);
     this.setFlashMessage = setFlashMessage || (() => null);
+    this.inFlightMutationRequests = 0;
+    window.inFlightMutationRequests = this.inFlightMutationRequests;
   }
 
   _parseQueryResult(result) {
@@ -152,6 +154,8 @@ class CheckNetworkLayer extends Relay.DefaultNetworkLayer {
   }
 
   _sendMutation(request) {
+    this.inFlightMutationRequests += 1;
+    window.inFlightMutationRequests = this.inFlightMutationRequests;
     const _interopRequireDefault = obj => obj && obj.__esModule ? obj : { default: obj };
 
     let init;
@@ -200,6 +204,8 @@ class CheckNetworkLayer extends Relay.DefaultNetworkLayer {
     }, fetchTimeout);
 
     return fetch(this._uri, init).then((response) => {
+      this.inFlightMutationRequests -= 1;
+      window.inFlightMutationRequests = this.inFlightMutationRequests;
       clearTimeout(timeout);
       return throwOnServerError(request, response);
     }).catch((error) => {

--- a/src/app/components/Home.js
+++ b/src/app/components/Home.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import Relay from 'react-relay/classic';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import { withRouter } from 'react-router';
 import Favicon from 'react-favicon';
 import isEqual from 'lodash.isequal';
 import styled from 'styled-components';
@@ -148,6 +149,23 @@ class HomeComponent extends Component {
 
   componentWillMount() {
     this.setContext();
+  }
+
+  componentDidMount() {
+    const currentRoute = this.props.router.routes[this.props.router.routes.length - 1];
+    this.props.router.setRouteLeaveHook(
+      currentRoute,
+      () => {
+        if (window.inFlightMutationRequests > 0) {
+          return this.props.intl.formatMessage({
+            id: 'home.navAwayDuringRequest',
+            defaultMessage: 'You have pending requests to the server. Do you wish to continue to a new page? Your work will not be saved.',
+            description: 'This is a prompt that appears when a user tries to exit a page before saving their work.',
+          });
+        }
+        return true;
+      },
+    );
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -308,7 +326,7 @@ HomeComponent.contextTypes = {
   store: PropTypes.object,
 };
 
-const ConnectedHomeComponent = withSetFlashMessage(withClientSessionId(HomeComponent));
+const ConnectedHomeComponent = withSetFlashMessage(withClientSessionId(withRouter(injectIntl(HomeComponent))));
 
 const HomeContainer = Relay.createContainer(ConnectedHomeComponent, {
   fragments: {

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { browserHistory, withRouter } from 'react-router';
+import { browserHistory } from 'react-router';
 import {
   Box,
   Typography,
@@ -356,4 +356,4 @@ const Tasks = ({
   return output;
 };
 
-export default withSetFlashMessage(withRouter(injectIntl(Tasks)));
+export default withSetFlashMessage(injectIntl(Tasks));


### PR DESCRIPTION
On the network layer, we modify a global `inFlightMutationRequests` variable that lives on `window` and can be accessed from any function. This was the most reasonable solution I could come up with for a small amount of code, even though it doesn't hook into the React lifecycle. The `HomeComponent` now calls `setRouteLeaveHook` with a function that tests to see if the number of in-progress mutation requests is greater than 0, and prompts the user to see if they really want to navigate away.

In the Jira ticket, the wording was to do this whenever _queries_ are still processing, but it doesn't make sense for non-mutation queries. A user should be allowed to navigate away from a page mid-READ, but prompted mid-WRITE.

This also removes an extraneous `withRouter` no longer needed in `Tasks.js` after Alex refactored it to use the `NavigateAwayDialog`. I am not using that new component here because this is a special case where I want the `setRouteLeaveHook` logic to be different and not coupled to the state change of a particular component. If I did that to `HomeComponent`, we would end up constantly rerendering the entire application, so it doesn't make sense here.

Fixes CHECK-1643.