### PR TITLE
Hide keyword search on shared feed "shared" tab

### DIFF
--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -443,17 +443,19 @@ function SearchResultsComponent({
             </span>
             {listActions}
           </div>
-          <SearchKeyword
-            query={unsortedQuery}
-            setQuery={setQuery}
-            project={project}
-            hideFields={hideFields}
-            title={title}
-            team={team}
-            showExpand={showExpand}
-            cleanupQuery={cleanupQuery}
-            handleSubmit={handleSubmit}
-          />
+          { /\/feed\/[0-9]+\/shared/.test(window.location.pathname) ?
+            null :
+            <SearchKeyword
+              query={unsortedQuery}
+              setQuery={setQuery}
+              project={project}
+              hideFields={hideFields}
+              title={title}
+              team={team}
+              showExpand={showExpand}
+              cleanupQuery={cleanupQuery}
+              handleSubmit={handleSubmit}
+            /> }
         </Row>
         <Row className="project__description">
           {listDescription && listDescription.trim().length ?


### PR DESCRIPTION
## Description

Basically because that way it could be saved as filters for the feed, which doesn't make much sense.

Reference: CHECK-2102.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I visited the "shared" tab for a shared feed and verified that the keyword search field is not rendered, while it's rendered on other pages.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)