### PR TITLE
Use the new information field for newsletter schedule.

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.json
@@ -13,7 +13,7 @@
   },
   {
     "id": "smoochBotNewsletterEditor.active",
-    "defaultMessage": "The newsletter will be sent to {count} users on {date}, {time}"
+    "defaultMessage": "The newsletter will be sent to {count} users on {dateTime}"
   },
   {
     "id": "smoochBotNewsletterEditor.none",

--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
@@ -221,11 +221,10 @@ const SmoochBotNewsletterEditor = ({
                 /> :
                 <FormattedMessage
                   id="smoochBotNewsletterEditor.active"
-                  defaultMessage="The newsletter will be sent to {count} users on {date}, {time}"
+                  defaultMessage="The newsletter will be sent to {count} users on {dateTime}"
                   values={{
                     count: newsletterInformation.subscribers_count,
-                    date: newsletterInformation.next_date,
-                    time: newsletterInformation.next_time,
+                    dateTime: newsletterInformation.next_date_and_time,
                   }}
                 /> }
             </Typography>


### PR DESCRIPTION
The backend has changed and now instead of two fields (date and time), that information is coming in a single field.

Fixes CHECK-1883.