### PR TITLE
Feature/1904 allow unconfirmed item actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14680,7 +14680,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -294,8 +294,11 @@ class MediaActionsBarComponent extends Component {
           {isParent ?
             <MediaStatus
               media={media}
-              readonly={media.archived > CheckArchivedFlags.NONE
-                || media.last_status_obj.locked || published}
+              readonly={(
+                (media.archived > CheckArchivedFlags.NONE && media.archived !== CheckArchivedFlags.UNCONFIRMED) ||
+                media.last_status_obj.locked ||
+                published
+              )}
             /> : null
           }
           <MediaActionsMenuButton
@@ -519,4 +522,5 @@ class MediaActionsBar extends React.PureComponent {
   }
 }
 
+export { MediaActionsBarComponent };
 export default MediaActionsBar;

--- a/src/app/components/media/MediaActionsBar.test.js
+++ b/src/app/components/media/MediaActionsBar.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { shallowWithIntl } from '../../../../test/unit/helpers/intl-test';
+import MediaStatus from './MediaStatus';
+import { MediaActionsBarComponent } from './MediaActionsBar';
+import CheckArchivedFlags from '../../CheckArchivedFlags';
+
+describe('<MediaActionsBarComponent />', () => {
+  const team = {
+    slug: 'test',
+    verification_statuses: {
+      label: 'Status',
+      default: 'undetermined',
+      active: 'in_progress',
+      statuses: [
+        {
+          description: 'Default, just added, no work has started',
+          id: 'undetermined',
+          label: 'Unstarted',
+          style: {
+            backgroundColor: '#518FFF',
+            color: '#518FFF',
+          },
+        },
+      ],
+    },
+    team_users: {
+      edges: [],
+    },
+  };
+
+  const classes = {};
+
+  it('should allow status change for Unconfirmed items', () => {
+    const media = {
+      team,
+      archived: CheckArchivedFlags.UNCONFIRMED,
+      last_status_obj: {
+        locked: false,
+        assignments: {
+          edges: [],
+        },
+      },
+      dynamic_annotation_report_design: {
+        data: {
+          state: 'not-published', // As opposed to 'published' for this matter. Not necessarily an actual possible value.
+        },
+      },
+    };
+    const wrapper = shallowWithIntl(<MediaActionsBarComponent media={media} classes={classes} setFlashMessage={() => {}} />);
+    expect(wrapper.find(MediaStatus)).toHaveLength(1);
+    expect(wrapper.find(MediaStatus).props().readonly).toEqual(false);
+  });
+
+  it('should NOT allow status change for Trashed items', () => {
+    const media = {
+      team,
+      archived: CheckArchivedFlags.TRASHED,
+      last_status_obj: {
+        locked: false,
+        assignments: {
+          edges: [],
+        },
+      },
+      dynamic_annotation_report_design: {
+        data: {
+          state: 'not-published', // As opposed to 'published' for this matter. Not necessarily an actual possible value.
+        },
+      },
+    };
+    const wrapper = shallowWithIntl(<MediaActionsBarComponent media={media} classes={classes} setFlashMessage={() => {}} />);
+    expect(wrapper.find(MediaStatus)).toHaveLength(1);
+    expect(wrapper.find(MediaStatus).props().readonly).toEqual(true);
+  });
+
+  it('should NOT allow status change for published items', () => {
+    const media = {
+      team,
+      archived: CheckArchivedFlags.NONE,
+      last_status_obj: {
+        locked: false,
+        assignments: {
+          edges: [],
+        },
+      },
+      dynamic_annotation_report_design: {
+        data: {
+          state: 'published',
+        },
+      },
+    };
+    const wrapper = shallowWithIntl(<MediaActionsBarComponent media={media} classes={classes} setFlashMessage={() => {}} />);
+    expect(wrapper.find(MediaStatus)).toHaveLength(1);
+    expect(wrapper.find(MediaStatus).props().readonly).toEqual(true);
+  });
+});

--- a/src/app/components/media/MediaActionsMenuButton.js
+++ b/src/app/components/media/MediaActionsMenuButton.js
@@ -112,7 +112,10 @@ class MediaActionsMenuButton extends React.PureComponent {
           </MenuItem>));
       }
 
