### PR TITLE
Remove depends on chromedriver from check web in docker-test file

### DIFF
--- a/docker-test.yml
+++ b/docker-test.yml
@@ -34,8 +34,6 @@ services:
       BOILERPLATE_ENV: test
       ALEGRE_PORT: 5000
   web:
-    depends_on:
-      - chromedriver
     environment:
       PLATFORM: web
       NODE_ENV: development


### PR DESCRIPTION
Remove dependacy to up only check web container when running only unit tests

Reference: CHECK-1765