### PR TITLE
Replace similarity strings to match glossary

### DIFF
--- a/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
@@ -30,7 +30,7 @@
     "defaultMessage": "Imported reports"
   },
   {
-    "id": "projectsComponent.suggestedMedias",
+    "id": "projectsComponent.suggestedMatches",
     "description": "Label for a list displayed on the left sidebar.",
     "defaultMessage": "Suggested media"
   },

--- a/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
@@ -30,9 +30,9 @@
     "defaultMessage": "Imported reports"
   },
   {
-    "id": "projectsComponent.suggestedMatches",
+    "id": "projectsComponent.suggestedMedias",
     "description": "Label for a list displayed on the left sidebar.",
-    "defaultMessage": "Suggested matches"
+    "defaultMessage": "Suggested media"
   },
   {
     "id": "projectsComponent.folders",

--- a/localization/react-intl/src/app/components/media/Similarity/MediaItem.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaItem.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "mediaItem.similarMedia",
-    "defaultMessage": "{count, plural, one {# similar media} other {# similar media}}"
+    "defaultMessage": "{count, plural, one {# matched media} other {# matched media}}"
   },
   {
     "id": "mediaItem.lastSubmitted",

--- a/localization/react-intl/src/app/components/media/Similarity/MediaRelationship.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaRelationship.json
@@ -22,12 +22,12 @@
   },
   {
     "id": "mediaItem.detach",
-    "defaultMessage": "Detach"
+    "defaultMessage": "Un-match media"
   },
   {
     "id": "detachDialog.dialogdetachedToListTitle",
     "description": "Dialog title prompting user to select a destination folder for the item",
-    "defaultMessage": "Move detached item to…"
+    "defaultMessage": "Move un-matched item to…"
   },
   {
     "id": "detachDialog.detached",

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilaritiesComponent.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilaritiesComponent.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "mediaSimilarities.matchedMedias",
+    "id": "mediaSimilarities.moreMedias",
     "description": "Heading for a list of matched medias",
     "defaultMessage": "Matched media"
   }

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilaritiesComponent.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilaritiesComponent.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": "mediaSimilarities.moreMedias",
-    "description": "Heading for a list of similar medias",
-    "defaultMessage": "More medias"
+    "id": "mediaSimilarities.matchedMedias",
+    "description": "Heading for a list of matched medias",
+    "defaultMessage": "Matched media"
   }
 ]

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "mediaSimilarityBarAdd.addMatchedToThisTitle",
+    "id": "mediaSimilarityBarAdd.addSimilarToThisTitle",
     "defaultMessage": "Import matched media from other items"
   },
   {
@@ -22,7 +22,7 @@
     "defaultMessage": "Add similar"
   },
   {
-    "id": "mediaSimilarityBarAdd.addMatchedToThis",
+    "id": "mediaSimilarityBarAdd.addSimilarToThis",
     "defaultMessage": "Import matched media into this item"
   },
   {

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": "mediaSimilarityBarAdd.addSimilarToThisTitle",
-    "defaultMessage": "Import similar media from other items"
+    "id": "mediaSimilarityBarAdd.addMatchedToThisTitle",
+    "defaultMessage": "Import matched media from other items"
   },
   {
     "id": "mediaSimilarityBarAdd.addThisToSimilarTitle",
@@ -22,8 +22,8 @@
     "defaultMessage": "Add similar"
   },
   {
-    "id": "mediaSimilarityBarAdd.addSimilarToThis",
-    "defaultMessage": "Import similar media into this item"
+    "id": "mediaSimilarityBarAdd.addMatchedToThis",
+    "defaultMessage": "Import matched media into this item"
   },
   {
     "id": "mediaSimilarityBarAdd.exportTooltip",

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarComponent.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarComponent.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": "mediaSimilarityBarComponent.similarMedia",
-    "description": "Plural. Heading for the number of similar media",
-    "defaultMessage": "Similar media"
+    "id": "mediaSimilarityBarComponent.matchedMedia",
+    "description": "Plural. Heading for the number of matched media",
+    "defaultMessage": "Matched medias"
   },
   {
-    "id": "mediaSimilarityBarComponent.suggestedMatches",
+    "id": "mediaSimilarityBarComponent.suggestedMedia",
     "description": "Plural. Heading for the number of suggested media",
     "defaultMessage": "Suggested media"
   }

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarComponent.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarComponent.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": "mediaSimilarityBarComponent.matchedMedia",
+    "id": "mediaSimilarityBarComponent.similarMedia",
     "description": "Plural. Heading for the number of matched media",
