### PR TITLE
CHECK-2136: allow user to search by annotated_by field

### DIFF
--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -50,6 +50,11 @@
     "defaultMessage": "Published by"
   },
   {
+    "id": "addFilterMenu.annotatedBy",
+    "description": "Menu option to enable searching items by annotated by",
+    "defaultMessage": "Annotated by"
+  },
+  {
     "id": "addFilterMenu.createdBy",
     "description": "Menu option to enable searching items by author",
     "defaultMessage": "Created by"

--- a/localization/react-intl/src/app/components/search/SearchFields/index.json
+++ b/localization/react-intl/src/app/components/search/SearchFields/index.json
@@ -150,6 +150,11 @@
     "defaultMessage": "Report published by"
   },
   {
+    "id": "search.annotatedBy",
+    "description": "Prefix label for field to filter by annotated by",
+    "defaultMessage": "Annotated by"
+  },
+  {
     "id": "search.language",
     "description": "Prefix label for field to filter by language",
     "defaultMessage": "Language is"

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -167,6 +167,18 @@ const AddFilterMenu = ({
     ),
   },
   {
+    id: 'add-filter-menu__annotated-by',
+    key: 'annotated_by',
+    icon: <PersonIcon />,
+    label: (
+      <FormattedMessage
+        id="addFilterMenu.annotatedBy"
+        defaultMessage="Annotated by"
+        description="Menu option to enable searching items by annotated by"
+      />
+    ),
+  },
+  {
     id: 'add-filter-menu__created-by',
     key: 'users',
     icon: <PersonIcon />,

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -224,6 +224,12 @@ class SearchFields extends React.Component {
     );
   }
 
+  handleAnnotatedByClick = (userIds) => {
+    this.props.setQuery(
+      updateStateQueryArrayValue(this.props.query, 'annotated_by', userIds),
+    );
+  }
+
   handleProjectGroupClick = (projectGroupDbids) => {
     this.props.setQuery(
       updateStateQueryArrayValue(this.props.query, 'project_group_id', projectGroupDbids),
@@ -620,6 +626,20 @@ class SearchFields extends React.Component {
               options={users.map(u => ({ label: u.node.name, value: `${u.node.dbid}` }))}
               onChange={this.handlePublishedByClick}
               onRemove={() => this.handleRemoveField('published_by')}
+            />
+          )}
+        </FormattedMessage>
+      ),
+      annotated_by: (
+        <FormattedMessage id="search.annotatedBy" defaultMessage="Annotated by" description="Prefix label for field to filter by annotated by">
+          { label => (
+            <MultiSelectFilter
+              label={label}
+              icon={<PersonIcon />}
+              selected={this.props.query.annotated_by}
+              options={users.map(u => ({ label: u.node.name, value: `${u.node.dbid}` }))}
+              onChange={this.handleAnnotatedByClick}
+              onRemove={() => this.handleRemoveField('annotated_by')}
             />
           )}
         </FormattedMessage>

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -266,17 +266,17 @@ class SearchFields extends React.Component {
     );
   }
 
-  handleTagsOperator = () => {
-    const operator = this.tagsOperatorIs('or') ? 'and' : 'or';
-    this.props.setQuery(
-      { ...this.props.query, tags_operator: operator },
-    );
+  handleSwitchOperator = (key) => {
+    const operator = this.switchOperatorIs('or', key) ? 'and' : 'or';
+    const query = { ...this.props.query };
+    query[key] = operator;
+    this.props.setQuery(query);
   }
 
-  tagsOperatorIs(operator) {
+  switchOperatorIs(operator, key) {
     let currentOperator = 'or'; // "or" is the default
-    if (this.props.query && this.props.query.tags_operator) {
-      currentOperator = this.props.query.tags_operator;
+    if (this.props.query && this.props.query[key]) {
+      currentOperator = this.props.query[key];
     }
     return currentOperator === operator;
   }
@@ -481,7 +481,7 @@ class SearchFields extends React.Component {
               onChange={(newValue) => {
                 this.handleTagClick(newValue);
               }}
-              onToggleOperator={this.handleTagsOperator}
+              onToggleOperator={() => this.handleSwitchOperator('tags_operator')}
               operator={this.props.query.tags_operator}
               onRemove={() => this.handleRemoveField('tags')}
             />
@@ -640,6 +640,8 @@ class SearchFields extends React.Component {
               options={users.map(u => ({ label: u.node.name, value: `${u.node.dbid}` }))}
               onChange={this.handleAnnotatedByClick}
               onRemove={() => this.handleRemoveField('annotated_by')}
+              onToggleOperator={() => this.handleSwitchOperator('annotated_by_operator')}
+              operator={this.props.query.annotated_by_operator}
             />
           )}
         </FormattedMessage>


### PR DESCRIPTION
## Description

Allow user to filter by user saving annotation.

References: CHECK-2136

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Add annotations via workspace settings -> Annotation 
- Add new items then answer annotations 
- Go to all item page then Add Filter -> Annotated by -> (search by different users)

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

