### PR TITLE
Fix/1874 unexpected error filtered list

### DIFF
--- a/src/app/components/search/CustomFiltersManager.js
+++ b/src/app/components/search/CustomFiltersManager.js
@@ -104,6 +104,8 @@ const CustomFiltersManager = ({
   const filterFields = filters.map((filter, i) => {
     if (filter.id) { // TODO: Have each metadata/task type return its appropriate widget (e.g.: choice/date/location/number)
       const teamTask = teamTasks.find(tt => tt.node.dbid.toString() === filter.id);
+      if (!teamTask) return null;
+
       let options = [...fixedOptions];
       if (filter.task_type === 'datetime') {
         options.push({ label: intl.formatMessage(messages.dateRange), value: 'DATE_RANGE', exclusive: true });
@@ -231,6 +233,9 @@ CustomFiltersManager.propTypes = {
     })),
   }).isRequired,
 };
+
+// eslint-disable-next-line import/no-unused-modules
+export { CustomFiltersManager as CustomFiltersManagerTest };
 
 export default createFragmentContainer(injectIntl(CustomFiltersManager), graphql`
   fragment CustomFiltersManager_team on Team {

--- a/src/app/components/search/CustomFiltersManager.js
+++ b/src/app/components/search/CustomFiltersManager.js
@@ -77,11 +77,12 @@ const CustomFiltersManager = ({
 
   const handleSelectMetadataField = (val, index) => {
     const teamTask = teamTasks.find(tt => tt.node.dbid.toString() === val);
-
-    handleTeamTaskFilterChange({
-      id: val,
-      task_type: teamTask.node.type,
-    }, index);
+    if (teamTask) {
+      handleTeamTaskFilterChange({
+        id: val,
+        task_type: teamTask.node.type,
+      }, index);
+    }
   };
 
   const filters = query.team_tasks && query.team_tasks.length > 0 ? query.team_tasks : [{}];
@@ -197,19 +198,20 @@ const CustomFiltersManager = ({
 
   return (
     <Box display="flex" alignItems="center" flexWrap="wrap">
-      { filterFields.map((key, index) => {
+      { filterFields.map((component, index) => {
+        const key = filters[index]?.id || 'new-filter';
         if (index > 0) {
           return (
             <React.Fragment key={key}>
               { operatorToggle }
-              { key }
+              { component }
             </React.Fragment>
           );
         }
 
         return (
           <span key={key}>
-            { key }
+            { component }
           </span>
         );
       })}
@@ -228,7 +230,10 @@ CustomFiltersManager.propTypes = {
   query: PropTypes.shape({
     team_tasks: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string,
-      response: PropTypes.string,
+      response: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.array,
+      ]),
       task_type: PropTypes.string,
     })),
   }).isRequired,

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -287,10 +287,10 @@ MultiSelectFilter.propTypes = {
   icon: PropTypes.element.isRequired,
   onChange: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
-  selected: PropTypes.arrayOf(PropTypes.oneOfType([
-    PropTypes.object,
+  selected: PropTypes.oneOfType([
+    PropTypes.array,
     PropTypes.string,
-  ])),
+  ]),
   onToggleOperator: PropTypes.func,
   readOnly: PropTypes.bool,
   onType: PropTypes.func,


### PR DESCRIPTION
Guard against no task selected and fix prop-types

Fix `handleSelectMetadataField` to make sure no error is thrown when val doesn't match a teamTask dbid. (E.g. not selecting a task).
Also fix React key for components mapped in filterFields. Keys were all [object Object], wrongly.
Finally, fix a couple of PropTypes which were causing prop validation errors.

Fixes CHECK-1874