### PR TITLE
Fix: 'TypeError: a.replace is not a function

### DIFF
--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -111,7 +111,7 @@ class AddAnnotation extends Component {
     );
     const message = getErrorMessage(transaction, fallbackMessage);
     this.setState({
-      message: message.replace(/<br\s*\/?>/gm, '; '),
+      message: typeof message === 'string' ? message.replace(/<br\s*\/?>/gm, '; ') : message,
       isSubmitting: false,
     });
   };

--- a/src/app/components/annotations/AddAnnotation.test.js
+++ b/src/app/components/annotations/AddAnnotation.test.js
@@ -7,13 +7,15 @@ describe('<AddAnnotation />', () => {
   const annotated_archived = { archived: CheckArchivedFlags.TRASHED };
   const annotated_not_archived = { archived: CheckArchivedFlags.NONE };
 
-  it('Hides when media is archived (Trash)', () => {
+  it('Should hides when media is archived (Trash)', () => {
     const addAnnotation = mountWithIntl(<AddAnnotation annotated={annotated_archived} />);
     expect(addAnnotation.html()).toEqual(null);
+    console.log(addAnnotation.debug());
   });
 
-  it('Render component when media is not archived (not in the trash)', () => {
+  it('Should render component when media is not archived (not in the trash)', () => {
     const addAnnotation = mountWithIntl(<AddAnnotation annotated={annotated_not_archived} />);
+    console.log(addAnnotation.debug());
     expect(addAnnotation.html()).not.toEqual('');
   });
 });

--- a/src/app/components/annotations/AddAnnotation.test.js
+++ b/src/app/components/annotations/AddAnnotation.test.js
@@ -10,12 +10,10 @@ describe('<AddAnnotation />', () => {
   it('Should hides when media is archived (Trash)', () => {
     const addAnnotation = mountWithIntl(<AddAnnotation annotated={annotated_archived} />);
     expect(addAnnotation.html()).toEqual(null);
-    console.log(addAnnotation.debug());
   });
 
   it('Should render component when media is not archived (not in the trash)', () => {
     const addAnnotation = mountWithIntl(<AddAnnotation annotated={annotated_not_archived} />);
-    console.log(addAnnotation.debug());
     expect(addAnnotation.html()).not.toEqual('');
   });
 });

--- a/src/app/helpers.test.js
+++ b/src/app/helpers.test.js
@@ -1,0 +1,27 @@
+/* eslint-disable @calm/react-intl/missing-attribute */
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { getErrorMessage } from './helpers';
+import { stringHelper } from './customHelpers';
+
+describe('Helpers', () => {
+  const fallbackMessage = (
+    <FormattedMessage
+      id="addAnnotation.error"
+      defaultMessage="Sorry, an error occurred while updating the item. Please try again and contact {supportEmail} if the condition persists."
+      values={{ supportEmail: stringHelper('SUPPORT_EMAIL') }}
+    />
+  );
+
+  it('Should return the transaction error message)', () => {
+    const transaction = { source: JSON.stringify({ errors: [{ message: 'This is not a default error message' }] }) };
+    const message = getErrorMessage(transaction, fallbackMessage);
+    expect(message).toMatch('This is not a default error message');
+  });
+
+  it('Should return the default error message)', () => {
+    const transaction = { source: 'error' };
+    const message = getErrorMessage(transaction, fallbackMessage);
+    expect(message.props.defaultMessage).toMatch('Sorry, an error occurred while updating the item. Please try again');
+  });
+});


### PR DESCRIPTION
## Description

This PR Fix the "TypeError: a.replace is not a function"
By add verification before try to use replace function and add unit tests for helper function

Reference: Ticket CHECK-2055

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add/update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

