### PR TITLE
Improving dev build performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3400,6 +3400,14 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-import": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.13.5.tgz",
+      "integrity": "sha512-IkqnoV+ov1hdJVofly9pXRJmeDm9EtROfrc5i6eII0Hix2xMs5FEm8FG3ExMvazbnZBbgHIt6qdO8And6lCloQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@react-google-maps/api": "1.8.7",
     "@vvo/tzdb": "^6.39.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-import": "^1.13.5",
     "babel-plugin-react-intl": "^3.5.1",
     "babel-plugin-relay": "^1.7.0",
     "babel-plugin-styled-components": "^1.10.7",

--- a/src/.babelrc.json
+++ b/src/.babelrc.json
@@ -17,6 +17,23 @@
     "@babel/plugin-proposal-optional-chaining",
     ["babel-plugin-styled-components", { "pure": true }],
     ["relay", { "compat": true, "schema": "relay.json" }],
-    ["react-intl", { "messagesDir": "localization/react-intl/" }]
+    ["react-intl", { "messagesDir": "localization/react-intl/" }],
+		["babel-plugin-import",
+      {
+        "libraryName": "@material-ui/core",
+        "libraryDirectory": "esm",
+        "camel2DashComponentName": false
+      },
+      "core"
+    ],
+    [
+      "babel-plugin-import",
+      {
+        "libraryName": "@material-ui/icons",
+        "libraryDirectory": "esm",
+        "camel2DashComponentName": false
+      },
+      "icons"
+    ]
   ]
 }


### PR DESCRIPTION
Following guidelines on https://v4.mui.com/guides/minimizing-bundle-size/, Option 2. Dev build size reduced from 57 MB to 27 MB and first load is reduced (on my machine at least) from 12 seconds to 8 seconds.