-    "defaultMessage": "Matched medias"
+    "defaultMessage": "Matched media"
   },
   {
-    "id": "mediaSimilarityBarComponent.suggestedMedia",
+    "id": "mediaSimilarityBarComponent.suggestedMatches",
     "description": "Plural. Heading for the number of suggested media",
     "defaultMessage": "Suggested media"
   }

--- a/localization/react-intl/src/app/components/project/ProjectHeader.json
+++ b/localization/react-intl/src/app/components/project/ProjectHeader.json
@@ -12,7 +12,7 @@
     "defaultMessage": "Imported reports"
   },
   {
-    "id": "projectHeader.suggestedMedias",
+    "id": "projectHeader.suggestedMatches",
     "defaultMessage": "Suggested media"
   },
   {

--- a/localization/react-intl/src/app/components/project/ProjectHeader.json
+++ b/localization/react-intl/src/app/components/project/ProjectHeader.json
@@ -12,8 +12,8 @@
     "defaultMessage": "Imported reports"
   },
   {
-    "id": "projectHeader.suggestedMatches",
-    "defaultMessage": "Suggested matches"
+    "id": "projectHeader.suggestedMedias",
+    "defaultMessage": "Suggested media"
   },
   {
     "id": "projectHeader.feed",

--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -70,14 +70,14 @@
     "defaultMessage": "Tipline request"
   },
   {
-    "id": "addFilterMenu.matchedMedias",
+    "id": "addFilterMenu.similarMedias",
     "description": "Menu option to enable searching items by matched medias",
-    "defaultMessage": "Number of matched medias"
+    "defaultMessage": "Number of matched media"
   },
   {
     "id": "addFilterMenu.suggestedMedias",
     "description": "Menu option to enable searching items by suggested medias",
-    "defaultMessage": "Number of suggested medias"
+    "defaultMessage": "Number of suggested media"
   },
   {
     "id": "addFilterMenu.tiplineRequests",

--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -70,9 +70,9 @@
     "defaultMessage": "Tipline request"
   },
   {
-    "id": "addFilterMenu.similarMedias",
-    "description": "Menu option to enable searching items by similar medias",
-    "defaultMessage": "Number of similar medias"
+    "id": "addFilterMenu.matchedMedias",
+    "description": "Menu option to enable searching items by matched medias",
+    "defaultMessage": "Number of matched medias"
   },
   {
     "id": "addFilterMenu.suggestedMedias",

--- a/localization/react-intl/src/app/components/search/NumericRangeFilter.json
+++ b/localization/react-intl/src/app/components/search/NumericRangeFilter.json
@@ -1,8 +1,8 @@
 [
   {
     "id": "numericRangeFilter.linkedItems",
-    "description": "Filter option that refers to number of similar medias",
-    "defaultMessage": "Number of similar medias is between"
+    "description": "Filter option that refers to number of matched medias",
+    "defaultMessage": "Number of matched medias is between"
   },
   {
     "id": "numericRangeFilter.suggestedItems",

--- a/localization/react-intl/src/app/components/search/NumericRangeFilter.json
+++ b/localization/react-intl/src/app/components/search/NumericRangeFilter.json
@@ -2,7 +2,7 @@
   {
     "id": "numericRangeFilter.linkedItems",
     "description": "Filter option that refers to number of matched medias",
-    "defaultMessage": "Number of matched medias is between"
+    "defaultMessage": "Number of matched media is between"
   },
   {
     "id": "numericRangeFilter.suggestedItems",

--- a/localization/react-intl/src/app/components/search/SearchResults.json
+++ b/localization/react-intl/src/app/components/search/SearchResults.json
@@ -6,7 +6,7 @@
   {
     "id": "search.showSimilar",
     "description": "Allow user to show/hide secondary items",
-    "defaultMessage": "Show similar"
+    "defaultMessage": "Show matched media"
   },
   {
     "id": "search.previousPage",

--- a/localization/react-intl/src/app/components/search/SearchResultsTable/index.json
+++ b/localization/react-intl/src/app/components/search/SearchResultsTable/index.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "list.LinkedItems",
-    "defaultMessage": "Similar media"
+    "defaultMessage": "Matched media"
   },
   {
     "id": "list.Type",
@@ -66,7 +66,7 @@
   },
   {
     "id": "list.suggestionsCount",
-    "defaultMessage": "Suggested matches"
+    "defaultMessage": "Suggested media"
   },
   {
     "id": "list.folder",
@@ -96,7 +96,7 @@
   {
     "id": "list.clusterSize",
     "description": "Table header for column that shows the number of similar items that belong to the same cluster",
-    "defaultMessage": "Similar media"
+    "defaultMessage": "Matched media"
   },
   {
     "id": "list.clusterFirstItemAt",

--- a/localization/react-intl/src/app/components/team/SuggestedMatches.json
+++ b/localization/react-intl/src/app/components/team/SuggestedMatches.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "suggestedMatches.title",
-    "defaultMessage": "Suggested matches"
+    "id": "suggestedMedias.title",
+    "defaultMessage": "Suggested media"
   }
 ]

--- a/localization/react-intl/src/app/components/team/SuggestedMatches.json
+++ b/localization/react-intl/src/app/components/team/SuggestedMatches.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "suggestedMedias.title",
+    "id": "suggestedMatches.title",
     "defaultMessage": "Suggested media"
   }
 ]

--- a/localization/react-intl/src/app/components/trends/TrendsItem.json
+++ b/localization/react-intl/src/app/components/trends/TrendsItem.json
@@ -20,7 +20,7 @@
   },
   {
     "id": "trendItem.media",
-    "defaultMessage": "Similar media"
+    "defaultMessage": "Matched media"
   },
   {
     "id": "trendItem.sortBy",

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -322,7 +322,7 @@ const ProjectsComponent = ({
               <NewReleasesIcon />
             </ListItemIcon>
             <ListItemText>
-              <FormattedMessage id="projectsComponent.suggestedMedias" defaultMessage="Suggested media" description="Label for a list displayed on the left sidebar." />
+              <FormattedMessage id="projectsComponent.suggestedMatches" defaultMessage="Suggested media" description="Label for a list displayed on the left sidebar." />
             </ListItemText>
           </ListItem> : null }
 

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -322,7 +322,7 @@ const ProjectsComponent = ({
               <NewReleasesIcon />
             </ListItemIcon>
             <ListItemText>
-              <FormattedMessage id="projectsComponent.suggestedMatches" defaultMessage="Suggested matches" description="Label for a list displayed on the left sidebar." />
+              <FormattedMessage id="projectsComponent.suggestedMedias" defaultMessage="Suggested media" description="Label for a list displayed on the left sidebar." />
             </ListItemText>
           </ListItem> : null }
 

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -147,7 +147,7 @@ const MediaItem = ({
                 { projectMedia.linked_items_count && !mainProjectMedia.id ?
                   <FormattedMessage
                     id="mediaItem.similarMedia"
-                    defaultMessage="{count, plural, one {# similar media} other {# similar media}}"
+                    defaultMessage="{count, plural, one {# matched media} other {# matched media}}"
                     values={{
                       count: projectMedia.linked_items_count,
                     }}

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -230,7 +230,7 @@ const RelationshipMenu = ({
               <ListItemText
                 className="similarity-media-item__delete-relationship"
                 primary={
-                  <FormattedMessage id="mediaItem.detach" defaultMessage="Detach" />
+                  <FormattedMessage id="mediaItem.detach" defaultMessage="Un-match media" />
                 }
               />
             </MenuItem>

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -71,9 +71,9 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => {
         <Typography variant="body">
           <strong>
             <FormattedMessage
-              id="mediaSimilarities.moreMedias"
-              defaultMessage="More medias"
-              description="Heading for a list of similar medias"
+              id="mediaSimilarities.matchedMedias"
+              defaultMessage="Matched media"
+              description="Heading for a list of matched medias"
             />
           </strong>
         </Typography>

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -71,7 +71,7 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => {
         <Typography variant="body">
           <strong>
             <FormattedMessage
-              id="mediaSimilarities.matchedMedias"
+              id="mediaSimilarities.moreMedias"
               defaultMessage="Matched media"
               description="Heading for a list of matched medias"
             />

--- a/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
@@ -43,7 +43,7 @@ const MediaSimilarityBarAdd = ({
   let label = '';
   let reverse = false;
   if (action === 'addSimilarToThis') {
-    label = <FormattedMessage id="mediaSimilarityBarAdd.addMatchedToThisTitle" defaultMessage="Import matched media from other items" />;
+    label = <FormattedMessage id="mediaSimilarityBarAdd.addSimilarToThisTitle" defaultMessage="Import matched media from other items" />;
   } else if (action === 'addThisToSimilar') {
     label = <FormattedMessage id="mediaSimilarityBarAdd.addThisToSimilarTitle" defaultMessage="Export all media to another item" />;
     reverse = true;
@@ -207,7 +207,7 @@ const MediaSimilarityBarAdd = ({
           <ListItemText
             primary={
               <FormattedMessage
-                id="mediaSimilarityBarAdd.addMatchedToThis"
+                id="mediaSimilarityBarAdd.addSimilarToThis"
                 defaultMessage="Import matched media into this item"
               />
             }

--- a/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
@@ -43,7 +43,7 @@ const MediaSimilarityBarAdd = ({
   let label = '';
   let reverse = false;
   if (action === 'addSimilarToThis') {
-    label = <FormattedMessage id="mediaSimilarityBarAdd.addSimilarToThisTitle" defaultMessage="Import similar media from other items" />;
+    label = <FormattedMessage id="mediaSimilarityBarAdd.addMatchedToThisTitle" defaultMessage="Import matched media from other items" />;
   } else if (action === 'addThisToSimilar') {
     label = <FormattedMessage id="mediaSimilarityBarAdd.addThisToSimilarTitle" defaultMessage="Export all media to another item" />;
     reverse = true;
@@ -207,8 +207,8 @@ const MediaSimilarityBarAdd = ({
           <ListItemText
             primary={
               <FormattedMessage
-                id="mediaSimilarityBarAdd.addSimilarToThis"
-                defaultMessage="Import similar media into this item"
+                id="mediaSimilarityBarAdd.addMatchedToThis"
+                defaultMessage="Import matched media into this item"
               />
             }
           />

--- a/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
@@ -86,8 +86,8 @@ const MediaSimilarityBarComponent = ({
           style={confirmedSimilarCount > 0 ? { color: checkBlue } : { color: opaqueBlack54 }}
         >
           <FormattedMessage
-            id="mediaSimilarityBarComponent.matchedMedia"
-            defaultMessage="Matched medias"
+            id="mediaSimilarityBarComponent.similarMedia"
+            defaultMessage="Matched media"
             description="Plural. Heading for the number of matched media"
           />
           <br />
@@ -99,7 +99,7 @@ const MediaSimilarityBarComponent = ({
           style={suggestionsCount > 0 ? { color: checkBlue } : { color: opaqueBlack54 }}
         >
           <FormattedMessage
-            id="mediaSimilarityBarComponent.suggestedMedia"
+            id="mediaSimilarityBarComponent.suggestedMatches"
             defaultMessage="Suggested media"
             description="Plural. Heading for the number of suggested media"
           />

--- a/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
@@ -86,9 +86,9 @@ const MediaSimilarityBarComponent = ({
           style={confirmedSimilarCount > 0 ? { color: checkBlue } : { color: opaqueBlack54 }}
         >
           <FormattedMessage
-            id="mediaSimilarityBarComponent.similarMedia"
-            defaultMessage="Similar media"
-            description="Plural. Heading for the number of similar media"
+            id="mediaSimilarityBarComponent.matchedMedia"
+            defaultMessage="Matched medias"
+            description="Plural. Heading for the number of matched media"
           />
           <br />
           <span className={classes.similarMediaCount}>{confirmedSimilarCount}</span>
@@ -99,7 +99,7 @@ const MediaSimilarityBarComponent = ({
           style={suggestionsCount > 0 ? { color: checkBlue } : { color: opaqueBlack54 }}
         >
           <FormattedMessage
-            id="mediaSimilarityBarComponent.suggestedMatches"
+            id="mediaSimilarityBarComponent.suggestedMedia"
             defaultMessage="Suggested media"
             description="Plural. Heading for the number of suggested media"
           />

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -29,7 +29,7 @@ class ProjectHeaderComponent extends React.PureComponent {
     } else if (/\/imported-reports(\/|$)/.test(listUrl)) {
       pageTitle = <FormattedMessage id="projectHeader.importedReports" defaultMessage="Imported reports" />;
     } else if (/\/suggested-matches(\/|$)/.test(listUrl)) {
-      pageTitle = <FormattedMessage id="projectHeader.suggestedMatches" defaultMessage="Suggested matches" />;
+      pageTitle = <FormattedMessage id="projectHeader.suggestedMedias" defaultMessage="Suggested media" />;
     } else if (isFeedPage) {
       pageTitle = <FormattedMessage id="projectHeader.feed" defaultMessage="Shared feed" />;
     } else if (project) {

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -29,7 +29,7 @@ class ProjectHeaderComponent extends React.PureComponent {
     } else if (/\/imported-reports(\/|$)/.test(listUrl)) {
       pageTitle = <FormattedMessage id="projectHeader.importedReports" defaultMessage="Imported reports" />;
     } else if (/\/suggested-matches(\/|$)/.test(listUrl)) {
-      pageTitle = <FormattedMessage id="projectHeader.suggestedMedias" defaultMessage="Suggested media" />;
+      pageTitle = <FormattedMessage id="projectHeader.suggestedMatches" defaultMessage="Suggested media" />;
     } else if (isFeedPage) {
       pageTitle = <FormattedMessage id="projectHeader.feed" defaultMessage="Shared feed" />;
     } else if (project) {

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -219,8 +219,8 @@ const AddFilterMenu = ({
     icon: <NumberIcon />,
     label: (
       <FormattedMessage
-        id="addFilterMenu.matchedMedias"
-        defaultMessage="Number of matched medias"
+        id="addFilterMenu.similarMedias"
+        defaultMessage="Number of matched media"
         description="Menu option to enable searching items by matched medias"
       />
     ),
@@ -234,7 +234,7 @@ const AddFilterMenu = ({
       label: (
         <FormattedMessage
           id="addFilterMenu.suggestedMedias"
-          defaultMessage="Number of suggested medias"
+          defaultMessage="Number of suggested media"
           description="Menu option to enable searching items by suggested medias"
         />
       ),

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -219,9 +219,9 @@ const AddFilterMenu = ({
     icon: <NumberIcon />,
     label: (
       <FormattedMessage
-        id="addFilterMenu.similarMedias"
-        defaultMessage="Number of similar medias"
-        description="Menu option to enable searching items by similar medias"
+        id="addFilterMenu.matchedMedias"
+        defaultMessage="Number of matched medias"
+        description="Menu option to enable searching items by matched medias"
       />
     ),
   },

--- a/src/app/components/search/NumericRangeFilter.js
+++ b/src/app/components/search/NumericRangeFilter.js
@@ -14,7 +14,7 @@ import { checkBlue } from '../../styles/js/shared';
 const messages = defineMessages({
   linkedItems: {
     id: 'numericRangeFilter.linkedItems',
-    defaultMessage: 'Number of matched medias is between',
+    defaultMessage: 'Number of matched media is between',
     description: 'Filter option that refers to number of matched medias',
   },
   suggestedItems: {

--- a/src/app/components/search/NumericRangeFilter.js
+++ b/src/app/components/search/NumericRangeFilter.js
@@ -14,8 +14,8 @@ import { checkBlue } from '../../styles/js/shared';
 const messages = defineMessages({
   linkedItems: {
     id: 'numericRangeFilter.linkedItems',
-    defaultMessage: 'Number of similar medias is between',
-    description: 'Filter option that refers to number of similar medias',
+    defaultMessage: 'Number of matched medias is between',
+    description: 'Filter option that refers to number of matched medias',
   },
   suggestedItems: {
     id: 'numericRangeFilter.suggestedItems',

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -135,7 +135,7 @@ const SaveList = ({
     }
   }
 
-  // Don't show the button if it's a tipline inbox or suggested matches page and nothing changed
+  // Don't show the button if it's a tipline inbox or suggested media page and nothing changed
   if (['tipline-inbox', 'suggested-matches'].indexOf(objectType) !== -1) {
     let defaultQuery = {};
     let savedQuery = '{}';

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -502,7 +502,7 @@ function SearchResultsComponent({
               label={
                 <FormattedMessage
                   id="search.showSimilar"
-                  defaultMessage="Show similar"
+                  defaultMessage="Show matched media"
                   description="Allow user to show/hide secondary items"
                 />
               }

--- a/src/app/components/search/SearchResultsTable/index.js
+++ b/src/app/components/search/SearchResultsTable/index.js
@@ -65,7 +65,7 @@ const AllPossibleColumns = [
   },
   {
     field: 'linked_items_count',
-    headerText: <FormattedMessage id="list.LinkedItems" defaultMessage="Similar media" />,
+    headerText: <FormattedMessage id="list.LinkedItems" defaultMessage="Matched media" />,
     cellComponent: LinkedItemsCountCell,
     align: 'center',
     sortKey: 'related',
@@ -138,7 +138,7 @@ const AllPossibleColumns = [
   },
   {
     field: 'suggestions_count',
-    headerText: <FormattedMessage id="list.suggestionsCount" defaultMessage="Suggested matches" />,
+    headerText: <FormattedMessage id="list.suggestionsCount" defaultMessage="Suggested media" />,
     cellComponent: SuggestionsCountCell,
     align: 'center',
     sortKey: 'suggestions_count',
@@ -174,7 +174,7 @@ const AllPossibleColumns = [
   },
   {
     field: 'cluster_size',
-    headerText: <FormattedMessage id="list.clusterSize" defaultMessage="Similar media" description="Table header for column that shows the number of similar items that belong to the same cluster" />,
+    headerText: <FormattedMessage id="list.clusterSize" defaultMessage="Matched media" description="Table header for column that shows the number of similar items that belong to the same cluster" />,
     cellComponent: ClusterSizeCell,
     align: 'center',
     sortKey: 'cluster_size',

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -43,7 +43,7 @@ const SuggestedMatches = ({ routeParams }) => (
             <Search
               searchUrlPrefix={`/${routeParams.team}/suggested-matches`}
               mediaUrlPrefix={`/${routeParams.team}/media`}
-              title={<FormattedMessage id="suggestedMatches.title" defaultMessage="Suggested matches" />}
+              title={<FormattedMessage id="suggestedMedias.title" defaultMessage="Suggested media" />}
               icon={<NewReleasesIcon />}
               teamSlug={routeParams.team}
               query={query}

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -43,7 +43,7 @@ const SuggestedMatches = ({ routeParams }) => (
             <Search
               searchUrlPrefix={`/${routeParams.team}/suggested-matches`}
               mediaUrlPrefix={`/${routeParams.team}/media`}
-              title={<FormattedMessage id="suggestedMedias.title" defaultMessage="Suggested media" />}
+              title={<FormattedMessage id="suggestedMatches.title" defaultMessage="Suggested media" />}
               icon={<NewReleasesIcon />}
               teamSlug={routeParams.team}
               query={query}


### PR DESCRIPTION
## Description

Replaced the strings below:
On the "folder" page: 
Similar media → Matched media
Suggested matches → Suggested media
Show matched media

On the "item" page: 
More media → Matched media
Detach media (in menu of single secondary media) → Un-match media

Reference: CHECK-2221
