### PR TITLE
Do not crash when open Select Project Dialog

### DIFF
--- a/src/app/components/media/SelectProjectDialog.js
+++ b/src/app/components/media/SelectProjectDialog.js
@@ -56,17 +56,18 @@ function SelectProjectDialog({
 
   // Add "empty folders" to empty collections, so they appear in the drop-down as well
   projectGroups.forEach((pg) => {
-    if (!projects.find(p => p.project_group_id === pg.dbid)) {
+    if (projects.length > 0 && !projects.find(p => p.project_group_id === pg.dbid)) {
       projects.push({ projectGroupTitle: pg.title, title: intl.formatMessage(messages.noFolders) });
     }
   });
 
   // Get a default folder
-  const defaultFolder = projects.filter(({ dbid }) => dbid === team.default_folder.dbid)[0];
+  // The value returned can be undefined if workspace default folder has privacy settings on
+  const defaultFolder = team.default_folder ? projects.filter(({ dbid }) => dbid === team.default_folder.dbid)[0] : null;
 
   // Lastly, sort options by title and exclude some options and defaultFolder to add it to the top of the list
   const filteredProjects = projects
-    .filter(({ dbid }) => !excludeProjectDbids.includes(dbid) && dbid !== defaultFolder.dbid)
+    .filter(({ dbid }) => team.default_folder && !excludeProjectDbids.includes(dbid) &&  dbid !== team.default_folder.dbid)
     .sort((a, b) => {
       // First sort by collection
       if (a.projectGroupTitle !== b.projectGroupTitle) {
@@ -76,11 +77,11 @@ function SelectProjectDialog({
       return a.title.localeCompare(b.title);
     });
 
-  const filteredProjectsOptions = [defaultFolder, ...filteredProjects];
-  const [value, setValue] = React.useState(defaultFolder);
+  const filteredProjectsOptions = defaultFolder ? [defaultFolder, ...filteredProjects] : [...filteredProjects];
+  const [value, setValue] = React.useState(defaultFolder || null);
 
   const handleSubmit = React.useCallback(() => {
-    setValue(defaultFolder);
+    setValue(defaultFolder || null);
     onSubmit(value);
   }, [onSubmit, value]);
 
@@ -222,3 +223,6 @@ const SelectProjectDialogRenderer = (parentProps) => {
 };
 
 export default injectIntl(SelectProjectDialogRenderer);
+
+// eslint-disable-next-line import/no-unused-modules
+export { SelectProjectDialog as SelectProjectDialogTest };

--- a/src/app/components/media/SelectProjectDialog.test.js
+++ b/src/app/components/media/SelectProjectDialog.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { SelectProjectDialogTest } from './SelectProjectDialog';
+
+const team = {
+  dbid: 1,
+  name: 'teamName',
+  slug: 'slugTeam',
+  members_count: 1,
+  project_groups: { edges: [{ node: { project_group_id: '1' } }] },
+  projects: { edges: [{ node: { project_group_id: '1' } }] },
+  user: {
+    dbid: 1,
+    name: 'User Name',
+  },
+};
+
+const intl = {
+  now: () => {},
+  formatDate: () => {},
+  formatTime: () => {},
+  formatRelative: () => {},
+  formatNumber: () => {},
+  formatPlural: () => {},
+  formatMessage: () => {},
+  formatHTMLMessage: () => {},
+};
+describe('<SelectProjectDialog/>', () => {
+  const node = <div />;
+  // render Dialog even without pass team default folder
+  it('should render Select Project Dialog', () => {
+    const wrapper = mountWithIntl(<SelectProjectDialogTest
+      open
+      excludeProjectDbids={[]}
+      title={node}
+      team={team}
+      intl={intl}
+      cancelLabel={node}
+      submitLabel={node}
+      submitButtonClassName="media-actions-bar__move-button"
+      onCancel={() => {}}
+      onSubmit={() => {}}
+    />);
+    expect(wrapper.find('.media-actions-bar__move-button').hostNodes()).toHaveLength(1);
+    expect(wrapper.html()).toMatch('Choose a folder');
+  });
+});


### PR DESCRIPTION
Do not crash when open select project dialog in a workspace that has privacy enabled on default folder if the user has no permission to see that project and add unit test

Reference: CHECK-2069