### PR TITLE
Feed page should show number of root requests, not total number of requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11679,7 +11679,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14922,7 +14922,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -101,7 +101,7 @@ const FeedRequestsTable = ({
         <IconButton onClick={onGoToThePreviousPage} disabled={!hasPreviousPage}>
           <PrevIcon />
         </IconButton>
-        <Box className={classes.pager}>{rangeStart} - {rangeEnd} / {feed.requests_count}</Box>
+        <Box className={classes.pager}>{rangeStart} - {rangeEnd > feed.root_requests_count ? feed.root_requests_count : rangeEnd} / {feed.root_requests_count}</Box>
         <IconButton onClick={onGoToTheNextPage} disabled={!hasNextPage}>
           <NextIcon />
         </IconButton>
@@ -213,7 +213,7 @@ const FeedRequestsTableQuery = ({
               feed(dbid: $feedId) {
                 dbid
                 name
-                requests_count
+                root_requests_count
                 requests(first: $pageSize, offset: $offset, sort: $sort, sort_type: $sortType) {
                   edges {
                     node {
@@ -263,7 +263,7 @@ const FeedRequestsTableQuery = ({
                 onGoToThePreviousPage={() => { setPage(page - 1); }}
                 rangeStart={((page - 1) * pageSize) + 1}
                 rangeEnd={((page - 1) * pageSize) + pageSize}
-                hasNextPage={(page * pageSize) < props.team?.feed?.requests_count}
+                hasNextPage={(page * pageSize) < props.team?.feed?.root_requests_count}
                 hasPreviousPage={page > 1}
               />);
           }


### PR DESCRIPTION
## Description

The feed table lists root requests, so the counter should use the same criteria. A root request is a feed request whose `request_id` attribute is null. So, it either doesn't have any request similar to it or it's the center of a cluster of similar requests.

Fixes CHECK-2389.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

There is a test for that in Check API.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

