### PR TITLE
Refactor Bot Resource Editor

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotResourceEditor.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotResourceEditor.json
@@ -4,6 +4,11 @@
     "defaultMessage": "Public URL that returns N articles in RSS format"
   },
   {
+    "id": "smoochBotResourceEditor.addContent",
+    "description": "Placeholder for manual content entry",
+    "defaultMessage": "Type something"
+  },
+  {
     "id": "smoochBotResourceEditor.error",
     "defaultMessage": "This URL does not seem to be a valid RSS feed"
   },
@@ -12,12 +17,19 @@
     "defaultMessage": "Bot resource title"
   },
   {
-    "id": "smoochBotResourceEditor.addContent",
-    "defaultMessage": "Add content manually"
+    "id": "smoochBotResourceEditor.content",
+    "description": "Header for the bot resource's content textfield",
+    "defaultMessage": "Content"
+  },
+  {
+    "id": "smoochBotResourceEditor.charsCounter",
+    "description": "Counter that shows how many characters can still be input for the tipline content",
+    "defaultMessage": "{count}/{max} characters available"
   },
   {
     "id": "smoochBotResourceEditor.rss",
-    "defaultMessage": "Add content from RSS feed"
+    "description": "Label of switch that toggles loading of content from a RSS feed",
+    "defaultMessage": "Load content from RSS feed"
   },
   {
     "id": "smoochBotResourceEditor.url",
@@ -33,6 +45,6 @@
   },
   {
     "id": "smoochBotResourceEditor.delete",
-    "defaultMessage": "Delete"
+    "defaultMessage": "Delete resource"
   }
 ]

--- a/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
@@ -10,6 +10,8 @@ import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Typography from '@material-ui/core/Typography';
 import CancelOutlinedIcon from '@material-ui/icons/CancelOutlined';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import SmoochBotPreviewFeed from './SmoochBotPreviewFeed';
 import ParsedText from '../../ParsedText';
 
