### PR TITLE
Refactoring workspace statuses settings page.

### DIFF
--- a/localization/react-intl/src/app/components/team/Statuses/DeleteStatusDialog.json
+++ b/localization/react-intl/src/app/components/team/Statuses/DeleteStatusDialog.json
@@ -1,22 +1,42 @@
 [
   {
+    "id": "deleteStatusDialog.statusNotInUseTitle",
+    "description": "Title displayed on a confirmation modal when a status being deleted is not in used by any item.",
+    "defaultMessage": "Confirm status deletion"
+  },
+  {
+    "id": "deleteStatusDialog.statusNotInUseMessage",
+    "description": "Confirmation message displayed on a modal when a status is deleted from statuses settings page.",
+    "defaultMessage": "Are you sure you want to delete this status?"
+  },
+  {
+    "id": "statusesComponent.deleteButton",
+    "description": "Button label to delete status",
+    "defaultMessage": "Delete status"
+  },
+  {
     "id": "deleteStatusDialog.moveItemsTo",
+    "description": "This is a field label. In this field, a destination status can be set, so, when a status is deleted, all existing items will be moved to this status defined here in this field.",
     "defaultMessage": "Move items to"
   },
   {
     "id": "deleteStatusDialog.statusInUseTitle",
+    "description": "Title of a modal that is displayed when a status in use is being deleted.",
     "defaultMessage": "{itemsCount, plural, one {You need to change the status of one item to delete this status} other {You need to change the status of # items to delete this status}}"
   },
   {
     "id": "deleteStatusDialog.statusInUseMessage",
+    "description": "Message of a modal that is displayed when a status in use is being deleted.",
     "defaultMessage": "{itemsCount, plural, one {There is one item with the status {statusLabel} that must be changed to another status before you can delete this status.} other {There are # items with the status {statusLabel} that must be changed to another status before you can delete this status.}}"
   },
   {
     "id": "deleteStatusDialog.itemsPublishedMessage",
+    "description": "Message of a modal that is displayed when a status in use is being deleted.",
     "defaultMessage": "{publishedCount, plural, one {There  is one item currently published with the status {statusLabel}. If you continue, all published items with this status will be paused. You must review those items to re-publish them.} other {There are # items currently published with the status {statusLabel}. If you continue, all published items with this status will be paused. You must review those items to re-publish them.}}"
   },
   {
     "id": "statusesComponent.moveItemsAndDelete",
+    "description": "Label of a button that is displayed when a status in use is being deleted.",
     "defaultMessage": "Move items and delete status"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Statuses/StatusesComponent.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusesComponent.json
@@ -1,18 +1,22 @@
 [
   {
     "id": "statusesComponent.error",
+    "description": "Error message displayed when status can't be changed.",
     "defaultMessage": "Sorry, an error occurred while updating the statuses. Please try again and contact {supportEmail} if the condition persists."
   },
   {
     "id": "statusesComponent.deleted",
+    "description": "Success message displayed when status is deleted.",
     "defaultMessage": "Status deleted successfully"
   },
   {
     "id": "statusesComponent.saved",
+    "description": "Success message displayed when status is saved.",
     "defaultMessage": "Statuses saved successfully"
   },
   {
     "id": "statusesComponent.created",
+    "description": "Success message displayed when status is created.",
     "defaultMessage": "Status created successfully"
   },
   {
@@ -22,10 +26,12 @@
   },
   {
     "id": "statusesComponent.newStatus",
+    "description": "Button label to create a new status.",
     "defaultMessage": "New status"
   },
   {
     "id": "statusesComponent.blurbSecondary",
+    "description": "Message displayed on status translation page.",
     "defaultMessage": "Translate statuses in secondary languages in order to display them in local languages in your fact checking reports."
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14680,7 +14680,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/src/app/components/team/Statuses/DeleteStatusDialog.js
+++ b/src/app/components/team/Statuses/DeleteStatusDialog.js
@@ -10,7 +10,9 @@ import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 
-const DeleteStatusDialog = ({
+/* Exported for unit test */
+/* eslint-disable-next-line import/no-unused-modules */
+export const DeleteStatusDialog = ({
   deleteStatus,
   onCancel,
   onProceed,

--- a/src/app/components/team/Statuses/DeleteStatusDialog.test.js
+++ b/src/app/components/team/Statuses/DeleteStatusDialog.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
-import DeleteStatusDialog from './DeleteStatusDialog';
+import { DeleteStatusDialog } from './DeleteStatusDialog';
 
 describe('<DeleteStatusDialog />', () => {
   const statuses = [
@@ -24,7 +24,7 @@ describe('<DeleteStatusDialog />', () => {
 
   it('should display the status to be deleted and show the message that one item is using this status', () => {
     const wrapper = mountWithIntl(<DeleteStatusDialog
-      defaultValue={statuses[2]}
+      deleteStatus={statuses[2]}
       onCancel={() => {}}
       onProceed={() => {}}
       handleSelect={() => {}}
@@ -40,7 +40,7 @@ describe('<DeleteStatusDialog />', () => {
 
   it('should display message that four items are using the status', () => {
     const wrapper = mountWithIntl(<DeleteStatusDialog
-      defaultValue={statuses[0]}
+      deleteStatus={statuses[0]}
       onCancel={() => {}}
       onProceed={() => {}}
       handleSelect={() => {}}
@@ -56,7 +56,7 @@ describe('<DeleteStatusDialog />', () => {
 
   it('should display the published items using this status', () => {
     const wrapper = mountWithIntl(<DeleteStatusDialog
-      defaultValue={statuses[1]}
+      deleteStatus={statuses[1]}
       onCancel={() => {}}
       onProceed={() => {}}
       handleSelect={() => {}}
@@ -71,7 +71,7 @@ describe('<DeleteStatusDialog />', () => {
 
   it('should not display published message when there is no item published', () => {
     const wrapper = mountWithIntl(<DeleteStatusDialog
-      defaultValue={statuses[0]}
+      deleteStatus={statuses[0]}
       onCancel={() => {}}
       onProceed={() => {}}
       handleSelect={() => {}}

--- a/src/app/components/team/Statuses/index.js
+++ b/src/app/components/team/Statuses/index.js
@@ -20,7 +20,6 @@ const Statuses = props => (
       query StatusesQuery($teamSlug: String!) {
         team(slug: $teamSlug) {
           id
-          verification_statuses_with_counters: verification_statuses(items_count: true, published_reports_count: true)
           verification_statuses
           get_language
           get_languages


### PR DESCRIPTION
## Description

For performance reasons, do not request the counters for the statuses until the "Delete status" option is chosen.

References: CHECK-2150.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add/Update automated tests)

## How has this been tested?

Since this is a performance improvement / refactoring, new tests are not needed. Just need to make sure that the current ones pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)