### PR TITLE
Differentiate similarity icons in item list view

### DIFF
--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -662,6 +662,8 @@ const SearchResultsContainer = Relay.createContainer(withStyles(Styles)(withPush
               is_read
               is_main
               is_secondary
+              is_suggested
+              is_confirmed
               report_status # Needed by BulkActionsStatus
               requests_count
               list_columns_values

--- a/src/app/components/search/SearchResultsTable/TitleCell.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.js
@@ -2,11 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import TableCell from '@material-ui/core/TableCell';
-import LayersIcon from '@material-ui/icons/Layers';
+import ContentCopyIcon from '@material-ui/icons/ContentCopy';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import { Link } from 'react-router';
 import { makeStyles } from '@material-ui/core/styles';
-import { units, black87, checkBlue, opaqueBlack54, opaqueBlack87 } from '../../../styles/js/shared';
+import {
+  units,
+  black87,
+  checkBlue,
+  checkOrange,
+  opaqueBlack54,
+  opaqueBlack87,
+} from '../../../styles/js/shared';
 
 const isTrendsPage = () => (/\/trends/.test(window.location.pathname));
 
@@ -116,15 +123,23 @@ const MaybeLink = ({ to, className, children }) => {
   return <span className={className}>{children}</span>;
 };
 
-const IconOrNothing = ({ isMain, isSecondary, className }) => {
+const IconOrNothing = ({
+  isMain,
+  isConfirmed,
+  isSuggested,
+  className,
+}) => {
   if (isTrendsPage()) {
     return null;
   }
   if (isMain) {
-    return <LayersIcon style={{ color: checkBlue }} className={className} />;
+    return <ContentCopyIcon style={{ color: checkBlue }} className={`${className} similarity-is-main`} />;
   }
-  if (isSecondary) {
-    return <LayersIcon style={{ transform: 'rotate(180deg)' }} className={className} />;
+  if (isConfirmed) {
+    return <ContentCopyIcon style={{ transform: 'rotate(180deg)' }} className={`${className} similarity-is-confirmed`} />;
+  }
+  if (isSuggested) {
+    return <ContentCopyIcon style={{ color: checkOrange }} className={`${className} similarity-is-suggested`} />;
   }
   return null;
 };
@@ -137,7 +152,8 @@ const TitleCell = ({ projectMedia, projectMediaUrl, viewMode }) => {
     show_warning_cover: maskContent,
     is_read: isRead,
     is_main: isMain,
-    is_secondary: isSecondary,
+    is_suggested: isSuggested,
+    is_confirmed: isConfirmed,
   } = projectMedia;
   const classes = useStyles({ isRead });
 
@@ -155,7 +171,7 @@ const TitleCell = ({ projectMedia, projectMediaUrl, viewMode }) => {
             classes={classes}
             title={
               <React.Fragment>
-                <IconOrNothing isMain={isMain} isSecondary={isSecondary} className={classes.similarityIcon} />
+                <IconOrNothing isMain={isMain} isConfirmed={isConfirmed} isSuggested={isSuggested} className={classes.similarityIcon} />
                 {title}
               </React.Fragment>
             }
@@ -178,7 +194,8 @@ TitleCell.propTypes = {
     picture: PropTypes.string, // thumbnail URL or null
     is_read: PropTypes.bool, // or null
     is_main: PropTypes.bool, // or null
-    is_secondary: PropTypes.bool, // or null
+    is_confirmed: PropTypes.bool, // or null
+    is_suggested: PropTypes.bool, // or null
   }).isRequired,
   projectMediaUrl: PropTypes.string, // or null
   viewMode: PropTypes.oneOf(['shorter', 'longer']),

--- a/src/app/components/search/SearchResultsTable/TitleCell.test.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import TitleCell from './TitleCell';
+import { mountWithIntlProvider } from '../../../../../test/unit/helpers/intl-test';
+
+function mountInTable(value) {
+  const tree = mountWithIntlProvider((
+    <table>
+      <tbody>
+        <tr>
+          {value}
+        </tr>
+      </tbody>
+    </table>
+  ));
+  return tree.find('tr>*');
+}
+
+describe('<TitleCell>', () => {
+  it('should render title', () => {
+    const cell = mountInTable(<TitleCell
+      projectMedia={{
+        title: 'Title of item',
+      }}
+    />);
+    expect(cell.find('h4').text()).toEqual('Title of item');
+  });
+
+  it('should render appropriate similarity icons', () => {
+    const cellMain = mountInTable(<TitleCell
+      projectMedia={{
+        title: 'Title of item',
+        description: 'This is a longer description', // may be empty string or null
+        picture: null, // thumbnail URL or null
+        is_read: false, // or null
+        is_main: true, // or null
+        is_confirmed: false, // or null
+        is_suggested: false, // or null
+      }}
+    />);
+    expect(cellMain.find('svg.similarity-is-main').length).toEqual(1);
+    expect(cellMain.find('svg.similarity-is-confirmed').length).toEqual(0);
+    expect(cellMain.find('svg.similarity-is-suggested').length).toEqual(0);
+
+    const cellSecondary = mountInTable(<TitleCell
+      projectMedia={{
+        title: 'Title of item',
+        description: 'This is a longer description', // may be empty string or null
+        picture: null, // thumbnail URL or null
+        is_read: false, // or null
+        is_main: false, // or null
+        is_confirmed: true, // or null
+        is_suggested: false, // or null
+      }}
+    />);
+    expect(cellSecondary.find('svg.similarity-is-main').length).toEqual(0);
+    expect(cellSecondary.find('svg.similarity-is-confirmed').length).toEqual(1);
+    expect(cellSecondary.find('svg.similarity-is-suggested').length).toEqual(0);
+
+    const cellHasMain = mountInTable(<TitleCell
+      projectMedia={{
+        title: 'Title of item',
+        description: 'This is a longer description', // may be empty string or null
+        picture: null, // thumbnail URL or null
+        is_read: false, // or null
+        is_main: false, // or null
+        is_confirmed: false, // or null
+        is_suggested: true, // or null
+      }}
+    />);
+    expect(cellHasMain.find('svg.similarity-is-main').length).toEqual(0);
+    expect(cellHasMain.find('svg.similarity-is-confirmed').length).toEqual(0);
+    expect(cellHasMain.find('svg.similarity-is-suggested').length).toEqual(1);
+  });
+});

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -11,6 +11,7 @@ export const white = '#ffffff';
 export const black = '#000000';
 export const alertRed = '#d0021b';
 export const checkBlue = '#2e77fc';
+export const checkOrange = '#f2994a';
 export const checkError = '#fa555f';
 export const inProgressYellow = '#efac51';
 export const completedGreen = '#5cae73';


### PR DESCRIPTION
Changing the icon and colors that show in the item list view for items that meet the following criteria:

 * Item is the "parent" of a similarity match or has suggested similarity items (`is_main` is `true`): blue icon
 * Item is confirmed as a similarity match (`is_confirmed` is `true`): default text color, icon renders upside-down
 * Item is suggested as a similarity match but not confirmed (`is_suggested` is `true`): orange icon

There are a few areas where we still use `is_secondary` -- I've added notes to a new ticket, CHECK-1938, about this.
Fixes CHECK-1613.