### PR TITLE
A couple fixes for feed subscriptions.

### DIFF
--- a/localization/react-intl/src/app/components/feed/Feed.json
+++ b/localization/react-intl/src/app/components/feed/Feed.json
@@ -7,7 +7,7 @@
   {
     "id": "feed.feed",
     "description": "Tab with label 'Feed' displayed on a feed page. It references content from different workspaces that is shared among them.",
-    "defaultMessage": "Feed"
+    "defaultMessage": "Fact-checks"
   },
   {
     "id": "feed.requests",

--- a/localization/react-intl/src/app/components/feed/ImportDialog.json
+++ b/localization/react-intl/src/app/components/feed/ImportDialog.json
@@ -22,7 +22,7 @@
   {
     "id": "feedItem.importSelectLabel",
     "description": "Select field label used in import claim dialog from feed page.",
-    "defaultMessage": "Select workspace"
+    "defaultMessage": "Import into"
   },
   {
     "id": "feedItem.importTextLabel",

--- a/src/app/components/feed/Feed.js
+++ b/src/app/components/feed/Feed.js
@@ -57,7 +57,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               label={
                 <FormattedMessage
                   id="feed.feed"
-                  defaultMessage="Feed"
+                  defaultMessage="Fact-checks"
                   description="Tab with label 'Feed' displayed on a feed page. It references content from different workspaces that is shared among them."
                 />
               }

--- a/src/app/components/feed/ImportDialog.js
+++ b/src/app/components/feed/ImportDialog.js
@@ -6,6 +6,7 @@ import {
   Box,
   Button,
   FormControl,
+  InputLabel,
   MenuItem,
   Select,
   TextField,
@@ -56,11 +57,12 @@ const ImportButton = ({ onClick, disabled }) => (
 
 const ImportDialog = ({
   teams,
+  currentTeam,
   mediaIds,
   setFlashMessage,
 }) => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [selectedTeamDbid, setSelectedTeamDbid] = React.useState(null);
+  const [selectedTeamDbid, setSelectedTeamDbid] = React.useState(currentTeam);
   const [claimDescription, setClaimDescription] = React.useState(null);
 
   const handleImport = () => {
@@ -125,6 +127,13 @@ const ImportDialog = ({
             </Typography>
             <Box my={3}>
               <FormControl variant="outlined" fullWidth>
+                <InputLabel id="import-to-workspace-label">
+                  <FormattedMessage
+                    id="feedItem.importSelectLabel"
+                    defaultMessage="Import into"
+                    description="Select field label used in import claim dialog from feed page."
+                  />
+                </InputLabel>
                 <Select
                   labelId="import-to-workspace-label"
                   value={selectedTeamDbid}
@@ -132,7 +141,7 @@ const ImportDialog = ({
                   label={
                     <FormattedMessage
                       id="feedItem.importSelectLabel"
-                      defaultMessage="Select workspace"
+                      defaultMessage="Import into"
                       description="Select field label used in import claim dialog from feed page."
                     />
                   }
@@ -183,6 +192,7 @@ const ImportDialogQuery = ({ mediaIds }) => (
     query={graphql`
       query ImportDialogQuery {
         me {
+          current_team_id
           teams(first: 10000) {
             edges {
               node {
@@ -196,7 +206,7 @@ const ImportDialogQuery = ({ mediaIds }) => (
     `}
     render={({ error, props }) => {
       if (!error && props) {
-        return (<ImportDialogWithFlashMessage teams={props.me.teams} mediaIds={mediaIds} />);
+        return (<ImportDialogWithFlashMessage teams={props.me.teams} currentTeam={props.me.current_team_id} mediaIds={mediaIds} />);
       }
       // TODO: We need a better error handling in the future, standardized with other components
       return null;


### PR DESCRIPTION
## Description

* Changing tab label from "Feed" to "Fact-checks"
* On import media dialog, auto-select the current workspace

Fixes CHECK-2254.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested by current unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

