### PR TITLE
Fix CloudFlare cache clear script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-cf-clear
 
 deploy_qa:
   image: python:3-alpine
@@ -42,6 +43,7 @@ deploy_qa:
     - sh scripts/clear-cf-cache.sh qa
   only:
     - develop
+    - fix-cf-clear
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-cf-clear
 
 deploy_qa:
   image: python:3-alpine
@@ -43,7 +42,6 @@ deploy_qa:
     - sh scripts/clear-cf-cache.sh qa
   only:
     - develop
-    - fix-cf-clear
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
-    - bash scripts/clear-cf-cache.sh qa
+    - sh scripts/clear-cf-cache.sh qa
   only:
     - develop
 
@@ -81,6 +81,6 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
-    - bash scripts/clear-cf-cache.sh live
+    - sh scripts/clear-cf-cache.sh live
   only:
     - master


### PR DESCRIPTION
The build environments may use a minimal shell like busybox instead of bash. Handle accordingly.