### PR TITLE
Fixing DateRangeFilter styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11669,7 +11669,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -5,6 +5,7 @@ import { DatePicker } from '@material-ui/pickers';
 import FormControl from '@material-ui/core/FormControl';
 import InputBase from '@material-ui/core/InputBase';
 import FormLabel from '@material-ui/core/FormLabel';
+import FormGroup from '@material-ui/core/FormGroup';
 import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
 import Select from '@material-ui/core/Select';
@@ -47,6 +48,7 @@ const StyledInputBaseDropdown = withStyles(theme => ({
     padding: `0 ${theme.spacing(0.5)}px`,
     height: theme.spacing(4.5),
     fontSize: 14,
+    borderRadius: '4px',
     '& .MuiSelect-icon': {
       color: 'white',
     },
@@ -88,6 +90,10 @@ const Styles = {
     marginLeft: '4px',
     marginRight: '4px',
   },
+  wrapper: {
+    backgroundColor: opaqueBlack07,
+    borderRadius: '4px',
+  },
 };
 
 function parseStartDateAsISOString(moment) {
@@ -98,6 +104,11 @@ function parseStartDateAsISOString(moment) {
 function parseEndDateAsISOString(moment) {
   const date = moment.toDate();
   return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59).toISOString();
+}
+
+// linear equation that gives us a good width relative to the text length with fairly stable right-padding
+function setInputWidth(textLength) {
+  return ((textLength || 7) * 12.5) - ((5 * Math.max(7, textLength)) - 35);
 }
 
 function DateRangeSelectorStartEnd(props) {
@@ -126,6 +137,7 @@ function DateRangeSelectorStartEnd(props) {
                 <StyledInputBaseDate
                   className={valueText ? ['date-range__start-date', classes.dateRangeFilterSelected].join(' ') : 'date-range__start-date'}
                   type="text"
+                  style={{ width: `${setInputWidth(valueText.length)}px` }}
                   placeholder={text}
                   onClick={onClick}
                   value={valueText}
@@ -153,6 +165,7 @@ function DateRangeSelectorStartEnd(props) {
                 <StyledInputBaseDate
                   className={valueText ? ['date-range__end-date', classes.dateRangeFilterSelected].join(' ') : 'date-range__end-date'}
                   type="text"
+                  style={{ width: `${setInputWidth(valueText.length)}px` }}
                   placeholder={text}
                   onClick={onClick}
                   value={valueText}
@@ -374,36 +387,38 @@ const DateRangeFilter = ({
   };
 
   return (
-    <div style={{ background: opaqueBlack07 }}>
+    <div className={classes.wrapper}>
       <FlexRow>
         <FormControl variant="outlined" className={classes.selectFormControl}>
           <FormLabel>{/* styling -- the <label> tag changes the height */}</FormLabel>
-          <Select
-            onChange={handleChangeType}
-            value={getValueType()}
-            input={
-              <StyledInputBaseDropdown
-                startAdornment={
-                  <RemoveableWrapper icon={<DateRangeIcon />} onRemove={onRemove} boxProps={{ pr: 1 }} />
-                }
-              />
-            }
-          >
-            <MenuItem value="created_at"> { label.created_at } </MenuItem>
-            <MenuItem value="media_published_at"> { label.media_published_at } </MenuItem>
-            <MenuItem value="updated_at"> { label.updated_at } </MenuItem>
-            <MenuItem value="report_published_at"> { label.report_published_at } </MenuItem>
-          </Select>
-          <Select
-            onChange={handleChangeRangeType}
-            value={rangeType}
-            input={
-              <StyledInputBaseDropdown />
-            }
-          >
-            <MenuItem value="startEnd"> { label.startEnd } </MenuItem>
-            <MenuItem value="relative"> { label.relative } </MenuItem>
-          </Select>
+          <FormGroup>
+            <Select
+              onChange={handleChangeType}
+              value={getValueType()}
+              input={
+                <StyledInputBaseDropdown
+                  startAdornment={
+                    <RemoveableWrapper icon={<DateRangeIcon />} onRemove={onRemove} boxProps={{ pr: 1 }} />
+                  }
+                />
+              }
+            >
+              <MenuItem value="created_at"> { label.created_at } </MenuItem>
+              <MenuItem value="media_published_at"> { label.media_published_at } </MenuItem>
+              <MenuItem value="updated_at"> { label.updated_at } </MenuItem>
+              <MenuItem value="report_published_at"> { label.report_published_at } </MenuItem>
+            </Select>
+            <Select
+              onChange={handleChangeRangeType}
+              value={rangeType}
+              input={
+                <StyledInputBaseDropdown />
+              }
+            >
+              <MenuItem value="startEnd"> { label.startEnd } </MenuItem>
+              <MenuItem value="relative"> { label.relative } </MenuItem>
+            </Select>
+          </FormGroup>
           { rangeType === rangeTypes.startEnd ? (
             <DateRangeSelectorStartEnd {...{
               classes,

--- a/src/app/components/search/DateRangeFilter.test.js
+++ b/src/app/components/search/DateRangeFilter.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
+import MomentUtils from '@date-io/moment';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import DateRangeFilter from './DateRangeFilter';
+
+describe('<DateRangeFilter />', () => {
+  it('should render basic filter', () => {
+    const wrapper = mountWithIntl(
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <DateRangeFilter
+          classes={{}}
+          value={{
+            created_at: {
+              start_time: '',
+              end_time: '',
+            },
+          }}
+          onChange={() => {}}
+          onRemove={() => {}}
+        />
+      </MuiPickersUtilsProvider>,
+    );
+
+    expect(wrapper.find('input[value="created_at"]').length).toBe(1);
+  });
+
+  it('should hide filter', () => {
+    const wrapper = mountWithIntl(
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <DateRangeFilter
+          classes={{}}
+          hide
+          value={{
+            created_at: {
+              start_time: '',
+              end_time: '',
+            },
+          }}
+          onChange={() => {}}
+          onRemove={() => {}}
+        />
+      </MuiPickersUtilsProvider>,
+    );
+
+    expect(wrapper.find('input[value="created_at"]').length).toBe(0);
+  });
+
+  it('should show alternate filters', () => {
+    const wrapper = mountWithIntl(
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <DateRangeFilter
+          classes={{}}
+          value={{
+            media_published_at: {
+              start_time: '',
+              end_time: '',
+            },
+          }}
+          onChange={() => {}}
+          onRemove={() => {}}
+        />
+      </MuiPickersUtilsProvider>,
+    );
+
+    expect(wrapper.find('input[value="media_published_at"]').length).toBe(1);
+    expect(wrapper.find('input[value="created_at"]').length).toBe(0);
+  });
+});


### PR DESCRIPTION
 * Adding consistent `border-radius` to `DateRangeFilter` (note: the filter is two boxes on top of each other, so both boxes must have the same border-radius for this to render correctly)
 * Came up with a linear equation that both expands the width of the input box based on the date text length rendered inside it, AND corrects for over-correction of the simple linear equation. Basically the first clause sets a basic width and the second clause (subtracting ((5*textLength)-35) corrects a natural overshoot that happens. (I just did a simple linear interpolation between good widths for "May 1st" and "December 31st", with clamping in place for default values -- hopefully this holds more or less for other localizations)
 * Add unit tests

Fixes CHECK-1574