### PR TITLE
Add safe navigation when trying to access properties 

### DIFF
--- a/src/app/components/ChangePassword.test.js
+++ b/src/app/components/ChangePassword.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mountWithIntl } from '../../../test/unit/helpers/intl-test';
+import ChangePasswordComponent from './ChangePasswordComponent';
+
+describe('<ChangePasswordComponent />', () => {
+  it('should render Change Password Component', () => {
+    const wrapper = mountWithIntl(<ChangePasswordComponent
+      type="reset-password"
+      showCurrentPassword="OldPaswword"
+    />);
+    expect(wrapper.find('.user-password-change__password-input')).toHaveLength(1);
+    expect(wrapper.html()).toMatch('New password (minimum 8 characters)');
+  });
+});

--- a/src/app/components/ChangePasswordComponent.js
+++ b/src/app/components/ChangePasswordComponent.js
@@ -45,7 +45,7 @@ function ChangePasswordComponent({
   const handleChangePasswordConfirm = (e) => {
     const { value } = e.target;
     const bothFilled =
-      password.length >= passwordLength.min && value.length >= passwordLength.min;
+      password?.length >= passwordLength.min && value.length >= passwordLength.min;
     const samePass = password === value;
     const message = bothFilled && !samePass ? (
       <FormattedMessage


### PR DESCRIPTION

## Description

Add safe navigation when trying to access properties to avoid trying to read properties of null and add unit test

Reference: CHECK-2052

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)


## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

