### PR TITLE
Clear the entire CloudFlare cache to avoid negative cache race condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
-    - sh scripts/clear-cf-cache.sh qa
+    - sh scripts/clear-cf-cache.sh
   only:
     - develop
 
@@ -81,6 +81,6 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
-    - sh scripts/clear-cf-cache.sh live
+    - sh scripts/clear-cf-cache.sh
   only:
     - master

--- a/scripts/clear-cf-cache.sh
+++ b/scripts/clear-cf-cache.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
-if [ "$#" -ne 1 ] ; then
-    echo "Missing required environment argument. Must be qa or live."
-    exit 0
-fi
 
-if [[ "$1" == "qa" ]]; then
-    echo "Clearing QA check-web cache at CloudFlare..."
-    curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+echo "Clearing check-web cache at CloudFlare..."
+curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
         -H "Authorization: Bearer ${CF_CACHE_TOKEN}" -H "Content-Type: application/json" \
-        --data '{"files":["https://qa.checkmedia.org/","https://qa.checkmedia.org/js/config.js"]}'
-elif [[ "$1" == "live" ]]; then
-    echo "Clearing Live check-web cache at CloudFlare..."
-    curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
-        -H "Authorization: Bearer ${CF_CACHE_TOKEN}" -H "Content-Type: application/json" \
-        --data '{"files":["https://checkmedia.org/","https://checkmedia.org/js/config.js"]}'
-else
-    echo "Invalid environment given. Must be qa or live."
-fi
+        --data '{"purge_everything":true}'
 
 exit 0


### PR DESCRIPTION
During the last deployment we encountered a scenario where the `check-web` service had an old and new task instance running. This in turn led to a race condition where the new root document referenced a vendor bundle file that did not exist on the old task instance. The resulting HTML file is then cached by CloudFlare, causing errors when viewing the site.

This change clears the entire CloudFlare cache during deployment, which will eliminate the race condition observed during the last deployment. Performance impact is expected to be minimal.

In the future, if we wish to be more fine grained with cache control, the Enterprise plan with CloudFlare supports clearing cache by prefix.