### PR TITLE
Hide "Add item" button on "Spam" page and on "Suggested matches" page

### DIFF
--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -53,7 +53,7 @@ const Toolbar = ({
           {actions}
           <ViewModeSwitcher viewMode={viewMode} onChangeViewMode={onChangeViewMode} />
         </Row>
-        {['trash', 'collection', 'list', 'imported-reports', 'tipline-inbox'].indexOf(page) === -1 && resultType !== 'trends' ? (
+        {['trash', 'collection', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches'].indexOf(page) === -1 && resultType !== 'trends' ? (
           <Can {...perms}>
             <OffsetButton>
               <CreateProjectMedia search={search} project={project} team={team} />
@@ -71,7 +71,7 @@ Toolbar.defaultProps = {
 };
 
 Toolbar.propTypes = {
-  page: PropTypes.oneOf(['trash', 'collection', 'folder', 'list', 'imported-reports', 'tipline-inbox']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['trash', 'collection', 'folder', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches']), // FIXME find a cleaner way to render Trash differently
   viewMode: PropTypes.oneOf(['shorter', 'longer']),
   onChangeViewMode: PropTypes.func.isRequired,
   // FIXME: Define other PropTypes


### PR DESCRIPTION
## Description
Hide "Add item" button on "Spam" page and on "Suggested matches" page
References: CHECK-2210, CHECK-2222

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Go to "Spam" Page 
Check that  "Add item" button does no appear on the page

- Go to "Suggested matches" Page 
Check that  "Add item" button does no appear on the page

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

