### PR TITLE
Fixing number of requests displayed on similar item page.

### DIFF
--- a/src/app/components/media/MediaRequests.js
+++ b/src/app/components/media/MediaRequests.js
@@ -75,7 +75,7 @@ class MediaRequestsComponent extends Component {
               id="mediaRequests.thisRequests"
               defaultMessage="{count, plural, one {# request} other {# requests}}"
               values={{
-                count: this.props.media.demand,
+                count: this.props.media.requests_count,
               }}
             />
           }
@@ -130,6 +130,7 @@ const MediaAllRequestsContainer = Relay.createContainer(withStyles(styles)(withP
         archived
         pusher_channel
         demand
+        requests_count
         media {
           file_path
         }
@@ -171,6 +172,7 @@ const MediaOwnRequestsContainer = Relay.createContainer(withStyles(styles)(withP
         archived
         pusher_channel
         demand
+        requests_count
         media {
           file_path
         }


### PR DESCRIPTION
## Description

For a similar item, only the tipline requests to that item (and not to the similar ones) are displayed, so the counter should reflect that.

Fixes CHECK-2503.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Current tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

