### PR TITLE
Fix MediaPreview to display MediaPlayerCard for UploadedAudio and Upl…

### DIFF
--- a/src/app/components/feed/MediaPreview.js
+++ b/src/app/components/feed/MediaPreview.js
@@ -5,10 +5,13 @@ import AspectRatio from '../layout/AspectRatio';
 
 const MediaPreview = ({ media }) => {
   let preview = null;
-  if (media.url && media.domain === 'youtube.com') {
+  if (
+    media.type === 'UploadedVideo' ||
+    media.type === 'UploadedAudio' ||
+    (media.url && media.domain === 'youtube.com')) {
     preview = (
       <MediaPlayerCard
-        filePath={media.url}
+        filePath={media.file_path || media.url}
       />
     );
   } else if (media.picture) {
@@ -26,10 +29,13 @@ const MediaPreview = ({ media }) => {
   );
 };
 
+export { MediaPreview };
 export default createFragmentContainer(MediaPreview, graphql`
   fragment MediaPreview_media on Media {
+    type
     domain
     picture
     url
+    file_path
   }
 `);

--- a/src/app/components/feed/MediaPreview.test.js
+++ b/src/app/components/feed/MediaPreview.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { MediaPreview } from './MediaPreview';
+import MediaPlayerCard from '../media/MediaPlayerCard';
+import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
+
+describe('<MediaPreview />', () => {
+  it('should display image', () => {
+    const media = { picture: 'foo' };
+    const component = mountWithIntlProvider(<MediaPreview media={media} />);
+    expect(component.find('img').length).toEqual(1);
+  });
+
+  it('should show player for UploadedVideo', () => {
+    const media = {
+      type: 'UploadedVideo',
+      file_path: 'foobar',
+    };
+    const component = mountWithIntlProvider(<MediaPreview media={media} />);
+    expect(component.find(MediaPlayerCard).length).toEqual(1);
+  });
+
+  it('should show player for UploadedAudio', () => {
+    const media = {
+      type: 'UploadedAudio',
+      file_path: 'foobar',
+    };
+    const component = mountWithIntlProvider(<MediaPreview media={media} />);
+    expect(component.find(MediaPlayerCard).length).toEqual(1);
+  });
+
+  it('should show player for Youtube links', () => {
+    const media = {
+      type: 'Link',
+      domain: 'youtube.com',
+      url: 'https://www.youtube.com/watch?v=e_u0PMKAvN1',
+    };
+    const component = mountWithIntlProvider(<MediaPreview media={media} />);
+    expect(component.find(MediaPlayerCard).length).toEqual(1);
+  });
+});

--- a/src/app/components/media/MediaPlayerCard.js
+++ b/src/app/components/media/MediaPlayerCard.js
@@ -41,10 +41,10 @@ const MediaPlayerCard = props => (
 );
 
 MediaPlayerCard.propTypes = {
-  contentWarning: PropTypes.bool.isRequired,
-  warningCreator: PropTypes.string.isRequired,
-  warningCategory: PropTypes.string.isRequired,
-  coverImage: PropTypes.string.isRequired,
+  contentWarning: PropTypes.bool,
+  warningCreator: PropTypes.string,
+  warningCategory: PropTypes.string,
+  coverImage: PropTypes.string,
   filePath: PropTypes.string.isRequired,
   playbackRate: PropTypes.number,
   setPlayerState: PropTypes.func,
@@ -58,6 +58,10 @@ MediaPlayerCard.propTypes = {
 };
 
 MediaPlayerCard.defaultProps = {
+  contentWarning: false,
+  warningCreator: '',
+  warningCategory: '',
+  coverImage: '',
   playbackRate: 1,
   setPlayerState: () => {},
   onPlayerReady: () => {},


### PR DESCRIPTION
…oadedVideo

Also writing an unit test for MediaPreview and removing unnecessary required props from MediaPlayerCard.

Fixes CHECK-2490

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

References: TICKET-ID-1, TICKET-ID-2, …, TICKET-ID-N

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Automated test (add or update automated tests)

## How has this been tested?

Tested locally. Testing steps:
- Create a feed request with uploaded video
- Create a feed request with uploaded audio
- Verify that these medias are displayed with the media player in the media preview dialog on the feed requests ui

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

