### PR TITLE
Update default sort on suggested matches page, mock relay unit tests

### DIFF
--- a/src/app/components/search/Search.js
+++ b/src/app/components/search/Search.js
@@ -134,7 +134,7 @@ Search.propTypes = {
   title: PropTypes.node.isRequired,
   icon: PropTypes.node,
   hideFields: PropTypes.arrayOf(PropTypes.string.isRequired), // or undefined
-  page: PropTypes.oneOf(['trash', 'collection', 'list', 'folder']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['trash', 'collection', 'list', 'folder', 'suggested-matches']), // FIXME find a cleaner way to render Trash differently
   query: PropTypes.object.isRequired, // may be empty
   showExpand: PropTypes.bool,
   resultType: PropTypes.string, // 'default' or 'trends', for now

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -33,7 +33,7 @@ const SuggestedMatches = ({ routeParams }) => (
           } else {
             query = {
               suggestions_count: { min: 1 },
-              sort: 'suggestions_count',
+              sort: 'recent_added',
               sort_type: 'DESC',
               ...safelyParseJSON(routeParams.query, {}),
             };

--- a/src/app/components/team/SuggestedMatches.test.js
+++ b/src/app/components/team/SuggestedMatches.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import SuggestedMatches from './SuggestedMatches';
+
+describe('<SuggestedMatches />', () => {
+  const team = 'new-team';
+
+  it('should sort Submitted descending by default', () => {
+    const wrapper = mountWithIntl(<SuggestedMatches
+      routeParams={{ team }}
+    />);
+
+    const renderedMockSearch = wrapper.find('ReactRelayQueryRenderer').props().render(
+      {
+        error: false,
+        props: {
+          team,
+        },
+      },
+    );
+
+    expect(renderedMockSearch.props.query.sort).toBe('recent_added');
+  });
+});


### PR DESCRIPTION
This commit changes the default sort on the `/suggested-matches/` route to "Submitted" (`recent_added`).

Added a unit test and picked up and fixed an additional minor bug in the `propTypes` for the `Search` component.

Note on testing: by running the `render` component of a `ReactRelayQueryRenderer` and passing in the appropriate `error` and `props` in a object as an argument to `render`, we can mock the relay renderer and do things like inspect derived properties on the rendered component.

```js
    const renderedMockSearch = wrapper.find('ReactRelayQueryRenderer').props().render(
      {
        error: false,
        props: {
          team,
        },
      },
    );
```

Fixes CHECK-1782.