### PR TITLE
Removing react-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14034,21 +14034,6 @@
         }
       }
     },
-    "react-icons": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.10.0.tgz",
-      "integrity": "sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==",
-      "requires": {
-        "camelcase": "^5.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        }
-      }
-    },
     "react-image-lightbox": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-image-lightbox/-/react-image-lightbox-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
- {
+{
   "name": "Check",
   "version": "0.0.1",
   "description": "Verify breaking news online",
@@ -154,7 +154,6 @@
     "react-favicon": "0.0.8",
     "react-ga": "^2.1.2",
     "react-helmet": "^6.0.0",
-    "react-icons": "^3.10.0",
     "react-image-lightbox": "^5.0.0",
     "react-infinite-scroller": "^1.0.1",
     "react-intercom": "^1.0.15",

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { FcGoogle } from 'react-icons/fc';
 import { browserHistory, Link } from 'react-router';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
+import SvgIcon from '@material-ui/core/SvgIcon';
 import Message from './Message';
 import UserTosForm from './UserTosForm';
 import { login, request } from '../redux/actions';
@@ -189,7 +189,8 @@ class Login extends React.Component {
                 fullWidth
                 style={styles.googleButton}
                 onClick={this.oAuthLogin.bind(this, 'google_oauth2')}
-                startIcon={<FcGoogle />}
+                // eslint-disable-next-line
+                startIcon={<SvgIcon viewBox="0 0 48 48"><path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12 c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24 c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"></path><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657 C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"></path><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36 c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"></path><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571 c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"></path></SvgIcon>}
               >
                 <FormattedMessage
                   id="login.withGoogle"

--- a/src/app/components/SocialIcon.js
+++ b/src/app/components/SocialIcon.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import SvgIcon from '@material-ui/core/SvgIcon';
 import FacebookIcon from '@material-ui/icons/Facebook';
 import InstagramIcon from '@material-ui/icons/Instagram';
 import TwitterIcon from '@material-ui/icons/Twitter';
 import YouTubeIcon from '@material-ui/icons/YouTube';
 import LinkIcon from '@material-ui/icons/Link';
-import { FaSlack } from 'react-icons/fa';
-import { FcGoogle } from 'react-icons/fc';
 import {
   slackGreen,
   twitterBlue,
@@ -31,7 +30,8 @@ const SocialIcon = ({ domain, inColor }) => {
   switch (domain) {
   case 'slack.com':
   case 'slack':
-    return <FaSlack className="logo" classes={{ root: classes.slack }} />;
+    // eslint-disable-next-line
+    return <SvgIcon className="logo" viewBox="0 0 448 512" classes={{ root: classes.slack }}><path d="M94.12 315.1c0 25.9-21.16 47.06-47.06 47.06S0 341 0 315.1c0-25.9 21.16-47.06 47.06-47.06h47.06v47.06zm23.72 0c0-25.9 21.16-47.06 47.06-47.06s47.06 21.16 47.06 47.06v117.84c0 25.9-21.16 47.06-47.06 47.06s-47.06-21.16-47.06-47.06V315.1zm47.06-188.98c-25.9 0-47.06-21.16-47.06-47.06S139 32 164.9 32s47.06 21.16 47.06 47.06v47.06H164.9zm0 23.72c25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06H47.06C21.16 243.96 0 222.8 0 196.9s21.16-47.06 47.06-47.06H164.9zm188.98 47.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06h-47.06V196.9zm-23.72 0c0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06V79.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06V196.9zM283.1 385.88c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06v-47.06h47.06zm0-23.72c-25.9 0-47.06-21.16-47.06-47.06 0-25.9 21.16-47.06 47.06-47.06h117.84c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06H283.1z"></path></SvgIcon>;
   case 'twitter.com':
   case 'twitter':
     return <TwitterIcon className="logo" classes={{ root: classes.twitter }} />;
@@ -46,7 +46,8 @@ const SocialIcon = ({ domain, inColor }) => {
     return <FacebookIcon className="logo" classes={{ root: classes.facebook }} />;
   case 'google.com':
   case 'google_oauth2':
-    return <FcGoogle className="logo" />;
+    // eslint-disable-next-line
+    return <SvgIcon className="logo" viewBox="0 0 48 48"><path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12 c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24 c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"></path><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657 C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"></path><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36 c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"></path><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571 c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"></path></SvgIcon>;
   default:
     return <LinkIcon />;
   }


### PR DESCRIPTION
No need to ship an entire dependency just to have two icons in our code base. Replacing both icons we use with inline SVG.

Fixes CHECK-1977.