### PR TITLE
Add unit tests for Select Project Dialog Component

### DIFF
--- a/src/app/components/media/SelectProjectDialog.test.js
+++ b/src/app/components/media/SelectProjectDialog.test.js
@@ -7,8 +7,23 @@ const team = {
   name: 'teamName',
   slug: 'slugTeam',
   members_count: 1,
-  project_groups: { edges: [{ node: { project_group_id: '1' } }] },
-  projects: { edges: [{ node: { project_group_id: '1' } }] },
+  default_folder: {dbid: 1},
+  project_groups: { edges: [{ node: { project_group_id: '1' , title: 'title'} }] },
+  projects: { edges: [{ node: { title: 'title', dbid: 2, project_group_id: '1'} }] },
+  user: {
+    dbid: 1,
+    name: 'User Name',
+  },
+};
+
+const team2 = {
+  dbid: 1,
+  name: 'teamName',
+  slug: 'slugTeam',
+  members_count: 1,
+  default_folder: {dbid: 1},
+  project_groups: { edges: [{ node: { project_group_id: '1' , title: 'title'} }] },
+  projects: { edges: [{ node: { title: 'title', dbid: 1, project_group_id: '1'} }] },
   user: {
     dbid: 1,
     name: 'User Name',
@@ -27,8 +42,24 @@ const intl = {
 };
 describe('<SelectProjectDialog/>', () => {
   const node = <div />;
-  // render Dialog even without pass team default folder
-  it('should render Select Project Dialog', () => {
+  it('should render Select Project Dialog when default folder is on project list ', () => {
+    const wrapper = mountWithIntl(<SelectProjectDialogTest
+      open
+      excludeProjectDbids={[]}
+      title={node}
+      team={team2}
+      intl={intl}
+      cancelLabel={node}
+      submitLabel={node}
+      submitButtonClassName="media-actions-bar__move-button"
+      onCancel={() => {}}
+      onSubmit={() => {}}
+    />);
+    expect(wrapper.find('.media-actions-bar__move-button').hostNodes()).toHaveLength(1);
+    expect(wrapper.html()).toMatch('Choose a folder');
+  });
+
+  it('should render Select Project Dialog when default folder is not on project list', () => {
     const wrapper = mountWithIntl(<SelectProjectDialogTest
       open
       excludeProjectDbids={[]}

--- a/src/app/components/media/SelectProjectDialog.test.js
+++ b/src/app/components/media/SelectProjectDialog.test.js
@@ -7,9 +7,15 @@ const team = {
   name: 'teamName',
   slug: 'slugTeam',
   members_count: 1,
-  default_folder: {dbid: 1},
-  project_groups: { edges: [{ node: { project_group_id: '1' , title: 'title'} }] },
-  projects: { edges: [{ node: { title: 'title', dbid: 2, project_group_id: '1'} }] },
+  default_folder: { dbid: 1, id: 'UHJvamVjdC80\n' },
+  project_groups: { edges: [{ node: { project_group_id: '1', title: 'title' } }] },
+  projects: {
+    edges: [{
+      node: {
+        title: 'title', dbid: 2, project_group_id: '1', id: 'ABJvamVjdC70\n',
+      },
+    }],
+  },
   user: {
     dbid: 1,
     name: 'User Name',
@@ -21,9 +27,15 @@ const team2 = {
   name: 'teamName',
   slug: 'slugTeam',
   members_count: 1,
-  default_folder: {dbid: 1},
-  project_groups: { edges: [{ node: { project_group_id: '1' , title: 'title'} }] },
-  projects: { edges: [{ node: { title: 'title', dbid: 1, project_group_id: '1'} }] },
+  default_folder: { dbid: 1, id: 'UHJvamVjdC80\n' },
+  project_groups: { edges: [{ node: { project_group_id: '1', title: 'title' } }] },
+  projects: {
+    edges: [{
+      node: {
+        title: 'title', dbid: 1, project_group_id: '1', id: 'UHJvamVjdC80\n',
+      },
+    }],
+  },
   user: {
     dbid: 1,
     name: 'User Name',


### PR DESCRIPTION
## Description

Add unit tests for verify that Select Project Dialog Component is rendered when default folder is on project list and when it is not.

References: CHECK-2078: 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add/Update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

