### PR TITLE
Add disabled relay/unused-fields rule to files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "plugins": [
         "require-path-exists",
         "@calm/react-intl",
+        "relay",
     ],
     "rules": {
         "indent": [2, 2],
@@ -31,6 +32,9 @@
         "react/prop-types": "off",
         "react/forbid-prop-types": "off",
         "react/no-children-prop": "off",
+
+        // Relay
+        "relay/unused-fields": "error",
 
         // TODO Fix a11y issues
         "jsx-a11y/no-static-element-interactions": "off",

--- a/localization/react-intl/src/app/components/media/MediaExpandedArchives.json
+++ b/localization/react-intl/src/app/components/media/MediaExpandedArchives.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "mediaExpandedArchives.archives",
+    "description": "This is a header that tells the user that what follows is a list of archival services on the internet that they can use to permanently save the content at a URL.",
     "defaultMessage": "Archives:"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaLanguageChip.json
+++ b/localization/react-intl/src/app/components/media/MediaLanguageChip.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "mediaLanguageChip.error",
+    "description": "This message appears when a user tries to update the language on a media item and an error occurs.",
     "defaultMessage": "Sorry, an error occurred while updating the language. Please try again and contact {supportEmail} if the condition persists."
   }
 ]

--- a/localization/react-intl/src/app/components/project/ProjectGroup.json
+++ b/localization/react-intl/src/app/components/project/ProjectGroup.json
@@ -1,10 +1,12 @@
 [
   {
     "id": "projectGroup.name",
+    "description": "A placeholder that appears if for some reason a collection lacks a name. This should never appear to the user, but please localize it just in case.",
     "defaultMessage": "collection"
   },
   {
     "id": "projectGroup.deleteMessage",
+    "description": "A message that appears when a user attempts to delete a collection to warn them that any folders inside will NOT be deleted, and will still be accessible.",
     "defaultMessage": "If you delete this collection, all folders will still be accessible outside of the collection."
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6382,6 +6382,15 @@
         }
       }
     },
+    "eslint-plugin-relay": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.8.3.tgz",
+      "integrity": "sha512-awyrwntUTZ7Z+lJUnniTCnJdZYr1dY2djQDARMx1P1y2BFMsBjtTljBK0lBEM7yiTHPBwVnE2OSnXxcD4yMb0A==",
+      "dev": true,
+      "requires": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
     "eslint-plugin-require-path-exists": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/eslint-plugin-require-path-exists/-/eslint-plugin-require-path-exists-1.1.7.tgz",
@@ -11671,7 +11680,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14680,7 +14689,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -14906,7 +14915,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.2",
     "enzyme": "^3.3.0",
