### PR TITLE
Add safe navigation when trying to access properties and add unit test

### DIFF
--- a/src/app/components/InviteNewAccount.js
+++ b/src/app/components/InviteNewAccount.js
@@ -134,12 +134,12 @@ const InviteNewAccountComponent = ({ user }) => {
                 id="inviteNewAccount.invitedBy"
                 defaultMessage="{name} has invited you to join the workspace"
                 values={{
-                  name: teamUser.invited_by.name,
+                  name: teamUser?.invited_by?.name,
                 }}
               />
             </Typography>
             <Typography component="div" align="center" className={classes.bold} paragraph="true">
-              {teamUser.team.name}
+              {teamUser?.team?.name}
             </Typography>
             <Typography component="div" align="center" paragraph="true">
               <FormattedHTMLMessage
@@ -310,4 +310,6 @@ InviteNewAccount.propTypes = {
   teamSlug: PropTypes.string.isRequired,
 };
 
+// eslint-disable-next-line import/no-unused-modules
+export { InviteNewAccountComponent };
 export default InviteNewAccount;

--- a/src/app/components/InviteNewAccount.test.js
+++ b/src/app/components/InviteNewAccount.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { mountWithIntlProvider } from '../../../test/unit/helpers/intl-test';
+
+import { InviteNewAccountComponent } from './InviteNewAccount';
+
+const team = {
+  id: '2',
+  name: 'Test Team A',
+  slug: 'team',
+  members_count: 1,
+  project_groups: { edges: [{ node: { project_group_id: '1', title: 'title' } }] },
+};
+
+const user = {
+  teams: team,
+  team_user: {
+    team: {
+      name: team.name,
+      dbid: team.dbid,
+      slug: team.slug,
+    },
+  },
+  name: 'username',
+  email: 'useremail',
+  accepted_terms: true,
+};
+
+describe('<InviteNewAccount />', () => {
+  it('should render New Account form', () => {
+    const wrapper = mountWithIntlProvider(<InviteNewAccountComponent
+      teamSlug={team.slug}
+      user={user}
+    />);
+    expect(wrapper.find('#login')).toHaveLength(1);
+    expect(wrapper.find('.login__password-confirmation')).toHaveLength(1);
+    expect(wrapper.html()).toMatch('has invited you to join the workspace');
+  });
+});


### PR DESCRIPTION
## Description

Add safe navigation when trying to access properties to avoid trying to read properties of null and add unit test

Reference: CHECK-2053

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

