### PR TITLE
Remove react-jsonschema-form-material-ui

### DIFF
--- a/localization/react-intl/src/app/components/team/FetchBot.json
+++ b/localization/react-intl/src/app/components/team/FetchBot.json
@@ -1,6 +1,6 @@
 [
   {
     "id": "fetchBot.contactUs",
-    "defaultMessage": "Contact us to setup"
+    "defaultMessage": "Contact us to set up"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,11 +2208,6 @@
         }
       }
     },
-    "@meedan/react-jsonschema-form-material-ui-v1": {
-      "version": "99.0.0",
-      "resolved": "https://registry.npmjs.org/@meedan/react-jsonschema-form-material-ui-v1/-/react-jsonschema-form-material-ui-v1-99.0.0.tgz",
-      "integrity": "sha512-u4FIcMEwW6pvly7AU7CuRcWksiRoduRN3NfTXQIHZDAWzGptnX3uwNuDrAHqGOur3jkvog+cV0GVVE9DJSodjQ=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@material-ui/lab": "^4.0.0-alpha.52",
     "@material-ui/pickers": "^3.2.10",
     "@meedan/check-ui": "^0.1.51",
-    "@meedan/react-jsonschema-form-material-ui-v1": "^99.0.0",
     "@react-google-maps/api": "1.8.7",
     "@vvo/tzdb": "^6.39.0",
     "babel-loader": "^8.1.0",

--- a/src/app/components/team/FetchBot.js
+++ b/src/app/components/team/FetchBot.js
@@ -1,13 +1,43 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
-const FetchBot = () => (
-  <a href="https://airtable.com/shrlr5jDk7z6bvE5W" target="_blank" rel="noopener noreferrer">
-    <FormattedMessage
-      id="fetchBot.contactUs"
-      defaultMessage="Contact us to setup"
-    />
-  </a>
-);
+const FetchBot = ({
+  intl,
+  onChange,
+  value,
+}) => {
+  function handleChange(field) {
+    const data = { ...value };
+    data[field] = !data[field];
+    onChange(data);
+  }
 
-export default FetchBot;
+  return (
+    <>
+      <FormControlLabel
+        control={<Checkbox
+          checked={value.auto_publish_reports}
+          onChange={() => handleChange('auto_publish_reports')}
+          name="checkedA"
+        />}
+        label={intl.formatMessage({
+          id: 'fetchBot.autoPublish',
+          defaultMessage: 'Auto-publish reports',
+          description: 'Label for a setting that causes a bot to automatically publish its reports in the workspace',
+        })}
+      />
+      <p>
+        <a href="https://airtable.com/shrlr5jDk7z6bvE5W" target="_blank" rel="noopener noreferrer">
+          <FormattedMessage
+            id="fetchBot.contactUs"
+            defaultMessage="Contact us to set up"
+          />
+        </a>
+      </p>
+    </>
+  );
+};
+
+export default injectIntl(FetchBot);

--- a/src/app/components/team/KeepBot.js
+++ b/src/app/components/team/KeepBot.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
+import Checkbox from '@material-ui/core/Checkbox';
+
+const KeepBot = ({
+  intl,
+  onChange,
+  value,
+}) => {
+  function handleChange(field) {
+    const data = { ...value };
+    data[field] = !data[field];
+    onChange(data);
+  }
+
+  return (
+    <>
+      <FormGroup>
+        <FormControlLabel
+          control={<Checkbox
+            checked={value.archive_archive_is_enabled}
+            onChange={() => handleChange('archive_archive_is_enabled')}
+            name="checkedA"
+          />}
+          label={intl.formatMessage({
+            id: 'keepBot.archiveIs',
+            defaultMessage: 'Enable Archive.is',
+            description: 'Label for a setting that causes a bot to enable the "Archive.is" service (name of a third party provider, should not be localized)',
+          })}
+        />
+        <FormControlLabel
+          control={<Checkbox
+            checked={value.archive_archive_org_enabled}
+            onChange={() => handleChange('archive_archive_org_enabled')}
+            name="checkedB"
+          />}
+          label={intl.formatMessage({
+            id: 'keepBot.archiveOrg',
+            defaultMessage: 'Enable Archive.org',
+            description: 'Label for a setting that causes a bot to enable the "Archive.org" service (name of a third party provider, should not be localized)',
+          })}
+        />
+        <FormControlLabel
+          control={<Checkbox
+            checked={value.archive_perma_cc_enabled}
+            onChange={() => handleChange('archive_perma_cc_enabled')}
+            name="checkedC"
+          />}
+          label={intl.formatMessage({
+            id: 'keepBot.permaCc',
+            defaultMessage: 'Enable Perma.cc',
+            description: 'Label for a setting that causes a bot to enable the "Perma.cc" service (name of a third party provider, should not be localized)',
+          })}
+        />
+      </FormGroup>
+    </>
+  );
+};
+
+export default injectIntl(KeepBot);

--- a/src/app/components/team/TeamBot.js
+++ b/src/app/components/team/TeamBot.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import Box from '@material-ui/core/Box';
-import Form from '@meedan/react-jsonschema-form-material-ui-v1';
 import styled from 'styled-components';
 import FetchBot from './FetchBot';
+import KeepBot from './KeepBot';
 import { units, black32 } from '../../styles/js/shared';
 
 const StyledSchemaForm = styled.div`
@@ -56,14 +56,30 @@ class TeamBot extends Component {
   }
 
   render() {
+    let botContent = null;
+    switch (this.props.bot.identifier) {
+    case 'fetch':
+      botContent = (
+        <FetchBot {...this.props} />
+      );
+      break;
+    case 'keep':
+      botContent = (
+        <KeepBot {...this.props} />
+      );
+      break;
+    default:
+      botContent = null;
+      break;
+    }
+
     return (
       <React.Fragment>
         <StyledSchemaForm>
           <Box id={`bot-${this.props.bot.identifier}`}>
-            <Form {...this.props} />
+            {botContent}
           </Box>
         </StyledSchemaForm>
-        { this.props.bot.name === 'Fetch' ? <FetchBot /> : null }
       </React.Fragment>
     );
   }

--- a/src/app/components/team/TeamBots.js
+++ b/src/app/components/team/TeamBots.js
@@ -142,7 +142,7 @@ class TeamBots extends Component {
                 </CardContent>
                 <Collapse in={botExpanded} timeout="auto">
                   <CardContent>
-                    { bot.settings_as_json_schema ?
+                    { bot.installation?.json_settings ?
                       <React.Fragment>
                         <Box display="flex" alignItems="center" justifyContent="space-between">
                           <h3><FormattedMessage id="teamBots.settings" defaultMessage="Settings" /></h3>
@@ -166,8 +166,6 @@ class TeamBots extends Component {
                         { botExpanded ?
                           <TeamBot
                             bot={bot}
-                            schema={JSON.parse(bot.settings_as_json_schema)}
-                            uiSchema={JSON.parse(bot.settings_ui_schema)}
                             value={this.state.settings[installation.id] || JSON.parse(installation.json_settings || '{}')}
                             onChange={this.handleSettingsUpdated.bind(this, installation)}
                           /> : null

--- a/src/app/components/team/TeamIntegrations.js
+++ b/src/app/components/team/TeamIntegrations.js
@@ -52,8 +52,6 @@ const TeamIntegrations = () => {
                   name
                   default
                   identifier
-                  settings_as_json_schema(team_slug: $teamSlug)
-                  settings_ui_schema
                   description: get_description
                   team_author {
                     name


### PR DESCRIPTION
 * remove the `react-jsonschema-form-material-ui` (500kb!)
 * fix an English typo
 * extend `FetchBot` and create `KeepBot` components to hard-code the settings for each respective bot, have `TeamBot` render these conditionally based on the bot `identifier` field
 * remove references to schema usage from `TeamBots`
 * remove schema fields from query in `TeamIntegrations`