### PR TITLE
Fix TypeError: 'Cannot read properties of undefined'

### DIFF
--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -77,7 +77,7 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => {
           </strong>
         </Typography>
       </Box>
-      { sort(projectMedia.confirmed_similar_relationships.edges).map(relationship => (
+      { sort(projectMedia?.confirmed_similar_relationships?.edges).map(relationship => (
         <MediaRelationship
           key={relationship.node.id}
           relationship={relationship.node}
@@ -88,8 +88,8 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => {
           mainProjectMediaId={projectMedia.id}
           mainProjectMediaDemand={projectMedia.demand}
           mainProjectMediaConfirmedSimilarCount={projectMedia.confirmedSimilarCount}
-          relationshipSourceId={relationship.node.source_id}
-          relationshipTargetId={relationship.node.target_id}
+          relationshipSourceId={relationship?.node?.source_id}
+          relationshipTargetId={relationship?.node?.target_id}
         />
       ))}
     </div>


### PR DESCRIPTION
## Description

Add safe navigation to avoid reading properties of undefined
Reference: CHECK-2576

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