@@ -50,6 +52,11 @@ const messages = defineMessages({
     id: 'smoochBotResourceEditor.rssPlaceholder',
     defaultMessage: 'Public URL that returns N articles in RSS format',
   },
+  typeHere: {
+    id: 'smoochBotResourceEditor.addContent',
+    defaultMessage: 'Type something',
+    description: 'Placeholder for manual content entry',
+  },
 });
 
 const SmoochBotResourceEditor = ({
@@ -66,7 +73,18 @@ const SmoochBotResourceEditor = ({
   const [count, setCount] = React.useState(resource.smooch_custom_resource_number_of_articles);
   const [refetch, setRefetch] = React.useState(1);
   const [loading, setLoading] = React.useState(false);
+  const [rssEnabled, setRssEnabled] = React.useState(Boolean(url));
   const [rssPreview, setRssPreview] = React.useState(null);
+  const [introduction, setIntroduction] = React.useState(resource.smooch_custom_resource_body);
+
+  const maxCharacters = 1024;
+  let charactersCount = 0;
+  if (introduction) {
+    charactersCount += introduction.length;
+  }
+  if (rssPreview) {
+    charactersCount += rssPreview.length;
+  }
 
   // Clear state when coming from another resource
   React.useEffect(() => {
@@ -105,6 +123,16 @@ const SmoochBotResourceEditor = ({
     onChange('smooch_custom_resource_feed_url', '');
   };
 
+  const handleToggleRss = (event) => {
+    const enabled = event.target.checked;
+    setRssEnabled(enabled);
+    if (enabled) {
+      onChange('smooch_custom_resource_feed_url', '');
+    } else {
+      handleReset();
+    }
+  };
+
   return (
     <React.Fragment>
       <Box display="flex" flexWrap="wrap">
@@ -125,20 +153,37 @@ const SmoochBotResourceEditor = ({
             variant="outlined"
             fullWidth
           /> : null }
-
+        <Box ml={1}>
+          <Typography>
+            <strong>
+              <FormattedMessage
+                id="smoochBotResourceEditor.content"
+                defaultMessage="Content"
+                description="Header for the bot resource's content textfield"
+              />
+            </strong>
+          </Typography>
+          <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: 'red' } : {}}>
+            <FormattedMessage
+              id="smoochBotResourceEditor.charsCounter"
+              defaultMessage="{count}/{max} characters available"
+              description="Counter that shows how many characters can still be input for the tipline content"
+              values={{
+                count: maxCharacters - charactersCount,
+                max: maxCharacters,
+              }}
+            />
+          </Typography>
+        </Box>
         <TextField
           key={Math.random().toString().substring(2, 10)}
-          label={
-            <FormattedMessage
-              id="smoochBotResourceEditor.addContent"
-              defaultMessage="Add content manually"
-            />
-          }
+          placeholder={intl.formatMessage(messages.typeHere)}
           className={classes.spaced}
           defaultValue={resource.smooch_custom_resource_body}
           onBlur={(event) => {
             onChange('smooch_custom_resource_body', event.target.value);
           }}
+          onChange={(e) => { setIntroduction(e.target.value); }}
           variant="outlined"
           rows={5}
           rowsMax={Infinity}
@@ -167,75 +212,87 @@ const SmoochBotResourceEditor = ({
             onSuccess={handleSuccess}
           /> : null }
       </Box>
-
-      <Typography variant="subtitle2" component="div" className={classes.title}>
-        <FormattedMessage
-          id="smoochBotResourceEditor.rss"
-          defaultMessage="Add content from RSS feed"
-        />
-      </Typography>
-      <Box display="flex" justifyContent="space-between" alignItems={error ? 'baseline' : 'center'}>
-        <TextField
-          key={Math.random().toString().substring(2, 10)}
-          label={
-            <FormattedMessage
-              id="smoochBotResourceEditor.url"
-              defaultMessage="URL"
+      <Box mb={3} mt={2} ml={1}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={rssEnabled}
+              onChange={handleToggleRss}
             />
           }
-          placeholder={intl.formatMessage(messages.rssPlaceholder)}
-          className={classes.spaced}
-          defaultValue={resource.smooch_custom_resource_feed_url}
-          onBlur={(event) => {
-            let feedUrl = event.target.value.trim();
-            if (feedUrl !== '' && !/^https?:\/\//.test(feedUrl)) {
-              feedUrl = `https://${feedUrl}`;
-            }
-            onChange('smooch_custom_resource_feed_url', feedUrl);
-          }}
-          error={Boolean(error)}
-          helperText={error}
-          variant="outlined"
-          fullWidth
-        />
-
-        <TextField
-          key={Math.random().toString().substring(2, 10)}
-          type="number"
           label={
             <FormattedMessage
-              id="smoochBotResourceEditor.numberOfArticles"
-              defaultMessage="Number of articles to return"
+              id="smoochBotResourceEditor.rss"
+              defaultMessage="Load content from RSS feed"
+              description="Label of switch that toggles loading of content from a RSS feed"
             />
           }
-          className={classes.spaced}
-          defaultValue={resource.smooch_custom_resource_number_of_articles || 0}
-          onBlur={(event) => {
-            onChange('smooch_custom_resource_number_of_articles', parseInt(event.target.value, 10));
-          }}
-          inputProps={{ step: 1, min: 1, max: 50 }}
-          variant="outlined"
-          fullWidth
         />
-
-        <Button variant="contained" color="primary" className={classes.spaced} onClick={handleLoad} disabled={loading}>
-          <FormattedMessage
-            id="smoochBotResourceEditor.load"
-            defaultMessage="Load"
-          />
-        </Button>
-
-        <IconButton onClick={handleReset}>
-          <CancelOutlinedIcon className={classes.icon} />
-        </IconButton>
       </Box>
+      { rssEnabled ?
+        <Box display="flex" justifyContent="space-between" alignItems={error ? 'baseline' : 'center'}>
+          <TextField
+            key={Math.random().toString().substring(2, 10)}
+            label={
+              <FormattedMessage
+                id="smoochBotResourceEditor.url"
+                defaultMessage="URL"
+              />
+            }
+            placeholder={intl.formatMessage(messages.rssPlaceholder)}
+            className={classes.spaced}
+            defaultValue={resource.smooch_custom_resource_feed_url}
+            onBlur={(event) => {
+              let feedUrl = event.target.value.trim();
+              if (feedUrl !== '' && !/^https?:\/\//.test(feedUrl)) {
+                feedUrl = `https://${feedUrl}`;
+              }
+              onChange('smooch_custom_resource_feed_url', feedUrl);
+            }}
+            error={Boolean(error)}
+            helperText={error}
+            variant="outlined"
+            fullWidth
+          />
+
+          <TextField
+            key={Math.random().toString().substring(2, 10)}
+            type="number"
+            label={
+              <FormattedMessage
+                id="smoochBotResourceEditor.numberOfArticles"
+                defaultMessage="Number of articles to return"
+              />
+            }
+            className={classes.spaced}
+            defaultValue={resource.smooch_custom_resource_number_of_articles || 0}
+            onBlur={(event) => {
+              onChange('smooch_custom_resource_number_of_articles', parseInt(event.target.value, 10));
+            }}
+            inputProps={{ step: 1, min: 1, max: 50 }}
+            variant="outlined"
+            fullWidth
+          />
+
+          <Button variant="contained" color="primary" className={classes.spaced} onClick={handleLoad} disabled={loading}>
+            <FormattedMessage
+              id="smoochBotResourceEditor.load"
+              defaultMessage="Load"
+            />
+          </Button>
+
+          <IconButton onClick={handleReset}>
+            <CancelOutlinedIcon className={classes.icon} />
+          </IconButton>
+        </Box>
+        : null }
 
       { onDelete ?
         <Box display="flex">
           <Button variant="outlined" onClick={onDelete} className={classes.spaced}>
             <FormattedMessage
               id="smoochBotResourceEditor.delete"
-              defaultMessage="Delete"
+              defaultMessage="Delete resource"
             />
           </Button>
         </Box> : null }


### PR DESCRIPTION
This commit changes SmoochBotResourceEditor.js to be more similar to SmoochBotNewsletterEditor.js.
This means adding an available character count for the resource body and a toggle for enabling the RSS feeds.
A few minor copy changes were made too:
- Changed body input placeholder to => 'Type something'
- Changed Delete button label to => 'Delete resource'