### PR TITLE
Do not load all tag texts from a workspace

### DIFF
--- a/src/app/components/tag/TagMenu.js
+++ b/src/app/components/tag/TagMenu.js
@@ -192,7 +192,7 @@ const TagMenuContainer = Relay.createContainer(withSetFlashMessage(TagMenuCompon
         dbid
         archived
         permissions
-        tags(first: 10000) {
+        tags(first: 50) {
           edges {
             node {
               tag,
@@ -203,7 +203,7 @@ const TagMenuContainer = Relay.createContainer(withSetFlashMessage(TagMenuCompon
         }
         team {
           id,
-          tag_texts(first: 10000) {
+          tag_texts(first: 50) {
             edges {
               node {
                 text


### PR DESCRIPTION
## Description

This triggers real performance issues. We should refactor this to use auto-complete.

For now, it fixes CHECK-2300.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Just tested it manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

