### PR TITLE
On report designer, show either the text report or the image report.

### DIFF
--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -201,7 +201,7 @@ const ReportDesignerForm = (props) => {
               />
             </Box> : null }
 
-          { data.use_visual_card ?
+          { data.use_visual_card && !data.use_text_message ?
             <Box>
               <TextField
                 key={`headline-${data.language}`}

--- a/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
@@ -172,7 +172,7 @@ const ReportDesignerPreview = (props) => {
             />
           )}
         </Box> : null }
-      { data.use_visual_card ?
+      { data.use_visual_card && !data.use_text_message ?
         <Box className={classes.visualCardPreview}>
           <ReportDesignerImagePreview
             style={{


### PR DESCRIPTION
This is mostly for legacy reasons, since today it's not possible, on the frontend side, to create both text report and visual card for the same item. But for some existing data, some items have both a text report and a visual card. Let's be sure that only one is displayed for those cases.

Fixes CHECK-1897.