### PR TITLE
Always show "Submitted" column setting, add unit tests, remove integration tests

### DIFF
--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -137,7 +137,7 @@ function SearchResultsComponent({
   hideFields,
   savedSearch,
 }) {
-  const defaultViewMode = window.storage.getValue('viewMode') || 'shorter'; // or "longer"
+  const defaultViewMode = window.storage?.getValue('viewMode') || 'shorter'; // or "longer"
   let pusherChannel = null;
   const [selectedProjectMediaIds, setSelectedProjectMediaIds] = React.useState([]);
   const [query, setQuery] = React.useState(defaultQuery);

--- a/src/app/components/search/SearchResultsTable/index.js
+++ b/src/app/components/search/SearchResultsTable/index.js
@@ -203,7 +203,8 @@ function buildColumnDefs(team, resultType) {
     .filter(({ onlyIfSmoochBotEnabled }) => onlyIfSmoochBotEnabled ? Boolean(team.smooch_bot) : true);
   const columns = [possibleColumns[0]];
   team.list_columns.forEach((listColumn) => {
-    if (listColumn.show) {
+    // Force legacy data to show "Submitted" field
+    if (listColumn.show || listColumn.key === 'created_at_timestamp') {
       let column = possibleColumns.find(c => c.field === listColumn.key);
       if (!column && /^task_value_/.test(listColumn.key)) {
         column = {

--- a/src/app/components/search/SearchResultsTable/index.test.js
+++ b/src/app/components/search/SearchResultsTable/index.test.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import SearchResultsTable from './index';
+
+describe('<SearchResultsTable />', () => {
+  const columns = [
+    {
+      index: 1, key: 'share_count', label: 'FB Shares', show: true,
+    },
+    {
+      index: 2, key: 'linked_items_count', label: 'Similar media', show: false,
+    },
+    {
+      index: 3, key: 'created_at_timestamp', label: 'Submitted', show: false,
+    },
+  ];
+
+  const team = {
+    slug: 'new-team',
+    id: '1',
+    list_columns: columns,
+    smooch_bot: null,
+  };
+  
+  const projectMedias = [
+    {
+      "__dataID__": "1",
+      "id": "1",
+      "dbid": 1,
+      "picture": "",
+      "show_warning_cover": false,
+      "title": "Test title 1",
+      "description": "Test description 1",
+      "is_read": true,
+      "is_main": true,
+      "is_secondary": false,
+      "report_status": "unpublished",
+      "requests_count": 0,
+      "list_columns_values": {
+        "created_at_timestamp": 1646000000,
+        "share_count": 200,
+        "linked_items_count": 10,
+      },
+      "source_id": null,
+      "cluster": null,
+      "project": {
+        "__dataID__": "UHJvamVjdC8y\n",
+        "dbid": 2,
+        "id": "UHJvamVjdC8y\n"
+      },
+    },
+    {
+      "__dataID__": "2",
+      "id": "2",
+      "dbid": 2,
+      "picture": "",
+      "show_warning_cover": false,
+      "title": "Test title 2",
+      "description": "Test description 2",
+      "is_read": true,
+      "is_main": true,
+      "is_secondary": false,
+      "report_status": "unpublished",
+      "requests_count": 0,
+      "list_columns_values": {
+        "created_at_timestamp": 1647000000,
+        "share_count": 200,
+        "linked_items_count": 10,
+      },
+      "source_id": null,
+      "cluster": null,
+      "project": {
+        "__dataID__": "UHJvamVjdC8y\n",
+        "dbid": 2,
+        "id": "UHJvamVjdC8y\n"
+      },
+    },
+  ];
+
+  it('should render hidden/shown columns', () => {
+    const wrapper = mountWithIntl(<SearchResultsTable
+      onChangeSelectedIds={() => {}}
+      onChangeSortParams={() => {}}
+      buildProjectMediaUrl={() => {}}
+      selectedIds={[]}
+      projectMedias={projectMedias}
+      team={team}
+    />);
+    // Use `render()` to get Cheerio object instead of Enzyme so we can run text() on multiple nodes
+    const tableHeaders = wrapper.render().find('th');
+    // "Submitted" must always be shown even if `.show` is false
+    expect(tableHeaders.text()).toContain('Submitted');
+    expect(tableHeaders.text()).not.toContain('Similar media');
+    expect(tableHeaders.text()).toContain('FB Shares');
+  });
+
+  it('should render items in the order given by the API', () => {
+    const wrapper = mountWithIntl(<SearchResultsTable
+      onChangeSelectedIds={() => {}}
+      onChangeSortParams={() => {}}
+      buildProjectMediaUrl={() => {}}
+      selectedIds={[]}
+      projectMedias={projectMedias}
+      team={team}
+    />);
+    expect(wrapper.find('tr').last().text()).toMatch('Test description 2');
+
+    const wrapperSorted = mountWithIntl(<SearchResultsTable
+      onChangeSelectedIds={() => {}}
+      onChangeSortParams={() => {}}
+      buildProjectMediaUrl={() => {}}
+      selectedIds={[]}
+      projectMedias={projectMedias.reverse()}
+      team={team}
+    />);
+    expect(wrapperSorted.find('tr').last().text()).toMatch('Test description 1');
+  });
+
+  it('should render the sorting UX based on sort parameters', () => {
+    const wrapperDescending = mountWithIntl(<SearchResultsTable
+      onChangeSelectedIds={() => {}}
+      onChangeSortParams={() => {}}
+      buildProjectMediaUrl={() => {}}
+      selectedIds={[]}
+      projectMedias={projectMedias}
+      sortParams={{ key: 'recent_added', ascending: false }}
+      team={team}
+    />);
+    expect(wrapperDescending.find('[aria-sort="descending"]')).toHaveLength(1);
+    expect(wrapperDescending.find('[aria-sort="ascending"]')).toHaveLength(0);
+
+    const wrapperAscending = mountWithIntl(<SearchResultsTable
+      onChangeSelectedIds={() => {}}
+      onChangeSortParams={() => {}}
+      buildProjectMediaUrl={() => {}}
+      selectedIds={[]}
+      projectMedias={projectMedias}
+      sortParams={{ key: 'recent_added', ascending: true }}
+      team={team}
+    />);
+    expect(wrapperAscending.find('[aria-sort="ascending"]')).toHaveLength(1);
+    expect(wrapperAscending.find('[aria-sort="descending"]')).toHaveLength(0);
+  });
+});

--- a/test/spec/search_spec.rb
+++ b/test/spec/search_spec.rb
@@ -104,24 +104,6 @@ shared_examples 'search' do
     expect(@driver.page_source.include?('My search result')).to be(true)
   end
 
-  it 'should search and change sort order', bin2: true do
-    api_create_claim_and_go_to_search_page
-    expect(@driver.current_url.to_s.match(/ASC|DESC/).nil?).to be(true)
-
-    wait_for_selector('#search-input')
-    wait_for_selector('th[data-field=linked_items_count]').click
-    wait_for_selector('.media__heading', :css, 20, true)
-    expect(@driver.current_url.to_s.match(/DESC/).nil?).to be(false)
-    expect(@driver.current_url.to_s.match(/ASC/).nil?).to be(true)
-    expect(@driver.page_source.include?('My search result')).to be(true)
-
-    wait_for_selector('th[data-field=linked_items_count]').click
-    wait_for_selector('.media__heading', :css, 20, true)
-    expect(@driver.current_url.to_s.match(/DESC/).nil?).to be(true)
-    expect(@driver.current_url.to_s.match(/ASC/).nil?).to be(false)
-    expect(@driver.page_source.include?('My search result')).to be(true)
-  end
-
   it 'should search by status through URL', bin1: true do
     api_create_claim_and_go_to_search_page
     expect((@driver.title =~ /False/).nil?).to be(true)
@@ -212,21 +194,6 @@ shared_examples 'search' do
     current = wait_for_selector_list('.medias__item').length
     expect(old == current).to be(true)
     expect(current.positive?).to be(true)
-  end
-
-  it 'should sort by submission order', bin1: true do
-    api_create_team_project_claims_sources_and_redirect_to_project_page({ count: 2 })
-    wait_for_selector_list('.medias__item')
-    claim1 = wait_for_selector_list('h4')[0].text
-    claim2 = wait_for_selector_list('h4')[1].text
-    expect(claim1 == 'Claim 1').to be(true)
-    expect(claim2 == 'Claim 0').to be(true)
-    wait_for_selector("//span[contains(text(), 'Submitted')]", :xpath).click
-    wait_for_text_change('Claim 1', 'h4')
-    claim1 = wait_for_selector_list('h4')[0].text
-    claim2 = wait_for_selector_list('h4')[1].text
-    expect(claim1 == 'Claim 0').to be(true)
-    expect(claim2 == 'Claim 1').to be(true)
   end
 
   # commented until #CHECK-852 be fixed


### PR DESCRIPTION
We made a design decision to always show the "Submitted" column setting. But there are some cases where workspaces that are older than our decision had it explicitly turned off, which means its `show` value was `false`. This commit makes a column setting show if it has the correct key value for the "Submitted" column, `created_at_timestamp` (the key is independent of localization).

I added a unit test for the functionality where the "Submitted" column setting should lack a show/hide button.

We are also replacing several integration tests with unit tests here. There is an integration test that checks to see if clicking the "Submitted" field changes the sort direction. The actual sorting is up to `check-api` and not `check-web`, so assuming that sorting is well-tested on `check-api`, this is now replaced with a unit test that makes sure the UI widget displays the correct direction when sort direction is changed via the URL (since ultimately all sorting action triggers a url change, then a call to the API, then a render of elements clientside). I've also removed a test (`should search and change sort order`) that was redundant to the unit test once we consider how the search and sort logic works.

Writing the unit tests also caught a small bug with unsafe object property access that has been fixed.