### PR TITLE
Show placeholder tag when deleted filter selected

### DIFF
--- a/localization/react-intl/src/app/components/search/MultiSelectFilter.json
+++ b/localization/react-intl/src/app/components/search/MultiSelectFilter.json
@@ -10,6 +10,11 @@
     "defaultMessage": "or"
   },
   {
+    "id": "filter.tag.deleted",
+    "description": "Message shown a placeholder when someone tries to filter a search by a property that the user has deleted",
+    "defaultMessage": "Property deleted"
+  },
+  {
     "id": "multiSelector.search",
     "defaultMessage": "Search…"
   },

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -10,7 +10,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { MultiSelector } from '@meedan/check-ui';
 import RemoveableWrapper from './RemoveableWrapper';
 import SelectButton from './SelectButton';
-import { checkBlue } from '../../styles/js/shared';
+import { checkBlue, checkError } from '../../styles/js/shared';
 
 const NoHoverButton = withStyles({
   root: {
@@ -74,6 +74,9 @@ const useTagStyles = makeStyles({
       height: '24px',
     },
   },
+  missingProperty: {
+    backgroundColor: checkError,
+  },
 });
 
 const Tag = ({
@@ -83,9 +86,18 @@ const Tag = ({
   ...props
 }) => {
   const classes = useTagStyles();
-  return (
+  return label ? (
     <div className={`multi-select-filter__tag ${classes.root}`} {...props}>
       <span>{label}</span>
+      { readOnly ? null : (
+        <CloseIcon className="multi-select-filter__tag-remove" onClick={onDelete} />
+      )}
+    </div>
+  ) : (
+    <div className={`multi-select-filter__tag ${classes.root} ${classes.missingProperty}`} {...props}>
+      <span>
+        <FormattedMessage id="filter.tag.deleted" defaultMessage="Property deleted" description="Message shown a placeholder when someone tries to filter a search by a property that the user has deleted" />
+      </span>
       { readOnly ? null : (
         <CloseIcon className="multi-select-filter__tag-remove" onClick={onDelete} />
       )}
@@ -150,7 +162,6 @@ const MultiSelectFilter = ({
     setVersion(version + 1); // Force refresh of wrapper component
     onChange(value);
   };
-
 
   return (
     <div>
@@ -258,7 +269,6 @@ const CustomSelectDropdown = ({
 MultiSelectFilter.defaultProps = {
   allowSearch: true,
   extraInputs: null,
-  icon: null,
   selected: [],
   onToggleOperator: null,
   readOnly: false,
@@ -274,8 +284,9 @@ MultiSelectFilter.propTypes = {
     PropTypes.string,
   ])).isRequired,
   label: PropTypes.node.isRequired,
-  icon: PropTypes.element,
+  icon: PropTypes.element.isRequired,
   onChange: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
   selected: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,

--- a/src/app/components/search/MultiSelectFilter.test.js
+++ b/src/app/components/search/MultiSelectFilter.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import CloseIcon from '@material-ui/icons/Close';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import MultiSelectFilter from './MultiSelectFilter';
+
+describe('<MultiSelectFilter />', () => {
+  const options = [
+    { value: 'first', label: 'First' },
+    { value: 'second', label: 'Second' },
+    { value: 'third', label: 'Third' },
+  ];
+
+  it('should render a selected option', () => {
+    const wrapper = mountWithIntl(<MultiSelectFilter
+      selected={['second']}
+      label="bar"
+      options={options}
+      onChange={() => {}}
+      onRemove={() => {}}
+      icon={<CloseIcon />}
+    />);
+
+    expect(wrapper.find('Tag').text()).toBe('Second');
+  });
+
+  it('should render a special "Property deleted" tag if an unavailable option is selected', () => {
+    const wrapper = mountWithIntl(<MultiSelectFilter
+      selected={['foo']}
+      label="bar"
+      options={options}
+      onChange={() => {}}
+      onRemove={() => {}}
+      icon={<CloseIcon />}
+    />);
+
+    expect(wrapper.find('Tag').text()).toBe('Property deleted');
+  });
+});
+

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -11,6 +11,7 @@ export const white = '#ffffff';
 export const black = '#000000';
 export const alertRed = '#d0021b';
 export const checkBlue = '#2e77fc';
+export const checkError = '#fa555f';
 export const inProgressYellow = '#efac51';
 export const completedGreen = '#5cae73';
 export const separationGray = '#E5E5E5';


### PR DESCRIPTION
If a user did something like create a new Status type, make a filter based on that Status, and then delete the Status, the filter would still show up just as a blank. This replaces the blank tag with a red "Property deleted" tag to notify the user.

Added tests, and added a `checkError` color value since we have a new "brandError" red color in Figma. Fixed some missing PropType declarations, too.

I checked the integration tests and there were no tests duplicating these unit tests so I left them alone.

Fixes CHECK-1396.