### PR TITLE
Fix errbit errors: avoid reading properties of null

### DIFF
--- a/src/app/components/DrawerNavigationComponent.js
+++ b/src/app/components/DrawerNavigationComponent.js
@@ -43,14 +43,14 @@ class DrawerNavigationComponent extends Component {
   }
 
   componentWillUpdate(nextProps) {
-    if (this.props.team && this.props.team.dbid !== nextProps.team.dbid) {
+    if (this.props.team && this.props.team?.dbid !== nextProps.team?.dbid) {
       this.unsubscribe();
     }
   }
 
   componentDidUpdate(prevProps) {
     this.setContextTeam();
-    if (this.props.team && this.props.team.dbid !== prevProps.team.dbid) {
+    if (this.props.team && this.props.team?.dbid !== prevProps.team?.dbid) {
       this.subscribe();
     }
   }

--- a/src/app/components/search/CustomFiltersManager.js
+++ b/src/app/components/search/CustomFiltersManager.js
@@ -58,18 +58,18 @@ const CustomFiltersManagerComponent = ({
   if (hide) { return null; }
   const [errorMessage, setErrorMessage] = React.useState('');
 
-  const teamTasks = team.team_tasks.edges;
+  const teamTasks = team?.team_tasks?.edges ? team.team_tasks.edges : [];
 
   const handleTeamTaskFilterChange = (teamTaskFilter, index) => {
     const newQuery = {};
-    newQuery.team_tasks = query.team_tasks ? [...query.team_tasks] : [];
+    newQuery.team_tasks = query?.team_tasks ? [...query.team_tasks] : [];
     newQuery.team_tasks.splice(index, 1, teamTaskFilter);
     onFilterChange(newQuery);
   };
 
   const handleRemoveFilter = (index) => {
     const newQuery = {};
-    newQuery.team_tasks = query.team_tasks ? [...query.team_tasks] : [];
+    newQuery.team_tasks = query?.team_tasks ? [...query.team_tasks] : [];
     newQuery.team_tasks.splice(index, 1);
     if (newQuery.team_tasks.length === 0) {
       delete newQuery.team_tasks;
@@ -87,7 +87,7 @@ const CustomFiltersManagerComponent = ({
     }
   };
 
-  const filters = query.team_tasks && query.team_tasks.length > 0 ? query.team_tasks : [{}];
+  const filters = query?.team_tasks && query?.team_tasks?.length > 0 ? query.team_tasks : [{}];
 
   const icons = {
     free_text: <ShortTextIcon />,


### PR DESCRIPTION
## Description

Fix TypeError: Cannot read properties of null (reading 'dbid') and t.team_tasks is undefined
Reference: CHECK-2359, CHECK-2360

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