-      if (can(projectMedia.permissions, 'update ProjectMedia') && projectMedia.archived === CheckArchivedFlags.NONE) {
+      if (can(projectMedia.permissions, 'update ProjectMedia') && (
+        projectMedia.archived === CheckArchivedFlags.NONE ||
+        projectMedia.archived === CheckArchivedFlags.UNCONFIRMED
+      )) {
         menuItems.push((
           <MenuItem
             key="mediaActions.sendToTrash"
@@ -152,6 +155,7 @@ class MediaActionsMenuButton extends React.PureComponent {
     return menuItems.length ? (
       <div>
         <IconButton
+          id="media-actions-menu-button__icon-button"
           tooltip={<FormattedMessage id="mediaActions.tooltip" defaultMessage="Item actions" />}
           onClick={this.handleOpenMenu}
         >
@@ -170,6 +174,7 @@ class MediaActionsMenuButton extends React.PureComponent {
   }
 }
 
+export { MediaActionsMenuButton };
 export default createFragmentContainer(MediaActionsMenuButton, {
   projectMedia: graphql`
     fragment MediaActionsMenuButton_projectMedia on ProjectMedia {

--- a/src/app/components/media/MediaActionsMenuButton.test.js
+++ b/src/app/components/media/MediaActionsMenuButton.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { MediaActionsMenuButton } from './MediaActionsMenuButton';
+import CheckArchivedFlags from '../../CheckArchivedFlags';
+
+describe('<MediaActionsMenuButton />', () => {
+  const props = {
+    isParent: true,
+    projectMedia: {
+      id: 'bli',
+      permissions: '{"update ProjectMedia":true}',
+      archived: CheckArchivedFlags.NONE,
+      last_status_obj: {
+        locked: false,
+      },
+      media: {
+        url: 'http://bli.blo',
+      },
+    },
+    handleRefresh: () => {},
+    handleSendToTrash: () => {},
+    handleSendToSpam: () => {},
+    handleAssign: () => {},
+    handleStatusLock: () => {},
+  };
+
+  it('should allow sending Unconfirmed items to the Trash and to Spam', () => {
+    const wrapper = mountWithIntl(<MediaActionsMenuButton {...props} />);
+    wrapper.find('#media-actions-menu-button__icon-button').hostNodes().simulate('click');
+    expect(wrapper.find('.media-actions').at(0).props().open).toEqual(true);
+    expect(wrapper.find('.media-actions__history').hostNodes().length).toEqual(1);
+    expect(wrapper.find('.media-actions__send-to-trash').hostNodes().length).toEqual(1);
+    expect(wrapper.find('.media-actions__send-to-spam').hostNodes().length).toEqual(1);
+  });
+});

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -136,7 +136,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   return (
     <Box id="media__fact-check">
       <Box id="media__fact-check-title" display="flex" alignItems="center" mb={2} justifyContent="space-between">
-        <Typography className={classes.title} variant="body" component="div">
+        <Typography className={classes.title} variant="body1" component="div">
           <strong>
             <FormattedMessage id="mediaFactCheck.factCheck" defaultMessage="Fact-check" description="Title of the media fact-check section." />
           </strong>

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
@@ -243,7 +243,7 @@ const ReportDesignerComponent = (props) => {
         state={data.state}
         readOnly={
           !can(media.permissions, 'update ProjectMedia') ||
-          media.archived > CheckArchivedFlags.NONE ||
+          (media.archived > CheckArchivedFlags.NONE && media.archived !== CheckArchivedFlags.UNCONFIRMED) ||
           pending
         }
         onStatusChange={handleStatusChange}

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import ReportDesignerComponent from './ReportDesignerComponent';
+import ReportDesignerTopBar from './ReportDesignerTopBar';
+import CheckArchivedFlags from '../../../CheckArchivedFlags';
+
+describe('<ReportDesignerComponent />', () => {
+
+  const props = {
+    media: {
+      permissions: '{"update ProjectMedia":true}',
+      archived: CheckArchivedFlags.UNCONFIRMED,
+      last_status: 'undetermined',
+      team: {
+        verification_statuses: {
+          label: 'Status',
+          default: 'undetermined',
+          active: 'in_progress',
+          statuses: [
+            {
+              description: 'Default, just added, no work has started',
+              id: 'undetermined',
+              label: 'Unstarted',
+              style: {
+                backgroundColor: '#518FFF',
+                color: '#518FFF',
+              },
+              locales: {
+                en: {
+                  label: 'Unstarted',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    routeParams: {
+      projectId: '1',
+    },
+    location: {
+      query: {
+        listPath: '',
+      },
+    },
+    setFlashMessage: () => {},
+  };
+
+  it('should allow status change for Unconfirmed items', () => {
+    const wrapper = mountWithIntl(<ReportDesignerComponent {...props} />);
+    expect(wrapper.find(ReportDesignerTopBar)).toHaveLength(1);
+    expect(wrapper.find(ReportDesignerTopBar).props().readOnly).toEqual(false);
+  });
+});

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
@@ -5,7 +5,6 @@ import ReportDesignerTopBar from './ReportDesignerTopBar';
 import CheckArchivedFlags from '../../../CheckArchivedFlags';
 
 describe('<ReportDesignerComponent />', () => {
-
   const props = {
     media: {
       permissions: '{"update ProjectMedia":true}',


### PR DESCRIPTION
Allow actions for Unconfirmed items

This commit allows setting statuses for unconfirmed items and sending them to trash or spam.
Unit tests implemented for components the modified components.

Fixes CHECK-1904