### PR TITLE
Useful stacktraces on Errbit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,19 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@airbrake/browser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@airbrake/browser/-/browser-2.1.7.tgz",
-      "integrity": "sha512-qCTG3STyE2syCQ8SAgRGW2Mpk0VM6FdZ4y7xHnWMU0FcPYpsth2rK/ZwtR8o4wrPvfTDRGHFch04nqRTkmixcw==",
-      "requires": {
-        "@types/promise-polyfill": "^6.0.3",
-        "@types/request": "2.48.7",
-        "cross-fetch": "^3.0.4",
-        "error-stack-parser": "^2.0.4",
-        "promise-polyfill": "^8.1.3",
-        "tdigest": "^0.1.1"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -2293,11 +2280,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2360,7 +2342,8 @@
     "@types/node": {
       "version": "13.13.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2378,11 +2361,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
-    },
-    "@types/promise-polyfill": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
-      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -2427,17 +2405,6 @@
         "@types/react": "*"
       }
     },
-    "@types/request": {
-      "version": "2.48.7",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.7.tgz",
-      "integrity": "sha512-GWP9AZW7foLd4YQxyFZDBepl0lPsWLMEXDZUjQ/c1gqVPDPECrRZyEzuhJdnPWioFCq3Tv0qoGpMD6U+ygd4ZA==",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      }
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -2451,11 +2418,6 @@
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -3995,11 +3957,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5033,43 +4990,6 @@
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
       }
     },
     "cross-spawn": {
@@ -11749,7 +11669,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -13496,11 +13416,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "promise-polyfill": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
-      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg=="
     },
     "prompts": {
       "version": "2.3.2",
@@ -15472,6 +15387,21 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      },
+      "dependencies": {
+        "stackframe": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+          "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+        }
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -15487,6 +15417,37 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
       "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
+    },
+    "stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "stackframe": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+          "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -15939,14 +15900,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
       }
     },
     "terminal-link": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
- {
+{
   "name": "Check",
   "version": "0.0.1",
   "description": "Verify breaking news online",
@@ -75,7 +75,6 @@
     "jest": "^25.4.0"
   },
   "dependencies": {
-    "@airbrake/browser": "^2.1.7",
     "@babel/core": "^7.9.0",
     "@babel/eslint-parser": "^7.14.5",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -172,6 +171,7 @@
     "relay-compiler": "^1.7.0",
     "rtl-detect": "^1.0.0",
     "serve-static": "^1.10.2",
+    "stacktrace-js": "^2.0.2",
     "style-loader": "^0.13.1",
     "styled-components": "^5.0.1",
     "superagent": "^3.3.0",

--- a/src/app/components/error/ErrorBoundary.js
+++ b/src/app/components/error/ErrorBoundary.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Notifier } from '@airbrake/browser';
+import StackTrace from 'stacktrace-js';
+import StackTraceGPS from 'stacktrace-gps';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
 import ErrorPage from './ErrorPage';
 import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
@@ -13,17 +14,54 @@ const messages = defineMessages({
   },
 });
 
+const errbitNotifier = ({
+  error,
+  errorInfo,
+  stackFrameArray,
+  session,
+  component,
+  callIntercom,
+}) => {
+  fetch(`${config.errbitHost}/api/v3/projects/1/notices?key=${config.errbitApiKey}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': window.navigator.userAgent,
+    },
+    body: JSON.stringify({
+      errors: [{
+        type: error.name,
+        message: error.message,
+        backtrace: stackFrameArray[0].toString(),
+      }],
+      environment: {},
+      params: { errorInfo, stackFrameArray },
+      session,
+      context: {
+        component,
+        severity: 'error',
+        language: 'JavaScript',
+        url: window.location.href,
+        notifier: {
+          name: 'Check ErrorBoundary',
+          version: '0.150.0',
+          url: 'https://github.com/meedan/check-web',
+        },
+      },
+    }),
+  }).then((response) => {
+    if (response.ok) {
+      response.json().then(data => callIntercom(data));
+    }
+  }).catch(err => console.error('Failed to notify Errbit:', err)); // eslint-disable-line no-console
+};
+
+const gps = new StackTraceGPS();
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
-    if (config.errbitApiKey && config.errbitHost) {
-      this.airbrake = new Notifier({
-        host: config.errbitHost,
-        projectId: 1,
-        projectKey: config.errbitApiKey,
-      });
-    }
   }
 
   static getDerivedStateFromError() {
@@ -31,25 +69,34 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    const { component, intl } = this.props;
+    if (config.errbitApiKey && config.errbitHost) {
+      const { component, intl } = this.props;
+      const errBack = err => console.error('stacktrace-js error:', err); // eslint-disable-line no-console
 
-    if (this.airbrake) {
-      const { dbid, email, name } = window.Check.store.getState().app.context.currentUser;
-      this.airbrake.notify({
-        // For some reason we need to reinstantiate the error or pass the error as string.
-        // Not doing this causes the additional info (contex, params, session) to be empty
-        error: new Error(error),
-        context: { component },
-        params: { info: errorInfo },
-        session: { name, dbid, email },
-      }).then((response) => {
-        if (Intercom) {
-          Intercom(
-            'showNewMessage',
-            `${intl.formatMessage(messages.askSupport)}\n\n${response.url}`,
-          );
-        }
-      });
+      StackTrace.fromError(error).then((stackFrameArray) => {
+        gps.pinpoint(stackFrameArray[0]).then((foundFunctionName) => {
+          console.log('foundFunctionName', foundFunctionName); // eslint-disable-line no-console
+        }, errBack);
+
+        const { dbid, email, name } = window.Check.store.getState().app.context.currentUser;
+        const callIntercom = (data) => {
+          if (Intercom) {
+            Intercom(
+              'showNewMessage',
+              `${intl.formatMessage(messages.askSupport)}\n\n${data.url}`,
+            );
+          }
+        };
+
+        errbitNotifier({
+          error,
+          errorInfo,
+          stackFrameArray,
+          session: { name, dbid, email },
+          component,
+          callIntercom,
+        });
+      }, errBack);
     }
   }
 


### PR DESCRIPTION
This commit makes use of stacktrace-js to convert a minified location of a crash into actual source code location.
This commit also ditches @airbrake/browser in favour of a fetch-based custom errbitNotifier function.

Fixes 1913