### PR TITLE
Display the right number of requests and medias on feed request cluster page

### DIFF
--- a/src/app/components/feed/FeedRequestedMedia.js
+++ b/src/app/components/feed/FeedRequestedMedia.js
@@ -61,7 +61,7 @@ const FeedRequestedMedia = ({ request }) => {
                 id="feedRequestedMedia.numberOfMedias"
                 defaultMessage="{mediasCount, plural, one {# media} other {# medias}}"
                 description="Header of medias list. Example: 3 medias"
-                values={{ mediasCount: request.medias?.edges.length }}
+                values={{ mediasCount: request.medias_count }}
               />
             </strong>
           </Box>
@@ -109,7 +109,8 @@ const FeedRequestedMedia = ({ request }) => {
 export default createFragmentContainer(FeedRequestedMedia, graphql`
   fragment FeedRequestedMedia_request on Request {
     dbid
-    medias(first: 50) {
+    medias_count
+    medias(first: 100) {
       edges {
         node {
           dbid

--- a/src/app/components/feed/RequestCards.js
+++ b/src/app/components/feed/RequestCards.js
@@ -31,7 +31,7 @@ const RequestCards = ({ request, mediaDbid }) => {
   const isParentRequest = request.media.dbid === mediaDbid;
   const classes = useStyles();
 
-  let requestsCount = request.similar_requests?.edges.length;
+  let requestsCount = request.requests_count;
   if (isAllMedias || isParentRequest) { requestsCount += 1; }
 
   const whatsappIcon = (
@@ -149,6 +149,7 @@ const RequestCardsQuery = ({ requestDbid, mediaDbid }) => (
             content
             subscriptions_count
             subscribed
+            requests_count
             last_called_webhook_at
             feed {
               name
@@ -157,7 +158,7 @@ const RequestCardsQuery = ({ requestDbid, mediaDbid }) => (
             media {
               dbid
             }
-            similar_requests(first: 50, media_id: $mediaId) {
+            similar_requests(first: 100, media_id: $mediaId) {
               edges {
                 node {
                   dbid


### PR DESCRIPTION
## Description

Display the right number of requests and medias on feed request cluster page

Fixes CHECK-2491.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

There is a test for that on Check API side.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

