### PR TITLE
Render 'Claim missing modal' when claim has empty description

### DIFF
--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -37,7 +37,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   const readOnly = projectMedia.is_secondary || projectMedia.suggested_main_item;
 
   const handleGoToReport = () => {
-    if (!claimDescription) {
+    if (!claimDescription || claimDescription.description.length === 0 || claimDescription.description.trim().length === 0) {
       setShowDialog(true);
     } else {
       window.location.assign(`${window.location.pathname.replace(/\/(suggested-matches|similar-media)/, '')}/report`);
@@ -261,6 +261,7 @@ const MediaFactCheck = ({ projectMedia }) => {
             <Typography variant="body1" component="p" paragraph>
               <FormattedMessage
                 id="mediaFactCheck.claimMissingDesc"
+                data-testid="media-fact-check__confirm-button-label"
                 defaultMessage="You must add a claim to access the fact-check report."
                 description="Content of a dialog that is displayed when user attempts to access a report from a fact-check but there is no claim yet"
               />

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -37,7 +37,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   const readOnly = projectMedia.is_secondary || projectMedia.suggested_main_item;
 
   const handleGoToReport = () => {
-    if (!claimDescription || claimDescription.description.length === 0 || claimDescription.description.trim().length === 0) {
+    if (!claimDescription || claimDescription.description.trim().length === 0) {
       setShowDialog(true);
     } else {
       window.location.assign(`${window.location.pathname.replace(/\/(suggested-matches|similar-media)/, '')}/report`);

--- a/src/app/components/media/MediaFactCheck.test.js
+++ b/src/app/components/media/MediaFactCheck.test.js
@@ -130,4 +130,10 @@ describe('<MediaFactCheck>', () => {
     expect(wrapper.find('#confirm-dialog__confirm-action-button').hostNodes()).toHaveLength(1);
     expect(wrapper.find('[data-testid="media-fact-check__confirm-button-label"]').text()).toContain('You must add a claim to access the fact-check report');
   });
+
+  it('should not render missing claim dialog when clicking the report button with a claim that have description', () => {
+    const wrapper = mountWithIntl(<MediaFactCheck projectMedia={projectMedia3} />);
+    wrapper.find('.media-fact-check__report-designer').hostNodes().simulate('click');
+    expect(wrapper.find('#confirm-dialog__confirm-action-button').hostNodes()).toHaveLength(0);
+  });
 });

--- a/src/app/components/media/MediaFactCheck.test.js
+++ b/src/app/components/media/MediaFactCheck.test.js
@@ -50,6 +50,36 @@ const projectMedia3 = {
   report: { data: { state: 'unpublished' } },
 };
 
+const projectMedia4 = {
+  team: { smooch_bot: { bla: 1 } },
+  permissions,
+  claim_description: {
+    description: '',
+    fact_check: {
+      title: 'title',
+      url: 'url',
+      summary: 'summary',
+      user: { name: 'Loren User test' },
+    },
+  },
+  report: { data: { state: 'unpublished' } },
+};
+
+const projectMedia5 = {
+  team: { smooch_bot: { bla: 1 } },
+  permissions,
+  claim_description: {
+    description: '     ',
+    fact_check: {
+      title: 'title',
+      url: 'url',
+      summary: 'summary',
+      user: { name: 'Loren User test' },
+    },
+  },
+  report: { data: { state: 'unpublished' } },
+};
+
 describe('<MediaFactCheck>', () => {
   it('should render fact check input fields', () => {
     const wrapper = mountWithIntl(<MediaFactCheck projectMedia={projectMedia} />);
@@ -83,5 +113,21 @@ describe('<MediaFactCheck>', () => {
     expect(wrapper.find('.media-fact-check__saved-by').find('span').first().text()).toContain('saved by Loren User test');
     expect(wrapper.html()).toMatch('saved by Loren User test');
     expect(wrapper.find('time').text()).toContain('May 26, 2022');
+  });
+
+  it('should render missing claim dialog when clicking the report button with a claim with empty description', () => {
+    const wrapper = mountWithIntl(<MediaFactCheck projectMedia={projectMedia4} />);
+    expect(wrapper.find('.media-fact-check__unpublished-report').text()).toEqual('Unpublished report');
+    wrapper.find('.media-fact-check__report-designer').hostNodes().simulate('click');
+    expect(wrapper.find('#confirm-dialog__confirm-action-button').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('[data-testid="media-fact-check__confirm-button-label"]').text()).toContain('You must add a claim to access the fact-check report');
+  });
+
+  it('should render missing claim dialog when clicking the report button with a claim with blank spaces description', () => {
+    const wrapper = mountWithIntl(<MediaFactCheck projectMedia={projectMedia5} />);
+    expect(wrapper.find('.media-fact-check__unpublished-report').text()).toEqual('Unpublished report');
+    wrapper.find('.media-fact-check__report-designer').hostNodes().simulate('click');
+    expect(wrapper.find('#confirm-dialog__confirm-action-button').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('[data-testid="media-fact-check__confirm-button-label"]').text()).toContain('You must add a claim to access the fact-check report');
   });
 });


### PR DESCRIPTION
or blank spaces description and add unit tests

Reference: CHECK-1953