+    "eslint-plugin-relay": "^1.8.3",
     "jest": "^25.4.0"
   },
   "dependencies": {

--- a/src/app/components/InviteNewAccount.js
+++ b/src/app/components/InviteNewAccount.js
@@ -277,13 +277,11 @@ const InviteNewAccount = ({ teamSlug }) => (
           dbid
           name
           email
-          login
           accepted_terms
           team_user(team_slug: $teamSlug) {
             team {
               dbid
               name
-              slug
             }
             invited_by {
               name

--- a/src/app/components/drawer/Projects/index.js
+++ b/src/app/components/drawer/Projects/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/media/BulkActions.js
+++ b/src/app/components/media/BulkActions.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/media/BulkActionsAssign.js
+++ b/src/app/components/media/BulkActionsAssign.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/media/BulkActionsMenu.js
+++ b/src/app/components/media/BulkActionsMenu.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/BulkActionsMove.js
+++ b/src/app/components/media/BulkActionsMove.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/ChangeMediaSource.js
+++ b/src/app/components/media/ChangeMediaSource.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/media/MediaActionsMenuButton.js
+++ b/src/app/components/media/MediaActionsMenuButton.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/MediaExpandedActions.js
+++ b/src/app/components/media/MediaExpandedActions.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/MediaExpandedArchives.js
+++ b/src/app/components/media/MediaExpandedArchives.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
+/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -76,11 +76,12 @@ MediaExpandedArchives.propTypes = {
   }).isRequired,
 };
 
+// eslint-disable-next-line import/no-unused-modules
+export { MediaExpandedArchives as MediaExpandedArchivesTest };
+
 export default createFragmentContainer(MediaExpandedArchives, {
   projectMedia: graphql`
     fragment MediaExpandedArchives_projectMedia on ProjectMedia {
-      id
-      dbid
       archiver: annotation(annotation_type: "archiver") {
         data
       }

--- a/src/app/components/media/MediaExpandedArchives.js
+++ b/src/app/components/media/MediaExpandedArchives.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -43,7 +43,7 @@ const MediaExpandedArchives = ({ projectMedia }) => {
       <Grid container spacing={2}>
         <Grid item xs={2}>
           <Typography variant="subtitle2">
-            <FormattedMessage id="mediaExpandedArchives.archives" defaultMessage="Archives:" />
+            <FormattedMessage id="mediaExpandedArchives.archives" defaultMessage="Archives:" description="This is a header that tells the user that what follows is a list of archival services on the internet that they can use to permanently save the content at a URL." />
           </Typography>
         </Grid>
         { activeArchivers.map(f => (

--- a/src/app/components/media/MediaExpandedArchives.test.js
+++ b/src/app/components/media/MediaExpandedArchives.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { MediaExpandedArchivesTest } from './MediaExpandedArchives';
+
+describe('<MediaExpandedArchives />', () => {
+  const projectMedia = {
+    archiver: {
+      data: {
+        fields: [
+          {
+            field_name: 'archive_is_response',
+            value_json: {
+              location: 'https://example.com/archive',
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it('should render with the test archive', () => {
+    const wrapper = mountWithIntl(<MediaExpandedArchivesTest
+      projectMedia={projectMedia}
+    />);
+
+    expect(wrapper.find('ExternalLink').text()).toBe('Archive.is');
+    expect(wrapper.find('ExternalLink').childAt(0).render().attr('href')).toBe('https://example.com/archive');
+  });
+});

--- a/src/app/components/media/MediaExpandedMetadata.js
+++ b/src/app/components/media/MediaExpandedMetadata.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedNumber } from 'react-intl';

--- a/src/app/components/media/MediaLanguageChip.js
+++ b/src/app/components/media/MediaLanguageChip.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
@@ -32,6 +32,7 @@ const MediaLanguageChip = ({ projectMedia, setFlashMessage }) => {
           id="mediaLanguageChip.error"
           defaultMessage="Sorry, an error occurred while updating the language. Please try again and contact {supportEmail} if the condition persists."
           values={{ supportEmail: stringHelper('SUPPORT_EMAIL') }}
+          description="This message appears when a user tries to update the language on a media item and an error occurs."
         />
       );
       const errorMessage = getErrorMessage(transaction, fallbackMessage);

--- a/src/app/components/media/MediaSearchRedirect.js
+++ b/src/app/components/media/MediaSearchRedirect.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/media/MediaSource.js
+++ b/src/app/components/media/MediaSource.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';

--- a/src/app/components/media/MediaTags.js
+++ b/src/app/components/media/MediaTags.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/NextPreviousLinks.js
+++ b/src/app/components/media/NextPreviousLinks.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/media/RestoreConfirmProjectMediaToProjectAction.js
+++ b/src/app/components/media/RestoreConfirmProjectMediaToProjectAction.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/media/Similarity/MediaSimilarityBar.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBar.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/media/Similarity/MediaSuggestions.js
+++ b/src/app/components/media/Similarity/MediaSuggestions.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/project/ProjectGroup.js
+++ b/src/app/components/project/ProjectGroup.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';
@@ -51,7 +51,7 @@ const ProjectGroup = ({ routeParams }) => (
                   <ProjectActions
                     object={props.project_group}
                     objectType="ProjectGroup"
-                    name={<FormattedMessage id="projectGroup.name" defaultMessage="collection" />}
+                    name={<FormattedMessage id="projectGroup.name" defaultMessage="collection" description="A placeholder that appears if for some reason a collection lacks a name. This should never appear to the user, but please localize it just in case." />}
                     updateMutation={graphql`
                       mutation ProjectGroupUpdateProjectGroupMutation($input: UpdateProjectGroupInput!) {
                         updateProjectGroup(input: $input) {
@@ -67,6 +67,7 @@ const ProjectGroup = ({ routeParams }) => (
                       <FormattedMessage
                         id="projectGroup.deleteMessage"
                         defaultMessage="If you delete this collection, all folders will still be accessible outside of the collection."
+                        description="A message that appears when a user attempts to delete a collection to warn them that any folders inside will NOT be deleted, and will still be accessible."
                       />
                     }
                     deleteMutation={graphql`

--- a/src/app/components/project/ProjectMoveDialog.js
+++ b/src/app/components/project/ProjectMoveDialog.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/search/SavedSearch.js
+++ b/src/app/components/search/SavedSearch.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/search/SearchFields/SearchFieldSource.js
+++ b/src/app/components/search/SearchFields/SearchFieldSource.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';

--- a/src/app/components/search/SearchKeywordConfig/SearchKeywordContainer.js
+++ b/src/app/components/search/SearchKeywordConfig/SearchKeywordContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/source/SourceInfo.js
+++ b/src/app/components/source/SourceInfo.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql, commitMutation, createFragmentContainer } from 'react-relay/compat';

--- a/src/app/components/team/ChangeUserRole.js
+++ b/src/app/components/team/ChangeUserRole.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/Languages/LanguagesComponent.js
+++ b/src/app/components/team/Languages/LanguagesComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/team/Languages/index.js
+++ b/src/app/components/team/Languages/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/Rules/index.js
+++ b/src/app/components/team/Rules/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/team/Similarity/index.js
+++ b/src/app/components/team/Similarity/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/SmoochBot/index.js
+++ b/src/app/components/team/SmoochBot/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/Statuses/index.js
+++ b/src/app/components/team/Statuses/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React, { Component } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';

--- a/src/app/components/team/TeamData/index.js
+++ b/src/app/components/team/TeamData/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/TeamDetails.js
+++ b/src/app/components/team/TeamDetails.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/TeamIntegrations.js
+++ b/src/app/components/team/TeamIntegrations.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/TeamLists/index.js
+++ b/src/app/components/team/TeamLists/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/TeamMembersComponent.js
+++ b/src/app/components/team/TeamMembersComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/TeamReport/index.js
+++ b/src/app/components/team/TeamReport/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/TeamTags/index.js
+++ b/src/app/components/team/TeamTags/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/TeamTaskContainer.js
+++ b/src/app/components/team/TeamTaskContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';

--- a/src/app/components/team/TeamTasks.js
+++ b/src/app/components/team/TeamTasks.js
@@ -1,3 +1,4 @@
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';

--- a/src/app/components/trends/Trends.js
+++ b/src/app/components/trends/Trends.js
@@ -17,7 +17,6 @@ const Trends = ({ routeParams }) => (
       query={graphql`
         query TrendsQuery($slug: String!) {
           team(slug: $slug) {
-            id
             get_trends_filters
             get_trends_enabled
           }

--- a/src/app/components/trends/TrendsItem.js
+++ b/src/app/components/trends/TrendsItem.js
@@ -1,3 +1,4 @@
+/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';
@@ -40,7 +41,6 @@ const TrendsItem = ({ routeParams, location }) => {
                       team {
                         name
                         dbid
-                        country
                       }
                     }
                   }
@@ -48,9 +48,6 @@ const TrendsItem = ({ routeParams, location }) => {
               }
             }
             cluster(id: $clusterId) {
-              size
-              first_item_at
-              last_item_at
               requests_count
               claim_descriptions(first: 1000) {
                 edges {
@@ -70,9 +67,6 @@ const TrendsItem = ({ routeParams, location }) => {
                         data
                       }
                       last_status
-                      last_status_obj {
-                        data
-                      }
                       tags(first: 10000) {
                         edges {
                           node {
@@ -86,7 +80,6 @@ const TrendsItem = ({ routeParams, location }) => {
                           node {
                             slug
                             label
-                            options
                             first_response_value
                           }
                         }
@@ -113,41 +106,24 @@ const TrendsItem = ({ routeParams, location }) => {
                     requests_count
                     updated_at
                     last_seen
-                    created_at
                     picture
-                    language_code
-                    pusher_channel
                     dbid
-                    project_id
-                    full_url
-                    domain
                     team {
                       id
                       dbid
                       slug
                       name
                       avatar
-                      get_language
-                      get_report
                       verification_statuses
-                      team_bots(first: 10000) {
-                        edges {
-                          node {
-                            login
-                          }
-                        }
-                      }
                     }
                     media {
                       dbid
                       url
                       quote
-                      embed_path
                       metadata
                       type
                       picture
                       file_path
-                      thumbnail_path
                     }
                   }
                 }


### PR DESCRIPTION
## Description

Per discussion on the engineering team, I'm adding the eslint relay plugin and having it flag an error whenever graphql fields are not used _in the same file_ as the query/fragment.

This means that the dozens of places where we have a big query on a parent component and then pass the result down to a child in a different file _will_ trigger a linter error. Since we can't fix this all at once, I'm taking the same path we did with the `description` eslint rule for react-intl and selectively disabling it in all files. As we do work on these files in the course of normal Check development, we will refactor the queries to correctly follow a pattern where data fragments of minimal size are pulled in only when needed by the code.

I also took the time to remove a few unused fields in a few files. I also added some `description` fields in a few places and removed the corresponding `eslint-disable @calm/react-intl/missing-attribute` comment in the header.

References: CHECK-2142

## Type of change

Refactor

## How has this been tested?

N/A, this is putting in eslint rules for future use.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [x] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)