### PR TITLE
Change sensitive content warning message

### DIFF
--- a/localization/react-intl/src/app/components/layout/AspectRatio.json
+++ b/localization/react-intl/src/app/components/layout/AspectRatio.json
@@ -20,6 +20,11 @@
     "defaultMessage": "<strong>{user_name}</strong> has detected this content as <strong>{warning_category}</strong>"
   },
   {
+    "id": "contentScreen.warningByAutomationRule",
+    "description": "Content warning displayed over sensitive content",
+    "defaultMessage": "An automation rule has detected this content as sensitive"
+  },
+  {
     "id": "contentScreen.viewContentButton",
     "description": "Button to enable view of sensitive content",
     "defaultMessage": "Temporarily view content"

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -95,6 +95,9 @@ const AspectRatioComponent = ({
 }) => {
   const [maskContent, setMaskContent] = React.useState(contentWarning);
   const classes = useStyles({ contentWarning: contentWarning && maskContent });
+  // const pastel = 'pastel';
+  // eslint-disable-next-line
+  console.log('warningCreator:', warningCreator);
   return (
     <div className={classes.container}>
       <div className={classes.innerWrapper}>
@@ -129,18 +132,27 @@ const AspectRatioComponent = ({
               <VisibilityOffIcon className={classes.icon} />
               <div style={{ visibility: contentWarning && maskContent ? 'visible' : 'hidden' }}>
                 <Typography variant="body1">
-                  <FormattedHTMLMessage
-                    id="contentScreen.warning"
-                    defaultMessage="<strong>{user_name}</strong> has detected this content as <strong>{warning_category}</strong>"
-                    description="Content warning displayed over sensitive content"
-                    values={{
-                      user_name: warningCreator,
-                      warning_category: (
-                        (messages[warningCategory] && intl.formatMessage(messages[warningCategory])) ||
+                  { warningCreator !== 'Alegre' ? (
+                    <FormattedHTMLMessage
+                      id="contentScreen.warning"
+                      defaultMessage={'<strong>{user_name}</strong> has detected this content as <strong>{warning_category}</strong>'}
+                      description="Content warning displayed over sensitive content"
+                      values={{
+                        user_name: warningCreator,
+                        warning_category: (
+                          (messages[warningCategory] && intl.formatMessage(messages[warningCategory])) ||
                         warningCategory
-                      ),
-                    }}
-                  />
+                        ),
+                      }}
+                    />
+                  ) : (
+                    <FormattedHTMLMessage
+                      id="contentScreen.warningByAutomationRule"
+                      defaultMessage="An automation rule has detected this content as sensitive"
+                      description="Content warning displayed over sensitive content"
+                    />
+                  )
+                  }
                 </Typography>
               </div>
               { contentWarning ? (


### PR DESCRIPTION
## Description

Change sensitive content warning message when an item is automatically flagged by Alegre
Reference: CHECK-2358

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

