### PR TITLE
Make sure that status on list view is updated when status is changed

### DIFF
--- a/src/app/relay/mutations/UpdateStatusMutation.js
+++ b/src/app/relay/mutations/UpdateStatusMutation.js
@@ -20,14 +20,15 @@ class UpdateStatusMutation extends Relay.Mutation {
       return Relay.QL`fragment on UpdateDynamicPayload {
         dynamicEdge,
         project_media {
-          dbid,
-          project_id,
-          log,
-          id,
-          last_status,
-          last_status_obj,
-          log_count,
-          dynamic_annotation_report_design,
+          dbid
+          project_id
+          log
+          id
+          last_status
+          last_status_obj
+          log_count
+          dynamic_annotation_report_design
+          list_columns_values
         }
       }`;
     default:


### PR DESCRIPTION
When a user goes to an item from the list view and changes its status, the value on the list view is not updated unless the page is refreshed. This happens because the view's data is in the Relay cache store. The mutation that changes the status must ask for the updated "list_columns_values" field, this way the status in the list view will be updated, because the data in the Relay store will be updated too.

Fixes CHECK-1186.