### PR TITLE
CHECK-2060: show update language on item history

### DIFF
--- a/localization/react-intl/src/app/components/annotations/Annotation.json
+++ b/localization/react-intl/src/app/components/annotations/Annotation.json
@@ -101,6 +101,10 @@
     "defaultMessage": "Language {value} added by {author}"
   },
   {
+    "id": "annotation.updateLanguage",
+    "defaultMessage": "Language {value} updated by {author}"
+  },
+  {
     "id": "annotation.metadataResponse",
     "defaultMessage": "Annotation \"{fieldLabel}\" edited by {author}: {response}"
   },

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -716,7 +716,7 @@ class Annotation extends Component {
         );
       }
 
-      if (object.field_name === 'language' && activityType === 'create_dynamicannotationfield') {
+      if (object.field_name === 'language') {
         const languageName = object.value !== 'und' ? languageLabel(object.value) : (
           <FormattedMessage
             id="annotation.unknownLanguage"
@@ -724,7 +724,7 @@ class Annotation extends Component {
             description="Show label for undefined language"
           />
         );
-        contentTemplate = (
+        contentTemplate = activityType === 'create_dynamicannotationfield' ? (
           <span>
             <FormattedMessage
               id="annotation.addLanguage"
@@ -732,6 +732,17 @@ class Annotation extends Component {
               values={{
                 value: languageName,
                 author: (<FormattedMessage {...globalStrings.appNameHuman} />),
+              }}
+            />
+          </span>
+        ) : (
+          <span>
+            <FormattedMessage
+              id="annotation.updateLanguage"
+              defaultMessage="Language {value} updated by {author}"
+              values={{
+                value: languageName,
+                author: authorName,
               }}
             />
           </span>


### PR DESCRIPTION
## Description

Show the update language event in item history i.e `{date}: Language {language_name} updated by {username}`
References: CHECK-2060

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
 - Create a new item
 - Go to item page and update the language
 - Open item history tab
 - You should find a log like this one `{date}: Language {language_name} updated by {username}`
