### PR TITLE
Request team task "tasks_with_answers_count" field only on demand

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamMetadataRender.json
+++ b/localization/react-intl/src/app/components/team/TeamMetadataRender.json
@@ -20,8 +20,8 @@
     "defaultMessage": "Create dynamic forms to annotate sources by adding fields."
   },
   {
-    "id": "teamMetadataRender.blankMetadata",
-    "description": "Text for empty metadata",
-    "defaultMessage": "No metadata fields"
+    "id": "teamMetadataRender.blankAnnotations",
+    "description": "Text for empty annotations",
+    "defaultMessage": "No annotation fields"
   }
 ]

--- a/src/app/components/team/TeamMetadataRender.js
+++ b/src/app/components/team/TeamMetadataRender.js
@@ -111,9 +111,9 @@ function TeamMetadataRender({ team, about }) {
               /> :
               <BlankState>
                 <FormattedMessage
-                  id="teamMetadataRender.blankMetadata"
-                  defaultMessage="No metadata fields"
-                  description="Text for empty metadata"
+                  id="teamMetadataRender.blankAnnotations"
+                  defaultMessage="No annotation fields"
+                  description="Text for empty annotations"
                 />
               </BlankState>
             }

--- a/src/app/components/team/TeamTaskContainer.js
+++ b/src/app/components/team/TeamTaskContainer.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+import { QueryRenderer, graphql } from 'react-relay/compat';
+
+const TeamTaskContainer = ({ task, team, children }) => {
+  const { dbid } = task;
+  const { slug } = team;
+
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query TeamTaskContainerQuery($slug: String!, $dbid: Int!) {
+          team(slug: $slug) {
+            team_task(dbid: $dbid) {
+              id
+              dbid
+              label
+              description
+              options
+              type
+              associated_type
+              project_ids
+              json_schema
+              show_in_browser_extension
+              required
+              conditional_info
+              tasks_count
+              tasks_with_answers_count
+            }
+          }
+        }
+      `}
+      variables={{
+        slug,
+        dbid,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          return <React.Fragment>{children(props.team.team_task)}</React.Fragment>;
+        }
+
+        // TODO: We need a better error handling in the future, standardized with other components
+        return null;
+      }}
+    />
+  );
+};
+
+TeamTaskContainer.defaultProps = {
+  task: { dbid: null },
+  team: { slug: null },
+};
+
+TeamTaskContainer.propTypes = {
+  task: PropTypes.shape({
+    dbid: PropTypes.number.isRequired,
+  }),
+  team: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+  }),
+};
+
+export default TeamTaskContainer;

--- a/src/app/components/team/TeamTasks.js
+++ b/src/app/components/team/TeamTasks.js
@@ -31,6 +31,7 @@ const TeamTasks = ({ team }) => {
           team(slug: $slug) {
             id
             dbid
+            slug
             team_tasks(fieldset: "metadata", first: 10000) {
               edges {
                 node {
@@ -47,7 +48,6 @@ const TeamTasks = ({ team }) => {
                   required
                   conditional_info
                   tasks_count
-                  tasks_with_answers_count
                 }
               }
             }

--- a/src/app/components/team/TeamTasksListItem.js
+++ b/src/app/components/team/TeamTasksListItem.js
@@ -12,6 +12,7 @@ import IconFileUpload from '@material-ui/icons/CloudUpload';
 import LinkOutlinedIcon from '@material-ui/icons/LinkOutlined';
 import TeamTaskConfirmDialog from './TeamTaskConfirmDialog';
 import TeamTaskCard from './TeamTaskCard';
+import TeamTaskContainer from './TeamTaskContainer';
 import Reorder from '../layout/Reorder';
 import ConditionalField from '../task/ConditionalField';
 import EditTaskDialog from '../task/EditTaskDialog';
@@ -37,7 +38,6 @@ function submitMoveTeamTaskUp({
                   label
                   order
                   tasks_count
-                  tasks_with_answers_count
                 }
               }
             }
@@ -76,7 +76,6 @@ function submitMoveTeamTaskDown({
                   label
                   order
                   tasks_count
-                  tasks_with_answers_count
                 }
               }
             }
@@ -115,7 +114,6 @@ function submitTask({
                   label
                   order
                   tasks_count
-                  tasks_with_answers_count
                 }
               }
             }
@@ -330,30 +328,37 @@ class TeamTasksListItem extends React.Component {
               onChange={this.handleConditionChange}
             />
           </TeamTaskCard>
-          <TeamTaskConfirmDialog
-            projects={projects}
-            selectedProjects={selectedProjects}
-            editedTask={this.state.editedTask}
-            editLabelOrDescription={this.state.editLabelOrDescription}
-            open={this.state.dialogOpen}
-            task={task}
-            action={this.state.action}
-            handleClose={this.handleCloseDialog}
-            handleConfirm={this.handleConfirmDialog}
-            message={this.state.message}
-          />
+          { this.state.dialogOpen ?
+            <TeamTaskContainer task={task} team={this.props.team}>
+              {teamTask => (
+                <TeamTaskConfirmDialog
+                  projects={projects}
+                  selectedProjects={selectedProjects}
+                  editedTask={this.state.editedTask}
+                  editLabelOrDescription={this.state.editLabelOrDescription}
+                  task={teamTask}
+                  open={this.state.dialogOpen}
+                  action={this.state.action}
+                  handleClose={this.handleCloseDialog}
+                  handleConfirm={this.handleConfirmDialog}
+                  message={this.state.message}
+                />
+              )}
+            </TeamTaskContainer> : null }
           { this.state.isEditing ?
-            <EditTaskDialog
-              task={task}
-              message={this.state.message}
-              taskType={task.type}
-              onDismiss={this.handleCloseEdit}
-              onSubmit={this.handleEdit}
-              projects={projects}
-              isTeamTask
-            />
-            : null
-          }
+            <TeamTaskContainer task={task} team={this.props.team}>
+              {teamTask => (
+                <EditTaskDialog
+                  message={this.state.message}
+                  taskType={teamTask.type}
+                  onDismiss={this.handleCloseEdit}
+                  onSubmit={this.handleEdit}
+                  projects={projects}
+                  task={teamTask}
+                  isTeamTask
+                />
+              )}
+            </TeamTaskContainer> : null }
         </Box>
       </React.Fragment>
     );
@@ -372,7 +377,6 @@ TeamTasksListItem.propTypes = {
     json_options: PropTypes.string,
     json_project_ids: PropTypes.string,
     json_schema: PropTypes.string,
-    tasks_with_answers_count: PropTypes.number,
     tasks_count: PropTypes.number,
   }).isRequired,
   tasks: PropTypes.array.isRequired,


### PR DESCRIPTION
The GraphQL field "tasks_with_answers_count" from "TeamTaskType" is pretty expensive. It was required in the list view of team tasks (a.k.a., "Annotations" settings page for a workspace) for all annotation fields, although it is required only when the "edit" or "delete" options for a field is clicked. So, there was a N + 1 performance problem happening here for workspace with many annotation fields. The fix was to wrap the components that need the "tasks_with_answers_count" GraphQL field by a new container that requests that field.

Reference: CHECK-2089.