### PR TITLE
Fix TypeError 'Cannot read properties of null'

### DIFF
--- a/localization/react-intl/src/app/components/UploadFile.json
+++ b/localization/react-intl/src/app/components/UploadFile.json
@@ -12,6 +12,10 @@
     "defaultMessage": "Drop an audio file here, or click to upload a file (max size: {audio_max_size}, allowed extensions: {audio_extensions})"
   },
   {
+    "id": "uploadFile.fileMessage",
+    "defaultMessage": "Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
+  },
+  {
     "id": "uploadFile.imageVideoAudioMessage",
     "defaultMessage": "Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
   },

--- a/src/app/components/UploadFile.js
+++ b/src/app/components/UploadFile.js
@@ -73,10 +73,10 @@ const UploadMessage = ({ type, about }) => {
       id="uploadFile.message"
       defaultMessage="Drop an image file here, or click to upload a file (max size: {upload_max_size}, allowed extensions: {upload_extensions}, allowed dimensions between {upload_min_dimensions} and {upload_max_dimensions} pixels)"
       values={{
-        upload_max_size: about.upload_max_size,
-        upload_extensions: about.upload_extensions.join(', '),
-        upload_max_dimensions: about.upload_max_dimensions,
-        upload_min_dimensions: about.upload_min_dimensions,
+        upload_max_size: about?.upload_max_size,
+        upload_extensions: about?.upload_extensions?.join(', '),
+        upload_max_dimensions: about?.upload_max_dimensions,
+        upload_min_dimensions: about?.upload_min_dimensions,
       }}
     />
   );
@@ -85,8 +85,8 @@ const UploadMessage = ({ type, about }) => {
       id="uploadFile.videoMessage"
       defaultMessage="Drop a video file here, or click to upload a file (max size: {video_max_size}, allowed extensions: {video_extensions})"
       values={{
-        video_max_size: about.video_max_size,
-        video_extensions: about.video_extensions.join(', '),
+        video_max_size: about?.video_max_size,
+        video_extensions: about?.video_extensions?.join(', '),
       }}
     />
   );
@@ -95,21 +95,33 @@ const UploadMessage = ({ type, about }) => {
       id="uploadFile.audioMessage"
       defaultMessage="Drop an audio file here, or click to upload a file (max size: {audio_max_size}, allowed extensions: {audio_extensions})"
       values={{
-        audio_max_size: about.audio_max_size,
-        audio_extensions: about.audio_extensions.join(', '),
+        audio_max_size: about?.audio_max_size,
+        audio_extensions: about?.audio_extensions?.join(', '),
       }}
     />
   );
+
+  case 'file': return (
+    <FormattedMessage
+      id="uploadFile.fileMessage"
+      defaultMessage="Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
+      values={{
+        file_max_size: about?.file_max_size,
+        file_extensions: about?.file_extensions?.join(', '),
+      }}
+    />
+  );
+
   case 'image+video+audio': return (
     <FormattedMessage
       id="uploadFile.imageVideoAudioMessage"
       defaultMessage="Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
       values={{
-        file_max_size: about.file_max_size,
-        file_extensions: about.upload_extensions
-          .concat(about.video_extensions)
-          .concat(about.audio_extensions)
-          .join(', '),
+        file_max_size: about?.file_max_size,
+        file_extensions: about?.upload_extensions
+          ?.concat(about?.video_extensions)
+          ?.concat(about?.audio_extensions)
+          ?.join(', '),
       }}
     />
   );
@@ -118,7 +130,7 @@ const UploadMessage = ({ type, about }) => {
 };
 
 UploadMessage.propTypes = {
-  type: PropTypes.oneOf(['image', 'video', 'audio', 'file']).isRequired,
+  type: PropTypes.oneOf(['image', 'video', 'audio', 'file', 'image+video+audio']).isRequired,
   about: PropTypes.shape({
     upload_max_size: PropTypes.string.isRequired,
     upload_extensions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
@@ -127,9 +139,9 @@ UploadMessage.propTypes = {
     video_max_size: PropTypes.string.isRequired,
     video_extensions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     audio_max_size: PropTypes.string.isRequired,
-    audio_extensions: PropTypes.string.isRequired,
+    audio_extensions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     file_max_size: PropTypes.string.isRequired,
-    file_extensions: PropTypes.string.isRequired,
+    file_extensions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   }).isRequired,
 };
 
@@ -285,5 +297,6 @@ UploadFile.propTypes = {
   onError: PropTypes.func.isRequired, // func(Image?, <FormattedMessage ...>) => undefined
   disabled: PropTypes.bool,
 };
-
+// eslint-disable-next-line
+export { UploadFileComponent };
 export default UploadFile;

--- a/src/app/components/UploadFile.test.js
+++ b/src/app/components/UploadFile.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mountWithIntl } from '../../../test/unit/helpers/intl-test';
+import { UploadFileComponent } from './UploadFile';
+
+describe('<UploadFileComponent />', () => {
+  const about = {
+    file_max_size: '1M',
+    upload_max_size: '1M',
+    upload_extensions: [''],
+    upload_max_dimensions: '1M',
+    upload_min_dimensions: '1M',
+    video_max_size: '1M',
+    video_extensions: [''],
+    audio_max_size: '1M',
+    audio_extensions: [''],
+    file_extensions: [''],
+  };
+
+  it('Should render if media type is audio', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="audio"
+      about={about}
+      value={null}
+      onChange={() => {}}
+      onError={() => {}}
+    />);
+    expect(wrapper.html()).toMatch('Drop an audio file here, or click to upload a file');
+    expect(wrapper.find('.without-file').hostNodes()).toHaveLength(1);
+  });
+
+  it('Should render if media type is video', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="video"
+      value={null}
+      onChange={() => {}}
+      about={about}
+      onError={() => {}}
+    />);
+    expect(wrapper.html()).toMatch('Drop a video file here, or click to upload a file');
+    expect(wrapper.find('.without-file').hostNodes()).toHaveLength(1);
+  });
+
+  it('Should render if media type is image', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="image"
+      value={null}
+      about={about}
+      onChange={() => {}}
+      onError={() => {}}
+    />);
+    expect(wrapper.html()).toMatch('Drop an image file here, or click to upload a file');
+    expect(wrapper.find('.without-file').hostNodes()).toHaveLength(1);
+  });
+
+  it('Should render if media type is file', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="file"
+      about={about}
+      value={null}
+      onChange={() => {}}
+      onError={() => {}}
+    />);
+    expect(wrapper.html()).toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.find('.without-file').hostNodes()).toHaveLength(1);
+  });
+
+  it('Should render if media type is image+video+audio', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="image+video+audio"
+      value={null}
+      about={about}
+      onChange={() => {}}
+      onError={() => {}}
+    />);
+    //
+    expect(wrapper.html()).toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.find('.without-file').hostNodes()).toHaveLength(1);
+  });
+
+  it('Should not render upload file message if already have a file', () => {
+    const wrapper = mountWithIntl(<UploadFileComponent
+      type="file"
+      value={{ state: { file: 'file/path' } }}
+      about={about}
+      onChange={() => {}}
+      onError={() => {}}
+    />);
+    expect(wrapper.html()).not.toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.find('.with-file').hostNodes()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

Add 'upload file' message when uploading file, fix TypeError 'Cannot read properties of null' on UploadFile Component, remove some warnings and add unit tests 

Reference: CHECK-2063

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

