### PR TITLE
Improve search input performance

### DIFF
--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -62,6 +62,7 @@ const SearchField = ({
   const [expand, setExpand] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [expandedText, setExpandedText] = React.useState(searchText);
+  const [localSearchText, setLocalSearchText] = React.useState(searchText);
 
   function handleExpand(event) {
     setExpand(true);
@@ -88,11 +89,22 @@ const SearchField = ({
             name="search-input"
             id="search-input"
             {...inputBaseProps}
-            onChange={(e) => {
+            onBlur={(e) => {
               setParentSearchText(e.target.value);
               inputBaseProps.onChange(e);
             }}
-            value={searchText}
+            onChange={(e) => {
+              setLocalSearchText(e.target.value);
+              inputBaseProps.onChange(e);
+            }}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') {
+                setParentSearchText(e.target.value);
+                setLocalSearchText(e.target.value);
+                inputBaseProps.onChange(e);
+              }
+            }}
+            value={localSearchText}
             InputProps={{
               disableUnderline: true,
               startAdornment: (

--- a/src/app/components/search/SearchKeyword.js
+++ b/src/app/components/search/SearchKeyword.js
@@ -221,7 +221,7 @@ class SearchKeyword extends React.Component {
                 return status ? status.label : '';
               })
               : [],
-            query.keyword,
+            this.initialQuery?.keyword,
             query.tags,
           // Remove empty entries
           // http://stackoverflow.com/a/19888749/209184
@@ -323,7 +323,6 @@ class SearchKeyword extends React.Component {
       projects = team.projects.edges.slice().sort((a, b) =>
         a.node.title.localeCompare(b.node.title));
     }
-
     const title = (this.filterIsActive() || this.keywordIsActive())
       ? this.title(statuses, projects)
       : (this.props.title || (this.props.project ? this.props.project.title : null));
@@ -391,8 +390,7 @@ class SearchKeyword extends React.Component {
                     setParentSearchText={this.setSearchText}
                     searchText={this.props.query.keyword || ''}
                     inputBaseProps={{
-                      defaultValue: this.props.query.keyword || '',
-                      onChange: this.handleInputChange,
+                      onBlur: this.handleInputChange,
                       ref: this.searchInput,
                       disabled: this.state.imgData.data.length > 0,
                     }}
@@ -560,6 +558,10 @@ SearchKeyword.propTypes = {
   cleanupQuery: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
 };
+
+
+// eslint-disable-next-line import/no-unused-modules
+export { SearchKeyword as SearchKeywordTest };
 
 export default createFragmentContainer(withStyles(styles)(withPusher(SearchKeyword)), graphql`
   fragment SearchKeyword_team on Team {

--- a/src/app/components/search/SearchKeyword.test.js
+++ b/src/app/components/search/SearchKeyword.test.js
@@ -25,10 +25,10 @@ describe('<SearchKeyword />', () => {
       classes={{}}
       team={team}
       pusher={{
-        subscribe: () => { return () => { return null;} },
+        subscribe: () => () => null,
         unsubscribe: () => {},
       }}
-      project={{project}}
+      project={project}
       query={{
         keyword: 'search keyword',
       }}
@@ -46,7 +46,7 @@ describe('<SearchKeyword />', () => {
       classes={{}}
       team={team}
       pusher={{
-        subscribe: () => { return () => { return null;} },
+        subscribe: () => () => null,
         unsubscribe: () => {},
       }}
       project={project}

--- a/src/app/components/search/SearchKeyword.test.js
+++ b/src/app/components/search/SearchKeyword.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { SearchKeywordTest } from './SearchKeyword';
+
+describe('<SearchKeyword />', () => {
+  const team = {
+    dbid: 123,
+    name: 'new-team',
+    slug: 'new-team',
+    pusher_channel: 'pusher',
+    verification_statuses: {
+      statuses: [{
+        id: 'one',
+        label: 'one',
+      }],
+    },
+  };
+
+  const project = {
+    title: 'project-title',
+  };
+
+  it('should render with title set to initial keyword', () => {
+    const wrapper = mountWithIntl(<SearchKeywordTest
+      classes={{}}
+      team={team}
+      pusher={{
+        subscribe: () => { return () => { return null;} },
+        unsubscribe: () => {},
+      }}
+      project={{project}}
+      query={{
+        keyword: 'search keyword',
+      }}
+      clientSessionId=""
+      setQuery={() => {}}
+      cleanupQuery={() => {}}
+      handleSubmit={() => {}}
+    />);
+
+    expect(wrapper.find('PageTitle').props().prefix).toBe('search keyword');
+  });
+
+  it('should render with title set to project title when no query keyword present', () => {
+    const wrapper = mountWithIntl(<SearchKeywordTest
+      classes={{}}
+      team={team}
+      pusher={{
+        subscribe: () => { return () => { return null;} },
+        unsubscribe: () => {},
+      }}
+      project={project}
+      query={{}}
+      clientSessionId=""
+      setQuery={() => {}}
+      cleanupQuery={() => {}}
+      handleSubmit={() => {}}
+    />);
+
+    expect(wrapper.find('PageTitle').props().prefix).toBe('project-title');
+  });
+});
+


### PR DESCRIPTION
Altered `SearchField` so it only updates the parent `query` value onBlur (on on an 'Enter' keypress) instead of onClick. This avoids rerendering the entire search page on each button press.

This also removes a side effect that caused the `<title>` of the page to update with each keypress (since the `PageTitle` is bound to `query` in `SearchKeyword`).

Add unit tests for basic page title rendering.

I want to draw attention to the footer of `SearchKeyword.js` where I do the following:

```js
// eslint-disable-next-line import/no-unused-modules
export { SearchKeyword as SearchKeywordTest };
```

This means we export the core component without its graphql fragment container, allowing us to mock any of the variables that would be passed by graphql. This way we are testing the component itself and not Relay.