### PR TITLE
Fixes onChange is not a function

### DIFF
--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -91,17 +91,16 @@ const SearchField = ({
             {...inputBaseProps}
             onBlur={(e) => {
               setParentSearchText(e.target.value);
-              inputBaseProps.onChange(e);
+              inputBaseProps.onBlur(e);
             }}
             onChange={(e) => {
               setLocalSearchText(e.target.value);
-              inputBaseProps.onChange(e);
             }}
             onKeyPress={(e) => {
               if (e.key === 'Enter') {
                 setParentSearchText(e.target.value);
                 setLocalSearchText(e.target.value);
-                inputBaseProps.onChange(e);
+                inputBaseProps.onBlur(e);
               }
             }}
             value={localSearchText}


### PR DESCRIPTION
Per some earlier refactoring, `onChanged` ceased to be passed from `SearchKeyword` to `SearchField`.
This commit replaces the usage of `onChange` by `onBlur` to update the parent component.

Fixes CHECK-1844