### PR TITLE
Remove unneeded eslint directive

### DIFF
--- a/src/app/components/feed/Feed.js
+++ b/src/app/components/feed/Feed.js
@@ -12,8 +12,6 @@ import FeedSharingSwitch from './FeedSharingSwitch';
 import Search from '../search/Search';
 import { safelyParseJSON } from '../../helpers';
 
-// Used in unit test
-// eslint-disable-next-line import/no-unused-modules
 export const FeedComponent = ({ routeParams, ...props }) => {
   const { team } = props;
   const { feed } = team;


### PR DESCRIPTION
`FeedComponent` is no longer used only by the unit test. It's used in the actual `Feed` top-level component now.