### PR TITLE
Fixing counter on requests sidebar

### DIFF
--- a/src/app/components/media/MediaRequests.js
+++ b/src/app/components/media/MediaRequests.js
@@ -75,7 +75,7 @@ class MediaRequestsComponent extends Component {
               id="mediaRequests.thisRequests"
               defaultMessage="{count, plural, one {# request} other {# requests}}"
               values={{
-                count: this.props.media.requests_count,
+                count: this.props.media.demand,
               }}
             />
           }
@@ -170,7 +170,7 @@ const MediaOwnRequestsContainer = Relay.createContainer(withStyles(styles)(withP
         dbid
         archived
         pusher_channel
-        requests_count
+        demand
         media {
           file_path
         }


### PR DESCRIPTION
The requests sidebar displays requests from all media (main item and all its similar items), but the counter was showing only the number of requests from the main item. Now it reflects the actual number of displayed requests.

Fixes CHECK-2014.