### PR TITLE
On feed requests table, show media type instead of request type.

### DIFF
--- a/localization/react-intl/src/app/components/feed/FeedRequestsTable.json
+++ b/localization/react-intl/src/app/components/feed/FeedRequestsTable.json
@@ -5,6 +5,11 @@
     "defaultMessage": "Text"
   },
   {
+    "id": "feedRequestsTable.mediaTypeLink",
+    "description": "Label for feed request media type",
+    "defaultMessage": "Link"
+  },
+  {
     "id": "feedRequestsTable.mediaTypeImage",
     "description": "Label for feed request media type",
     "defaultMessage": "Image"

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -87,28 +87,35 @@ const FeedRequestsTable = ({
   const classes = useStyles();
 
   const mediaType = requestType => ({
-    text: (
+    Claim: (
       <FormattedMessage
         id="feedRequestsTable.mediaTypeText"
         defaultMessage="Text"
         description="Label for feed request media type"
       />
     ),
-    image: (
+    Link: (
+      <FormattedMessage
+        id="feedRequestsTable.mediaTypeLink"
+        defaultMessage="Link"
+        description="Label for feed request media type"
+      />
+    ),
+    UploadedImage: (
       <FormattedMessage
         id="feedRequestsTable.mediaTypeImage"
         defaultMessage="Image"
         description="Label for feed request media type"
       />
     ),
-    audio: (
+    UploadedAudio: (
       <FormattedMessage
         id="feedRequestsTable.mediaTypeAudio"
         defaultMessage="Audio"
         description="Label for feed request media type"
       />
     ),
-    video: (
+    UploadedVideo: (
       <FormattedMessage
         id="feedRequestsTable.mediaTypeVideo"
         defaultMessage="Video"
@@ -273,7 +280,7 @@ const FeedRequestsTable = ({
                       day="2-digit"
                     />
                   </TableCell>
-                  <TableCell align="left">{mediaType(r.node.request_type)}</TableCell>
+                  <TableCell align="left">{mediaType(r.node.media_type)}</TableCell>
                   <TableCell align="left">{Math.max(0, r.node.requests_count - r.node.subscriptions_count)}</TableCell>
                   <TableCell align="left">{r.node.subscriptions_count}</TableCell>
                   <TableCell align="left">{r.node.project_medias_count}</TableCell>
@@ -343,6 +350,7 @@ const FeedRequestsTableQuery = ({
                       fact_checked_by
                       title
                       request_type
+                      media_type
                       media {
                         metadata
                         quote


### PR DESCRIPTION
## Description

And include the "Link" type as well.

Fixes CHECK-2622.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing tests should take care of this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

