### PR TITLE
Change filter to find default folder by checking is_default field

### DIFF
--- a/src/app/components/media/SelectProjectDialog.js
+++ b/src/app/components/media/SelectProjectDialog.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
@@ -12,11 +11,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 import Box from '@material-ui/core/Box';
-import Radio from '@material-ui/core/Radio';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Typography from '@material-ui/core/Typography';
-import { units } from '../../styles/js/shared';
 
 const messages = defineMessages({
   notInAnyCollection: {
@@ -47,7 +42,7 @@ function SelectProjectDialog({
   const projectGroups = team.project_groups.edges.map(({ node }) => node);
 
   // Fill in the collection title for each folder, even if "not in any collection"
-  const projects = team.projects.edges
+  const projects = team.projects?.edges
     .map(({ node }) => {
       const projectGroup = projectGroups.find(pg => pg.dbid === node.project_group_id) ||
                            { title: intl.formatMessage(messages.notInAnyCollection) };
@@ -56,18 +51,18 @@ function SelectProjectDialog({
 
   // Add "empty folders" to empty collections, so they appear in the drop-down as well
   projectGroups.forEach((pg) => {
-    if (projects.length > 0 && !projects.find(p => p.project_group_id === pg.dbid)) {
+    if (!projects.find(p => p.project_group_id === pg.dbid)) {
       projects.push({ projectGroupTitle: pg.title, title: intl.formatMessage(messages.noFolders) });
     }
   });
 
   // Get a default folder
   // The value returned can be undefined if workspace default folder has privacy settings on
-  const defaultFolder = team.default_folder ? projects.filter(({ dbid }) => dbid === team.default_folder.dbid)[0] : null;
+  const defaultFolder = projects.filter(({ is_default }) => is_default === true)[0];
 
   // Lastly, sort options by title and exclude some options and defaultFolder to add it to the top of the list
   const filteredProjects = projects
-    .filter(({ dbid }) => !excludeProjectDbids.includes(dbid) &&  dbid !== team.default_folder?.dbid)
+    .filter(({ dbid }) => !excludeProjectDbids.includes(dbid) && dbid !== defaultFolder?.dbid)
     .sort((a, b) => {
       // First sort by collection
       if (a.projectGroupTitle !== b.projectGroupTitle) {
@@ -98,16 +93,17 @@ function SelectProjectDialog({
       onClick={event => event.stopPropagation()}
       open={open}
       onClose={onCancel}
-      maxWidth="sm" fullWidth
+      maxWidth="sm"
+      fullWidth
     >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         { extraContent ?
-            <Box py={2}>
-              <Typography variant="body1" component="p" paragraph>
-                {extraContent}
-              </Typography>
-            </Box>: null }
+          <Box py={2}>
+            <Typography variant="body1" component="p" paragraph>
+              {extraContent}
+            </Typography>
+          </Box> : null }
         <Autocomplete
           options={filteredProjectsOptions}
           autoHighlight
@@ -123,7 +119,11 @@ function SelectProjectDialog({
               autoFocus
               name="project-title"
               label={
-                <FormattedMessage id="destinationProjects.choose" defaultMessage="Choose a folder" />
+                <FormattedMessage
+                  id="destinationProjects.choose"
+                  defaultMessage="Choose a folder"
+                  description="Choose a folder input label"
+                />
               }
               variant="outlined"
             />
@@ -179,10 +179,6 @@ const SelectProjectDialogRenderer = (parentProps) => {
             id
             dbid
             name
-            default_folder {
-              id
-              dbid
-            }
             projects(first: 10000) {
               edges {
                 node {
@@ -192,6 +188,7 @@ const SelectProjectDialogRenderer = (parentProps) => {
                   project_group_id
                   medias_count  # For optimistic updates when adding/moving items
                   search_id  # For optimistic updates when adding/moving items
+                  is_default
                 }
               }
             }

--- a/src/app/components/media/SelectProjectDialog.test.js
+++ b/src/app/components/media/SelectProjectDialog.test.js
@@ -7,12 +7,11 @@ const team = {
   name: 'teamName',
   slug: 'slugTeam',
   members_count: 1,
-  default_folder: { dbid: 1, id: 'UHJvamVjdC80\n' },
   project_groups: { edges: [{ node: { project_group_id: '1', title: 'title' } }] },
   projects: {
     edges: [{
       node: {
-        title: 'title', dbid: 2, project_group_id: '1', id: 'ABJvamVjdC70\n',
+        title: 'title', dbid: 2, project_group_id: '1', id: 'ABJvamVjdC70\n', is_default: false,
       },
     }],
   },
@@ -27,12 +26,11 @@ const team2 = {
   name: 'teamName',
   slug: 'slugTeam',
   members_count: 1,
-  default_folder: { dbid: 1, id: 'UHJvamVjdC80\n' },
   project_groups: { edges: [{ node: { project_group_id: '1', title: 'title' } }] },
   projects: {
     edges: [{
       node: {
-        title: 'title', dbid: 1, project_group_id: '1', id: 'UHJvamVjdC80\n',
+        title: 'title', dbid: 1, project_group_id: '1', id: 'UHJvamVjdC80\n', is_default: true,
       },
     }],
   },


### PR DESCRIPTION
## Description

- Add is_default field to each project and remove default_folder from the query
- Find default folder by checking is_default field instead of filtering by team.default_folder
- Remove /* eslint-disable */ comment from the top of the file and fix linter problems
- And update unit tests

Reference: CHECK-2110

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)

## Things to pay attention to during code review

SelectProjectDialog Query was updated: Added is_default field to each project and removed default_folder

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

