### PR TITLE
Prevent random argument reset

### DIFF
--- a/src/app/components/search/CustomFiltersManager.js
+++ b/src/app/components/search/CustomFiltersManager.js
@@ -231,6 +231,7 @@ const CustomFiltersManager = ({
   query,
 }) => {
   const teamSlug = team.slug;
+  const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer
       environment={Relay.Store}
@@ -254,7 +255,7 @@ const CustomFiltersManager = ({
       `}
       variables={{
         teamSlug,
-        random: String(Math.random()),
+        random,
       }}
       render={({ error, props }) => {
         if (!error && props) {

--- a/src/app/components/search/CustomFiltersManager.js
+++ b/src/app/components/search/CustomFiltersManager.js
@@ -231,6 +231,7 @@ const CustomFiltersManager = ({
   query,
 }) => {
   const teamSlug = team.slug;
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
+++ b/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
@@ -13,6 +13,7 @@ const SearchFieldClusterTeams = ({
   onChange,
   onRemove,
 }) => {
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
+++ b/src/app/components/search/SearchFields/SearchFieldClusterTeams.js
@@ -12,42 +12,45 @@ const SearchFieldClusterTeams = ({
   selected,
   onChange,
   onRemove,
-}) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query SearchFieldClusterTeamsQuery($teamSlug: String!, $random: String!) {
-        team(slug: $teamSlug, random: $random) {
-          shared_teams
+}) => {
+  const [random] = React.useState(String(Math.random()));
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query SearchFieldClusterTeamsQuery($teamSlug: String!, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
+            shared_teams
+          }
         }
-      }
-    `}
-    variables={{
-      teamSlug,
-      random: String(Math.random()),
-    }}
-    render={({ error, props }) => {
-      if (!error && props) {
-        const { shared_teams: sharedTeams } = props.team;
-        const options = Object.keys(sharedTeams).map(t => ({ label: sharedTeams[t], value: t }));
+      `}
+      variables={{
+        teamSlug,
+        random,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          const { shared_teams: sharedTeams } = props.team;
+          const options = Object.keys(sharedTeams).map(t => ({ label: sharedTeams[t], value: t }));
 
-        return (
-          <MultiSelectFilter
-            label={label}
-            icon={icon}
-            selected={selected}
-            options={options}
-            onChange={(newValue) => { onChange(newValue); }}
-            onRemove={onRemove}
-          />
-        );
-      }
+          return (
+            <MultiSelectFilter
+              label={label}
+              icon={icon}
+              selected={selected}
+              options={options}
+              onChange={(newValue) => { onChange(newValue); }}
+              onRemove={onRemove}
+            />
+          );
+        }
 
-      // TODO: We need a better error handling in the future, standardized with other components
-      return <CircularProgress size={36} />;
-    }}
-  />
-);
+        // TODO: We need a better error handling in the future, standardized with other components
+        return <CircularProgress size={36} />;
+      }}
+    />
+  );
+};
 
 SearchFieldClusterTeams.defaultProps = {
   selected: [],

--- a/src/app/components/search/SearchFields/SearchFieldProject.js
+++ b/src/app/components/search/SearchFields/SearchFieldProject.js
@@ -16,6 +16,7 @@ const SearchFieldProject = ({
   onRemove,
   readOnly,
 }) => {
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldProject.js
+++ b/src/app/components/search/SearchFields/SearchFieldProject.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
@@ -24,14 +23,11 @@ const SearchFieldProject = ({
       query={graphql`
         query SearchFieldProjectQuery($teamSlug: String!, $random: String!) {
           team(slug: $teamSlug, random: $random) {
-            id
             projects(first: 10000) {
               edges {
                 node {
                   title
                   dbid
-                  id
-                  description
                   project_group_id
                 }
               }

--- a/src/app/components/search/SearchFields/SearchFieldProject.js
+++ b/src/app/components/search/SearchFields/SearchFieldProject.js
@@ -15,93 +15,96 @@ const SearchFieldProject = ({
   onChange,
   onRemove,
   readOnly,
-}) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query SearchFieldProjectQuery($teamSlug: String!, $random: String!) {
-        team(slug: $teamSlug, random: $random) {
-          id
-          projects(first: 10000) {
-            edges {
-              node {
-                title
-                dbid
-                id
-                description
-                project_group_id
+}) => {
+  const [random] = React.useState(String(Math.random()));
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query SearchFieldProjectQuery($teamSlug: String!, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
+            id
+            projects(first: 10000) {
+              edges {
+                node {
+                  title
+                  dbid
+                  id
+                  description
+                  project_group_id
+                }
               }
             }
-          }
-          project_groups(first: 10000) {
-            edges {
-              node {
-                title
-                dbid
+            project_groups(first: 10000) {
+              edges {
+                node {
+                  title
+                  dbid
+                }
               }
             }
           }
         }
-      }
-    `}
-    variables={{
-      teamSlug,
-      random: String(Math.random()),
-    }}
-    render={({ error, props }) => {
-      if (!error && props) {
-        // Folder options are grouped by collection
-        // FIXME: Simplify the code below and improve its performance
-        const projects = props.team.projects.edges.slice().map(p => p.node).sort((a, b) => a.title.localeCompare(b.title));
-        let projectOptions = [];
-        props.team.project_groups.edges.slice().map(pg => pg.node).sort((a, b) => a.title.localeCompare(b.title)).forEach((pg) => {
-          const subProjects = [];
-          projects.filter(p => p.project_group_id === pg.dbid).forEach((p) => {
-            subProjects.push({ label: p.title, value: `${p.dbid}` });
+      `}
+      variables={{
+        teamSlug,
+        random,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          // Folder options are grouped by collection
+          // FIXME: Simplify the code below and improve its performance
+          const projects = props.team.projects.edges.slice().map(p => p.node).sort((a, b) => a.title.localeCompare(b.title));
+          let projectOptions = [];
+          props.team.project_groups.edges.slice().map(pg => pg.node).sort((a, b) => a.title.localeCompare(b.title)).forEach((pg) => {
+            const subProjects = [];
+            projects.filter(p => p.project_group_id === pg.dbid).forEach((p) => {
+              subProjects.push({ label: p.title, value: `${p.dbid}` });
+            });
+            if (subProjects.length > 0) {
+              projectOptions.push({ label: pg.title, value: '', projectsTitles: subProjects.map(sp => sp.label).join(',') });
+              projectOptions = projectOptions.concat(subProjects);
+            }
           });
-          if (subProjects.length > 0) {
-            projectOptions.push({ label: pg.title, value: '', projectsTitles: subProjects.map(sp => sp.label).join(',') });
-            projectOptions = projectOptions.concat(subProjects);
+          const orphanProjects = [];
+          projects.filter(p => !p.project_group_id).forEach((p) => {
+            orphanProjects.push({ label: p.title, value: `${p.dbid}` });
+          });
+          if (orphanProjects.length > 0) {
+            projectOptions.push({
+              label: <FormattedMessage id="SearchFieldProject.notInAny" defaultMessage="Not in any collection" description="Label displayed before listing all folders that are not part of any collection" />,
+              value: '',
+              orphanProjects: orphanProjects.map(op => op.label).join(','),
+            });
+            projectOptions = projectOptions.concat(orphanProjects);
           }
-        });
-        const orphanProjects = [];
-        projects.filter(p => !p.project_group_id).forEach((p) => {
-          orphanProjects.push({ label: p.title, value: `${p.dbid}` });
-        });
-        if (orphanProjects.length > 0) {
-          projectOptions.push({
-            label: <FormattedMessage id="SearchFieldProject.notInAny" defaultMessage="Not in any collection" description="Label displayed before listing all folders that are not part of any collection" />,
-            value: '',
-            orphanProjects: orphanProjects.map(op => op.label).join(','),
-          });
-          projectOptions = projectOptions.concat(orphanProjects);
+
+          const selectedProjects = query.projects ? query.projects.map(p => `${p}`) : [];
+          const selected = project ? [project.dbid] : selectedProjects;
+
+          return (
+            <FormattedMessage id="SearchFieldProject.label" defaultMessage="Folder is" description="Prefix label for field to filter by folder to which items belong">
+              { label => (
+                <MultiSelectFilter
+                  label={label}
+                  icon={<FolderOpenIcon />}
+                  selected={selected}
+                  options={projectOptions}
+                  onChange={(newValue) => { onChange(newValue); }}
+                  readOnly={readOnly}
+                  onRemove={onRemove}
+                />
+              )}
+            </FormattedMessage>
+          );
         }
 
-        const selectedProjects = query.projects ? query.projects.map(p => `${p}`) : [];
-        const selected = project ? [project.dbid] : selectedProjects;
-
-        return (
-          <FormattedMessage id="SearchFieldProject.label" defaultMessage="Folder is" description="Prefix label for field to filter by folder to which items belong">
-            { label => (
-              <MultiSelectFilter
-                label={label}
-                icon={<FolderOpenIcon />}
-                selected={selected}
-                options={projectOptions}
-                onChange={(newValue) => { onChange(newValue); }}
-                readOnly={readOnly}
-                onRemove={onRemove}
-              />
-            )}
-          </FormattedMessage>
-        );
-      }
-
-      // TODO: We need a better error handling in the future, standardized with other components
-      return <CircularProgress size={36} />;
-    }}
-  />
-);
+        // TODO: We need a better error handling in the future, standardized with other components
+        return <CircularProgress size={36} />;
+      }}
+    />
+  );
+};
 
 SearchFieldProject.defaultProps = {
   project: null,

--- a/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
+++ b/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
@@ -24,7 +23,6 @@ const SearchFieldProjectGroup = ({
       query={graphql`
         query SearchFieldProjectGroupQuery($teamSlug: String!, $random: String!) {
           team(slug: $teamSlug, random: $random) {
-            id
             project_groups(first: 10000) {
               edges {
                 node {

--- a/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
+++ b/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
@@ -15,59 +15,62 @@ const SearchFieldProjectGroup = ({
   onChange,
   onRemove,
   readOnly,
-}) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query SearchFieldProjectGroupQuery($teamSlug: String!, $random: String!) {
-        team(slug: $teamSlug, random: $random) {
-          id
-          project_groups(first: 10000) {
-            edges {
-              node {
-                title
-                dbid
+}) => {
+  const [random] = React.useState(String(Math.random()));
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query SearchFieldProjectGroupQuery($teamSlug: String!, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
+            id
+            project_groups(first: 10000) {
+              edges {
+                node {
+                  title
+                  dbid
+                }
               }
             }
           }
         }
-      }
-    `}
-    variables={{
-      teamSlug,
-      random: String(Math.random()),
-    }}
-    render={({ error, props }) => {
-      if (!error && props) {
-        const selectedProjectGroups = query.project_group_id ? query.project_group_id.map(p => `${p}`) : [];
-        const selected = projectGroup ? [projectGroup.dbid] : selectedProjectGroups;
-        const projectGroupOptions = [];
-        props.team.project_groups.edges.slice().map(pg => pg.node).sort((a, b) => a.title.localeCompare(b.title)).forEach((pg) => {
-          projectGroupOptions.push({ label: pg.title, value: `${pg.dbid}` });
-        });
+      `}
+      variables={{
+        teamSlug,
+        random,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          const selectedProjectGroups = query.project_group_id ? query.project_group_id.map(p => `${p}`) : [];
+          const selected = projectGroup ? [projectGroup.dbid] : selectedProjectGroups;
+          const projectGroupOptions = [];
+          props.team.project_groups.edges.slice().map(pg => pg.node).sort((a, b) => a.title.localeCompare(b.title)).forEach((pg) => {
+            projectGroupOptions.push({ label: pg.title, value: `${pg.dbid}` });
+          });
 
-        return (
-          <FormattedMessage id="SearchFieldProjectGroup.collection" defaultMessage="Collection is" description="Prefix label for field to filter by collection">
-            { label => (
-              <MultiSelectFilter
-                label={label}
-                icon={<FolderSpecialIcon />}
-                options={projectGroupOptions}
-                selected={selected}
-                onChange={onChange}
-                readOnly={readOnly}
-                onRemove={onRemove}
-              />
-            )}
-          </FormattedMessage>
-        );
-      }
+          return (
+            <FormattedMessage id="SearchFieldProjectGroup.collection" defaultMessage="Collection is" description="Prefix label for field to filter by collection">
+              { label => (
+                <MultiSelectFilter
+                  label={label}
+                  icon={<FolderSpecialIcon />}
+                  options={projectGroupOptions}
+                  selected={selected}
+                  onChange={onChange}
+                  readOnly={readOnly}
+                  onRemove={onRemove}
+                />
+              )}
+            </FormattedMessage>
+          );
+        }
 
-      // TODO: We need a better error handling in the future, standardized with other components
-      return <CircularProgress size={36} />;
-    }}
-  />
-);
+        // TODO: We need a better error handling in the future, standardized with other components
+        return <CircularProgress size={36} />;
+      }}
+    />
+  );
+};
 
 SearchFieldProjectGroup.defaultProps = {
   projectGroup: null,

--- a/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
+++ b/src/app/components/search/SearchFields/SearchFieldProjectGroup.js
@@ -16,6 +16,7 @@ const SearchFieldProjectGroup = ({
   onRemove,
   readOnly,
 }) => {
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldSource.js
+++ b/src/app/components/search/SearchFields/SearchFieldSource.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
@@ -38,12 +37,10 @@ const SearchFieldSource = ({
       query={graphql`
         query SearchFieldSourceQuery($teamSlug: String!, $keyword: String, $max: Int, $random: String!) {
           team(slug: $teamSlug, random: $random) {
-            id
             sources_count(keyword: $keyword)
             sources(first: $max, keyword: $keyword) {
               edges {
                 node {
-                  id
                   dbid
                   name
                 }

--- a/src/app/components/search/SearchFields/SearchFieldSource.js
+++ b/src/app/components/search/SearchFields/SearchFieldSource.js
@@ -17,6 +17,7 @@ const SearchFieldSource = ({
   onRemove,
 }) => {
   const [keyword, setKeyword] = React.useState('');
+  const [random] = React.useState(String(Math.random()));
 
   // Maximum number of options to be displayed
   const max = 500;
@@ -54,7 +55,7 @@ const SearchFieldSource = ({
         teamSlug,
         keyword,
         max,
-        random: String(Math.random()),
+        random,
       }}
       render={({ error, props }) => {
         if (!error && props) {

--- a/src/app/components/search/SearchFields/SearchFieldSource.js
+++ b/src/app/components/search/SearchFields/SearchFieldSource.js
@@ -17,6 +17,7 @@ const SearchFieldSource = ({
   onRemove,
 }) => {
   const [keyword, setKeyword] = React.useState('');
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
 
   // Maximum number of options to be displayed

--- a/src/app/components/search/SearchFields/SearchFieldTag.js
+++ b/src/app/components/search/SearchFields/SearchFieldTag.js
@@ -16,55 +16,58 @@ const SearchFieldTag = ({
   onToggleOperator,
   operator,
   readOnly,
-}) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query SearchFieldTagQuery($teamSlug: String!, $random: String!) {
-        team(slug: $teamSlug, random: $random) {
-          id
-          tag_texts(first: 10000) {
-            edges {
-              node {
-                text
+}) => {
+  const [random] = React.useState(String(Math.random()));
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query SearchFieldTagQuery($teamSlug: String!, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
+            id
+            tag_texts(first: 10000) {
+              edges {
+                node {
+                  text
+                }
               }
             }
           }
         }
-      }
-    `}
-    variables={{
-      teamSlug,
-      random: String(Math.random()),
-    }}
-    render={({ error, props }) => {
-      if (!error && props) {
-        const plainTagsTexts = props.team.tag_texts ?
-          props.team.tag_texts.edges.map(t => t.node.text) : [];
-        return (
-          <FormattedMessage id="SearchFieldTag.label" defaultMessage="Tag is" description="Prefix label for field to filter by tags">
-            { label => (
-              <MultiSelectFilter
-                label={label}
-                icon={<LocalOfferIcon />}
-                selected={query.tags}
-                options={plainTagsTexts.map(t => ({ label: t, value: t }))}
-                onChange={onChange}
-                onToggleOperator={onToggleOperator}
-                operator={operator}
-                readOnly={readOnly}
-                onRemove={onRemove}
-              />
-            )}
-          </FormattedMessage>
-        );
-      }
+      `}
+      variables={{
+        teamSlug,
+        random,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          const plainTagsTexts = props.team.tag_texts ?
+            props.team.tag_texts.edges.map(t => t.node.text) : [];
+          return (
+            <FormattedMessage id="SearchFieldTag.label" defaultMessage="Tag is" description="Prefix label for field to filter by tags">
+              { label => (
+                <MultiSelectFilter
+                  label={label}
+                  icon={<LocalOfferIcon />}
+                  selected={query.tags}
+                  options={plainTagsTexts.map(t => ({ label: t, value: t }))}
+                  onChange={onChange}
+                  onToggleOperator={onToggleOperator}
+                  operator={operator}
+                  readOnly={readOnly}
+                  onRemove={onRemove}
+                />
+              )}
+            </FormattedMessage>
+          );
+        }
 
-      // TODO: We need a better error handling in the future, standardized with other components
-      return <CircularProgress size={36} />;
-    }}
-  />
-);
+        // TODO: We need a better error handling in the future, standardized with other components
+        return <CircularProgress size={36} />;
+      }}
+    />
+  );
+};
 
 SearchFieldTag.propTypes = {
   teamSlug: PropTypes.string.isRequired,

--- a/src/app/components/search/SearchFields/SearchFieldTag.js
+++ b/src/app/components/search/SearchFields/SearchFieldTag.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
@@ -25,7 +24,6 @@ const SearchFieldTag = ({
       query={graphql`
         query SearchFieldTagQuery($teamSlug: String!, $random: String!) {
           team(slug: $teamSlug, random: $random) {
-            id
             tag_texts(first: 10000) {
               edges {
                 node {

--- a/src/app/components/search/SearchFields/SearchFieldTag.js
+++ b/src/app/components/search/SearchFields/SearchFieldTag.js
@@ -17,6 +17,7 @@ const SearchFieldTag = ({
   operator,
   readOnly,
 }) => {
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldUser.js
+++ b/src/app/components/search/SearchFields/SearchFieldUser.js
@@ -17,57 +17,60 @@ const SearchFieldUser = ({
   readOnly,
   onToggleOperator,
   operator,
-}) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query SearchFieldUserQuery($teamSlug: String!, $random: String!) {
-        team(slug: $teamSlug, random: $random) {
-          id
-          users(first: 10000) {
-            edges {
-              node {
-                id
-                dbid
-                name
-                is_bot
+}) => {
+  const [random] = React.useState(String(Math.random()));
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query SearchFieldUserQuery($teamSlug: String!, $random: String!) {
+          team(slug: $teamSlug, random: $random) {
+            id
+            users(first: 10000) {
+              edges {
+                node {
+                  id
+                  dbid
+                  name
+                  is_bot
+                }
               }
             }
           }
         }
-      }
-    `}
-    variables={{
-      teamSlug,
-      random: String(Math.random()),
-    }}
-    render={({ error, props }) => {
-      if (!error && props) {
-        const users = props.team.users ?
-          props.team.users.edges.slice()
-            .filter(u => !u.node.is_bot)
-            .sort((a, b) => a.node.name.localeCompare(b.node.name)) : [];
+      `}
+      variables={{
+        teamSlug,
+        random,
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          const users = props.team.users ?
+            props.team.users.edges.slice()
+              .filter(u => !u.node.is_bot)
+              .sort((a, b) => a.node.name.localeCompare(b.node.name)) : [];
 
-        return (
-          <MultiSelectFilter
-            label={label}
-            icon={icon}
-            selected={selected}
-            options={extraOptions.concat(users.map(u => ({ label: u.node.name, value: `${u.node.dbid}` })))}
-            onChange={(newValue) => { onChange(newValue); }}
-            readOnly={readOnly}
-            onRemove={onRemove}
-            onToggleOperator={onToggleOperator}
-            operator={operator}
-          />
-        );
-      }
+          return (
+            <MultiSelectFilter
+              label={label}
+              icon={icon}
+              selected={selected}
+              options={extraOptions.concat(users.map(u => ({ label: u.node.name, value: `${u.node.dbid}` })))}
+              onChange={(newValue) => { onChange(newValue); }}
+              readOnly={readOnly}
+              onRemove={onRemove}
+              onToggleOperator={onToggleOperator}
+              operator={operator}
+            />
+          );
+        }
 
-      // TODO: We need a better error handling in the future, standardized with other components
-      return <CircularProgress size={36} />;
-    }}
-  />
-);
+        // TODO: We need a better error handling in the future, standardized with other components
+        return <CircularProgress size={36} />;
+      }}
+    />
+  );
+};
 
 SearchFieldUser.defaultProps = {
   selected: [],

--- a/src/app/components/search/SearchFields/SearchFieldUser.js
+++ b/src/app/components/search/SearchFields/SearchFieldUser.js
@@ -18,6 +18,7 @@ const SearchFieldUser = ({
   onToggleOperator,
   operator,
 }) => {
+  // Keep random argument in state so it's generated only once when component is mounted (CHECK-2366)
   const [random] = React.useState(String(Math.random()));
   return (
     <QueryRenderer

--- a/src/app/components/search/SearchFields/SearchFieldUser.js
+++ b/src/app/components/search/SearchFields/SearchFieldUser.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
@@ -26,11 +25,9 @@ const SearchFieldUser = ({
       query={graphql`
         query SearchFieldUserQuery($teamSlug: String!, $random: String!) {
           team(slug: $teamSlug, random: $random) {
-            id
             users(first: 10000) {
               edges {
                 node {
-                  id
                   dbid
                   name
                   is_bot


### PR DESCRIPTION
This commit is a workaround for the random argument being reset every time the filters are interacted with. Keeping the random value in a state generates it only once when the component is mounted, as opposed to regenerating on each render which would make the QueryRenderer refetch unwantedly.

References CHECK-2366 CHECK-2331

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

