### PR TITLE
Sort feed requests by number of organizations that have a fact-checked it

### DIFF
--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -207,11 +207,13 @@ const FeedRequestsTable = ({
                 </TableSort>
               </TableCell>
               <TableCell align="left" className={classes.tableHeadCell}>
-                <FormattedMessage
-                  id="feedRequestsTable.factCheckBy"
-                  defaultMessage="Fact-check by"
-                  description="Header label for fact-check by column"
-                />
+                <TableSort field="fact_checked_by">
+                  <FormattedMessage
+                    id="feedRequestsTable.factCheckBy"
+                    defaultMessage="Fact-check by"
+                    description="Header label for fact-check by column"
+                  />
+                </TableSort>
               </TableCell>
               <TableCell align="left" className={classes.tableHeadCell}>
                 <TableSort field="medias">


### PR DESCRIPTION
## Description

Sort feed requests by number of organizations that have a fact-checked it.

Reference: CHECK-2500.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Clicking on the "fact-checked by" column in the feed requests table should sort the table accordingly.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

