### PR TITLE
CHECK-2331: Add random argument to team graphql type

### DIFF
--- a/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
+++ b/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
@@ -16,13 +16,16 @@ const SearchFieldClusterTeams = ({
   <QueryRenderer
     environment={Relay.Store}
     query={graphql`
-      query SearchFieldClusterTeamsQuery($teamSlug: String!) {
-        team(slug: $teamSlug) {
+      query SearchFieldClusterTeamsQuery($teamSlug: String!, $random: String!) {
+        team(slug: $teamSlug, random: $random) {
           shared_teams
         }
       }
     `}
-    variables={{ teamSlug }}
+    variables={{
+      teamSlug,
+      random: String(Math.random()),
+    }}
     render={({ error, props }) => {
       if (!error && props) {
         const { shared_teams: sharedTeams } = props.team;

--- a/src/app/components/search/SearchFields/SearchFieldProject.js
+++ b/src/app/components/search/SearchFields/SearchFieldProject.js
@@ -19,8 +19,8 @@ const SearchFieldProject = ({
   <QueryRenderer
     environment={Relay.Store}
     query={graphql`
-      query SearchFieldProjectQuery($teamSlug: String!) {
-        team(slug: $teamSlug) {
+      query SearchFieldProjectQuery($teamSlug: String!, $random: String!) {
+        team(slug: $teamSlug, random: $random) {
           id
           projects(first: 10000) {
             edges {
@@ -46,6 +46,7 @@ const SearchFieldProject = ({
     `}
     variables={{
       teamSlug,
+      random: String(Math.random()),
     }}
     render={({ error, props }) => {
       if (!error && props) {

--- a/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
+++ b/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
@@ -19,8 +19,8 @@ const SearchFieldProjectGroup = ({
   <QueryRenderer
     environment={Relay.Store}
     query={graphql`
-      query SearchFieldProjectGroupQuery($teamSlug: String!) {
-        team(slug: $teamSlug) {
+      query SearchFieldProjectGroupQuery($teamSlug: String!, $random: String!) {
+        team(slug: $teamSlug, random: $random) {
           id
           project_groups(first: 10000) {
             edges {
@@ -35,6 +35,7 @@ const SearchFieldProjectGroup = ({
     `}
     variables={{
       teamSlug,
+      random: String(Math.random()),
     }}
     render={({ error, props }) => {
       if (!error && props) {

--- a/src/app/components/search/SearchFields/SearchFieldSource.js
+++ b/src/app/components/search/SearchFields/SearchFieldSource.js
@@ -34,8 +34,8 @@ const SearchFieldSource = ({
     <QueryRenderer
       environment={Relay.Store}
       query={graphql`
-        query SearchFieldSourceQuery($teamSlug: String!, $keyword: String, $max: Int) {
-          team(slug: $teamSlug) {
+        query SearchFieldSourceQuery($teamSlug: String!, $keyword: String, $max: Int, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
             id
             sources_count(keyword: $keyword)
             sources(first: $max, keyword: $keyword) {
@@ -54,6 +54,7 @@ const SearchFieldSource = ({
         teamSlug,
         keyword,
         max,
+        random: String(Math.random()),
       }}
       render={({ error, props }) => {
         if (!error && props) {

--- a/src/app/components/search/SearchFields/SearchFieldTag.js
+++ b/src/app/components/search/SearchFields/SearchFieldTag.js
@@ -20,8 +20,8 @@ const SearchFieldTag = ({
   <QueryRenderer
     environment={Relay.Store}
     query={graphql`
-      query SearchFieldTagQuery($teamSlug: String!) {
-        team(slug: $teamSlug) {
+      query SearchFieldTagQuery($teamSlug: String!, $random: String!) {
+        team(slug: $teamSlug, random: $random) {
           id
           tag_texts(first: 10000) {
             edges {
@@ -35,6 +35,7 @@ const SearchFieldTag = ({
     `}
     variables={{
       teamSlug,
+      random: String(Math.random()),
     }}
     render={({ error, props }) => {
       if (!error && props) {

--- a/src/app/components/search/SearchFields/SearchFieldUser.js
+++ b/src/app/components/search/SearchFields/SearchFieldUser.js
@@ -21,8 +21,8 @@ const SearchFieldUser = ({
   <QueryRenderer
     environment={Relay.Store}
     query={graphql`
-      query SearchFieldUserQuery($teamSlug: String!) {
-        team(slug: $teamSlug) {
+      query SearchFieldUserQuery($teamSlug: String!, $random: String!) {
+        team(slug: $teamSlug, random: $random) {
           id
           users(first: 10000) {
             edges {
@@ -39,6 +39,7 @@ const SearchFieldUser = ({
     `}
     variables={{
       teamSlug,
+      random: String(Math.random()),
     }}
     render={({ error, props }) => {
       if (!error && props) {


### PR DESCRIPTION
## Description

This commit adds a `random` argument to team graphql type to cheat weird relay caching. Some queries in SearchFieldXxx components were not trigerred, probably because of having a similar root to both QueryRenderers.

Fixes: CHECK-2331

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I created a filter with fields "Assigned to" and "Folder is" and applied it to "All items" and verified that the page loads correctly without crashing.
I haven't implemented any automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

