### PR TITLE
Fix text when hovering page title links on "item" page and on "list" page

### DIFF
--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -46,7 +46,7 @@ class ProjectHeaderComponent extends React.PureComponent {
           <IconButton onClick={() => browserHistory.push(listUrl)} className="project-header__back-button">
             <ArrowBackIcon />
           </IconButton>
-          <HeaderTitle className="project-header__title" style={{ maxWidth: 300 }} title={pageTitle}>
+          <HeaderTitle className="project-header__title" style={{ maxWidth: 300 }} title={pageTitle?.props?.defaultMessage || pageTitle}>
             <Text ellipsis>
               {pageTitle}
             </Text>

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -429,7 +429,7 @@ function SearchResultsComponent({
         <Row className="search__list-header-filter-row">
           <div
             className="project__title"
-            title={title}
+            title={title?.props?.defaultMessage || title}
             style={{
               font: headline,
               color: textSecondary,


### PR DESCRIPTION
## Description
`[object Object]` was being displayed when hovering "All items", "Suggested Media", "Spam" and "Trash" on list page and on "Item" page.
Reference: CHECK-2565

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

