### PR TITLE
Fix context field when context is undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11679,7 +11679,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14922,7 +14922,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/media/MediaContext.js
+++ b/src/app/components/media/MediaContext.js
@@ -24,7 +24,7 @@ const MediaContext = ({
 
   // override to compensate for fast onBlur stateless component
   const textElement = document.querySelector('#media-claim__context');
-  if (textElement && claimDescription && textElement.value !== claimDescription.context) {
+  if (textElement && claimDescription && claimDescription.context && textElement.value !== claimDescription.context) {
     textElement.value = claimDescription.context;
   }
 


### PR DESCRIPTION
We were updating the context field under "Claim" if the context met a bunch of criteria, but there is a case where the criteria can be true _and_ context can be `undefined`. Now we check for `undefined` before updating.

CHECK-2391

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)
