### PR TITLE
Fixing characters counter on newsletter settings page

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
@@ -146,6 +146,9 @@ const SmoochBotNewsletterEditor = ({
   } else {
     charactersCount += body.length;
   }
+  if (introduction && (rssPreview || body)) {
+    charactersCount += 2; // Two line breaks are added to separate the introduction from the body
+  }
 
   const handleError = () => {
     setLoading(false);

--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.test.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.test.js
@@ -22,4 +22,23 @@ describe('<SmoochBotNewsletterEditor />', () => {
     expect(wrapper.find('div#time-select').text()).toMatch(/8:00/);
     expect(wrapper.find('div#timezone-select').text()).toMatch(/America\/Tijuana \(GMT-7\)/);
   });
+
+  it('should count number of characters in a newsletter', () => {
+    const wrapper = mountWithIntl(<SmoochBotNewsletterEditor
+      installationId="foo"
+      newsletter={{
+        smooch_newsletter_feed_url: '',
+        smooch_newsletter_day: 'thursday',
+        smooch_newsletter_introduction: 'Hello',
+        smooch_newsletter_time: '8',
+        smooch_newsletter_timezone: 'America/Tijuana (GMT-07:00)',
+        smooch_newsletter_body: 'Test',
+        smooch_newsletter_introduction: 'Foo',
+      }}
+      language="en"
+      onChange={() => {}}
+    />);
+
+    expect(wrapper.html()).toMatch(/1015\/1024 characters available/);
+  });
 });


### PR DESCRIPTION
The counter was wrong because it was not taking into account that two line breaks are added to separate the introduction from the rest of the newsletter content.

I added a unit test for that.

Fixes CHECK-2090.