### PR TITLE
Fix claim attribute styling

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaCreatedBy.json
+++ b/localization/react-intl/src/app/components/media/MediaCreatedBy.json
@@ -21,6 +21,7 @@
   },
   {
     "id": "mediaCreatedBy.createdBy",
+    "description": "A text field that indicates who the original author of a claim is. The {name} field will render the display name of the user who created the item.",
     "defaultMessage": "Item created by {name}"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaFactCheck.json
+++ b/localization/react-intl/src/app/components/media/MediaFactCheck.json
@@ -36,10 +36,12 @@
   },
   {
     "id": "mediaActionsBar.publishedReport",
+    "description": "A label on a button that opens the report for this item. This displays if the report for this media item is currently in the 'Published' state.",
     "defaultMessage": "Published report"
   },
   {
     "id": "mediaActionsBar.unpublishedReport",
+    "description": "A label on a button that opens the report for this item. This displays if the report for this media item is NOT currently in the 'Published' state.",
     "defaultMessage": "Unpublished report"
   },
   {
@@ -54,6 +56,7 @@
   },
   {
     "id": "mediaFactCheck.confirmButtonLabel",
+    "description": "A label on a button that the user can press to go back to the screen where they edit a fact check.",
     "defaultMessage": "Go back to editing"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11671,7 +11671,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14680,7 +14680,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -14906,7 +14906,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/media/MediaClaim.js
+++ b/src/app/components/media/MediaClaim.js
@@ -13,10 +13,6 @@ import { parseStringUnixTimestamp } from '../../helpers';
 import { can } from '../Can';
 
 const useStyles = makeStyles(() => ({
-  savedBy: {
-    fontSize: '9px',
-    letterSpacing: 0,
-  },
   title: {
     fontSize: '16px',
   },
@@ -126,7 +122,7 @@ const MediaClaim = ({ projectMedia }) => {
           </strong>
         </Typography>
         {' '}
-        <Typography className={classes.savedBy} variant="caption" component="div">
+        <Typography variant="caption" component="div">
           { error ?
             <FormattedMessage
               id="mediaClaim.error"

--- a/src/app/components/media/MediaCreatedBy.js
+++ b/src/app/components/media/MediaCreatedBy.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, FormattedMessage, intlShape } from 'react-intl';
@@ -55,6 +54,7 @@ const MediaCreatedBy = ({ projectMedia, intl }) => {
         values={{
           name: showUserName ? <a href={`/check/user/${userId}`}>{creatorName}</a> : formattedChannelName,
         }}
+        description="A text field that indicates who the original author of a claim is. The {name} field will render the display name of the user who created the item."
       />
     </Typography>
   );

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
@@ -237,11 +236,13 @@ const MediaFactCheck = ({ projectMedia }) => {
                 className="media-fact-check__published-report"
                 id="mediaActionsBar.publishedReport"
                 defaultMessage="Published report"
+                description="A label on a button that opens the report for this item. This displays if the report for this media item is currently in the 'Published' state."
               /> :
               <FormattedMessage
                 className="media-fact-check__unpublished-report"
                 id="mediaActionsBar.unpublishedReport"
                 defaultMessage="Unpublished report"
+                description="A label on a button that opens the report for this item. This displays if the report for this media item is NOT currently in the 'Published' state."
               /> }
           </Button>
         </Box> : null }
@@ -270,6 +271,7 @@ const MediaFactCheck = ({ projectMedia }) => {
           <FormattedMessage
             id="mediaFactCheck.confirmButtonLabel"
             defaultMessage="Go back to editing"
+            description="A label on a button that the user can press to go back to the screen where they edit a fact check."
           />
         }
         onProceed={() => { setShowDialog(false); }}


### PR DESCRIPTION
Turns out we just needed to remove a custom CSS override to make this display correctly. The default `caption` style is working! Also added some `description` fields to localized text in related files.