### PR TITLE
Do not show 'Please report this issue to Meedan to help us fix it' me…

### DIFF
--- a/src/app/components/feed/ImportDialog.js
+++ b/src/app/components/feed/ImportDialog.js
@@ -16,7 +16,9 @@ import SystemUpdateAltOutlinedIcon from '@material-ui/icons/SystemUpdateAltOutli
 import { withSetFlashMessage } from '../FlashMessage';
 import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
 import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
-import { getErrorMessageForRelayModernProblem } from '../../helpers';
+import { getErrorMessageForRelayModernProblem, safelyParseJSON } from '../../helpers';
+
+import CheckError from '../../CheckError';
 
 const submitImport = (input, onCompleted, onError) => {
   commitMutation(Relay.Store, {
@@ -79,8 +81,13 @@ const ImportDialog = ({
     };
 
     const onError = (error) => {
-      const errorMessage = getErrorMessageForRelayModernProblem(error) || <GenericUnknownErrorMessage />;
-      setFlashMessage(errorMessage, 'error');
+      const json = safelyParseJSON(error.source);
+      if (json.errors[0].code === CheckError.codes.DUPLICATED) {
+        setFlashMessage(CheckError.messages.DUPLICATED);
+      } else {
+        const errorMessage = getErrorMessageForRelayModernProblem(error) || <GenericUnknownErrorMessage />;
+        setFlashMessage(errorMessage);
+      }
       setDialogOpen(false);
     };
 


### PR DESCRIPTION
…ssage if error is about duplicated importations

## Description

removing report issue option as the duplicated importations message is a notification not a bug to be reported

Reference: CHECK-2509

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

