### PR TITLE
Add FactCheckCell to column settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11679,7 +11679,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14922,7 +14922,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/search/SearchResultsTable/FactCheckCell.js
+++ b/src/app/components/search/SearchResultsTable/FactCheckCell.js
@@ -86,25 +86,27 @@ const MaybeLink = ({ to, className, children }) => {
   return <span className={className}>{children}</span>;
 };
 
-
 const FactCheckCell = ({ projectMedia, viewMode }) => {
   const title = projectMedia.feed_columns_values.fact_check_title;
   const summary = projectMedia.feed_columns_values.fact_check_summary;
   const url = projectMedia.feed_columns_values.fact_check_url;
   const classes = useStyles();
+  const isBlank = !summary && !title;
 
   return (
     <TableCell className="media__heading" component="th" scope="row">
-      <MaybeLink className={classes.root} to={url}>
-        <Box display="flex" alignItems="center">
-          <TitleText
-            classes={classes}
-            title={title}
-            description={summary}
-            viewMode={viewMode}
-          />
-        </Box>
-      </MaybeLink>
+      {isBlank ? <Box>-</Box> : (
+        <MaybeLink className={classes.root} to={url}>
+          <Box display="flex" alignItems="center">
+            <TitleText
+              classes={classes}
+              title={title}
+              description={summary}
+              viewMode={viewMode}
+            />
+          </Box>
+        </MaybeLink>
+      )}
     </TableCell>
   );
 };

--- a/src/app/components/search/SearchResultsTable/FactCheckCell.test.js
+++ b/src/app/components/search/SearchResultsTable/FactCheckCell.test.js
@@ -29,7 +29,7 @@ const projectMediaBlank = {
     fact_check_summary: '',
     fact_check_url: undefined,
   },
-}
+};
 
 describe('<FactCheckCell>', () => {
   it('should render title', () => {

--- a/src/app/components/search/SearchResultsTable/FactCheckCell.test.js
+++ b/src/app/components/search/SearchResultsTable/FactCheckCell.test.js
@@ -23,6 +23,14 @@ const projectMedia = {
   },
 };
 
+const projectMediaBlank = {
+  feed_columns_values: {
+    fact_check_title: null,
+    fact_check_summary: '',
+    fact_check_url: undefined,
+  },
+}
+
 describe('<FactCheckCell>', () => {
   it('should render title', () => {
     const cell = mountInTable(<FactCheckCell projectMedia={projectMedia} />);
@@ -43,5 +51,11 @@ describe('<FactCheckCell>', () => {
     projectMedia.feed_columns_values.fact_check_url = null;
     const cell = mountInTable(<FactCheckCell projectMedia={projectMedia} />);
     expect(cell.find('a').length).toEqual(0);
+  });
+
+  it('should render a "-" instead of blank', () => {
+    projectMedia.feed_columns_values.fact_check_url = null;
+    const cell = mountInTable(<FactCheckCell projectMedia={projectMediaBlank} />);
+    expect(cell.text()).toEqual('-');
   });
 });

--- a/src/app/components/search/SearchResultsTable/index.js
+++ b/src/app/components/search/SearchResultsTable/index.js
@@ -44,7 +44,7 @@ const AllPossibleColumns = [
     sortKey: 'title',
   },
   {
-    field: 'fact_check',
+    field: 'fact_check_title',
     headerText: <FormattedMessage id="list.factCheck" defaultMessage="Fact-check" />,
     cellComponent: FactCheckCell,
   },
@@ -203,7 +203,7 @@ const showInFeed = [
 ];
 
 const showInFactCheck = [
-  'fact_check',
+  'fact_check_title',
   'status',
   'updated_at_timestamp',
   'team_name',


### PR DESCRIPTION
This also modifies FactCheckCell to render '-' in the cases where it is blank, per CHECK-2309. This shouldn't affect the feeds page anyway since it's never blank on that page.

References: CHECK-2309

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Wrote unit test for the new display feature and manually tested on dev.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas, if any
- [X] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [X] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [X] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)