### PR TITLE
Add error message when trying to save fact-check with no title or no …

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaFactCheck.json
+++ b/localization/react-intl/src/app/components/media/MediaFactCheck.json
@@ -5,9 +5,9 @@
     "defaultMessage": "Fact-check"
   },
   {
-    "id": "mediaFactCheck,error",
-    "description": "Caption that informs that a fact-check could not be saved",
-    "defaultMessage": "error"
+    "id": "mediaFactCheck.error",
+    "description": "Caption that informs that a fact-check could not be saved and that the fields have to be filled",
+    "defaultMessage": "Title and description have to be filled"
   },
   {
     "id": "mediaFactCheck.saving",
@@ -15,7 +15,7 @@
     "defaultMessage": "saving…"
   },
   {
-    "id": "mediaFactCheck,saved",
+    "id": "mediaFactCheck.saved",
     "description": "Caption that informs who last saved this fact-check and when it happened.",
     "defaultMessage": "saved by {userName} {timeAgo}"
   },

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -93,7 +93,7 @@ const MediaFactCheck = ({ projectMedia }) => {
             setError(true);
           },
         });
-      } else if (values.title || values.summary || values.url) {
+      } else if (values.title && values.summary) {
         setSaving(true);
         commitMutation(Relay.Store, {
           mutation: graphql`
@@ -135,6 +135,9 @@ const MediaFactCheck = ({ projectMedia }) => {
             setError(true);
           },
         });
+      } else {
+        setSaving(false);
+        setError(true);
       }
     }
   };
@@ -151,9 +154,9 @@ const MediaFactCheck = ({ projectMedia }) => {
         <Typography variant="caption" component="div">
           { error ?
             <FormattedMessage
-              id="mediaFactCheck,error"
-              defaultMessage="error"
-              description="Caption that informs that a fact-check could not be saved"
+              id="mediaFactCheck.error"
+              defaultMessage="Title and description have to be filled"
+              description="Caption that informs that a fact-check could not be saved and that the fields have to be filled"
             /> : null }
           { saving && !error ?
             <FormattedMessage
@@ -164,7 +167,7 @@ const MediaFactCheck = ({ projectMedia }) => {
           { !saving && !error && factCheck ?
             <FormattedMessage
               className="media-fact-check__saved-by"
-              id="mediaFactCheck,saved"
+              id="mediaFactCheck.saved"
               defaultMessage="saved by {userName} {timeAgo}"
               values={{
                 userName: factCheck.user.name,
@@ -185,6 +188,7 @@ const MediaFactCheck = ({ projectMedia }) => {
           setTitle(newValue);
           handleBlur('title', newValue);
         }}
+        required
         hasClaimDescription={Boolean(claimDescription?.description)}
         hasPermission={hasPermission}
         disabled={readOnly || published}
@@ -201,6 +205,7 @@ const MediaFactCheck = ({ projectMedia }) => {
           setSummary(newValue);
           handleBlur('summary', newValue);
         }}
+        required
         hasClaimDescription={Boolean(claimDescription?.description)}
         hasPermission={hasPermission}
         disabled={readOnly || published}

--- a/src/app/components/media/MediaFactCheckField.js
+++ b/src/app/components/media/MediaFactCheckField.js
@@ -23,6 +23,7 @@ const MediaFactCheckField = ({
   rows,
   onBlur,
   intl,
+  required,
 }) => {
   let defaultValue = intl.formatMessage(messages.placeholder);
 
@@ -39,6 +40,7 @@ const MediaFactCheckField = ({
         rows={rows}
         value={defaultValue}
         textFieldProps={{
+          required,
           id: `media-fact-check__${name}`,
           className: `media-fact-check__${name}`,
           disabled: (!hasPermission || disabled),
@@ -52,6 +54,7 @@ const MediaFactCheckField = ({
 MediaFactCheckField.defaultProps = {
   disabled: false,
   rows: 3,
+  required: false,
 };
 
 MediaFactCheckField.propTypes = {
@@ -65,6 +68,7 @@ MediaFactCheckField.propTypes = {
   rows: PropTypes.number,
   onBlur: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  required: PropTypes.bool,
 };
 
 export default injectIntl(MediaFactCheckField);


### PR DESCRIPTION
…description

## Description

just try to run MediaFactCheckCreateFactCheckMutation if title and description fields are filled
add error message when trying to save fact-check with no title or no description
add required symbol to required fields
Reference: CHECK-2415

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

