### PR TITLE
Do not add 'https' prefix in empty string in report field

### DIFF
--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -88,6 +88,7 @@ const ReportDesignerForm = (props) => {
           onToggle={(enabled) => { props.onUpdate('use_introduction', enabled); }}
           label={
             <FormattedMessage
+              data-testid="report-designer__introduction"
               id="reportDesigner.introduction"
               defaultMessage="Introduction"
             />
@@ -183,6 +184,7 @@ const ReportDesignerForm = (props) => {
               />
               <LimitedTextFieldWithCounter
                 limit={140}
+                data-testid="report-designer__text-url"
                 label={
                   <FormattedMessage
                     id="reportDesigner.textUrl"
@@ -192,7 +194,7 @@ const ReportDesignerForm = (props) => {
                 }
                 onUpdate={(newValue) => {
                   let newUrl = newValue;
-                  if (!/^https?:\/\//.test(newUrl)) {
+                  if (newValue.trim().length !== 0 && !/^https?:\/\//.test(newUrl)) {
                     newUrl = `https://${newUrl}`;
                   }
                   props.onUpdate('published_article_url', newUrl);

--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.test.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import ReportDesignerForm from './ReportDesignerForm';
+
+describe('<ReportDesignerForm />', () => {
+  const data = {
+    use_text_message: true,
+    use_introduction: false,
+    introduction: '',
+    image: '',
+    title: 'title',
+    headline: 'title',
+    text: 'sumary',
+    description: 'desc',
+    published_article_url: '',
+  };
+  const media = {
+    title: 'title',
+  };
+
+  it('should render report form', () => {
+    const wrapper = mountWithIntl(<ReportDesignerForm
+      state="published"
+      media={media}
+      data={data}
+      onUpdate={() => {}}
+      pending
+      disabled={false}
+    />);
+    expect(wrapper.find('[data-testid="report-designer__introduction"]')).toHaveLength(1);
+    expect(wrapper.find('[data-testid="report-designer__text-url"]')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

Do not add 'https' in empty string  in report designer URL field and add unit tests to Report Designer Component

Reference: CHECK-2143

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- create an item
- go to "report designer" page

check that the Article URL field do not have the 'https' on empty string

- type some string on the Article URL field
- save
check that 'https' prefix is added to the string 

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

