### PR TITLE
Feature/2628 small media card amendments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11679,7 +11679,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14696,7 +14696,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -14922,7 +14922,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/feed/FeedRequestedMedia.js
+++ b/src/app/components/feed/FeedRequestedMedia.js
@@ -76,7 +76,7 @@ const FeedRequestedMedia = ({ request }) => {
             />
             { /* FIXME: Find the optimal way of passing props to MediaCardCondensed for the sake of reusability  */ }
             <MediaCardCondensed
-              title={`${request.request_type}-${request.feed.name.replace(' ', '-')}-${m.node.dbid}`}
+              title={m.node.quote || `${request.request_type}-${request.feed.name.replace(' ', '-')}-${m.node.dbid}`}
               details={[
                 <MediaTypeDisplayName mediaType={m.node.type} />,
                 (<FormattedMessage
@@ -121,6 +121,7 @@ export default createFragmentContainer(FeedRequestedMedia, graphql`
         node {
           dbid
           type
+          quote
           ...MediaCardCondensed_media
         }
       }

--- a/src/app/components/feed/FeedRequestedMedia.js
+++ b/src/app/components/feed/FeedRequestedMedia.js
@@ -106,7 +106,7 @@ const FeedRequestedMedia = ({ request }) => {
   );
 };
 
-
+export { FeedRequestedMedia };
 export default createFragmentContainer(FeedRequestedMedia, graphql`
   fragment FeedRequestedMedia_request on Request {
     dbid

--- a/src/app/components/feed/FeedRequestedMedia.test.js
+++ b/src/app/components/feed/FeedRequestedMedia.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { FeedRequestedMedia } from './FeedRequestedMedia';
+import MediaCardCondensed from './MediaCardCondensed';
+import { shallowWithIntl } from '../../../../test/unit/helpers/intl-test';
+
+describe('<FeedRequestedMedia />', () => {
+  it('should display media quote as title', () => {
+    const request = {
+      dbid: 1,
+      request_type: 'text',
+      feed: {
+        name: 'Test Feed',
+      },
+      medias: {
+        edges: [
+          {
+            node: {
+              dbid: 1,
+              type: 'Claim',
+              quote: 'Hello Text Claim',
+            },
+          },
+        ],
+      },
+    };
+    const component = shallowWithIntl(<FeedRequestedMedia request={request} />);
+    expect(component.find(MediaCardCondensed).props().title).toEqual('Hello Text Claim');
+  });
+
+  it('should display generated slug as title', () => {
+    const request = {
+      dbid: 1,
+      request_type: 'audio',
+      feed: {
+        name: 'Test Feed',
+      },
+      medias: {
+        edges: [
+          {
+            node: {
+              dbid: 1,
+              type: 'UploadedAudio',
+            },
+          },
+        ],
+      },
+    };
+    const component = shallowWithIntl(<FeedRequestedMedia request={request} />);
+    expect(component.find(MediaCardCondensed).props().title).toEqual('audio-Test-Feed-1');
+  });
+});

--- a/src/app/components/feed/FeedRequestedMediaDialog.js
+++ b/src/app/components/feed/FeedRequestedMediaDialog.js
@@ -73,7 +73,7 @@ const FeedRequestedMediaDialog = ({
           <div className={classes.column}>
             <ImportButton onClick={onImport} />
             <MediaCard
-              title={`${request.request_type}-${request.feed.name.replace(' ', '-')}-${media.dbid}`}
+              title={media.quote || `${request.request_type}-${request.feed.name.replace(' ', '-')}-${media.dbid}`}
               details={[
                 <MediaTypeDisplayName mediaType={media.type} />,
                 (
@@ -109,6 +109,7 @@ export default createFragmentContainer(injectIntl(FeedRequestedMediaDialog), gra
   fragment FeedRequestedMediaDialog_media on Media {
     dbid
     type
+    quote
     ...MediaCard_media
   }
 `);

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -253,6 +253,7 @@ const FeedRequestsTable = ({
               } else {
                 requestTitle = r.node.title;
               }
+              const requestPicture = r.node.request_type === 'audio' ? '/images/image_placeholder.svg' : r.node.media?.picture;
 
               // This means a request for the latest fact-checks
               if (r.node.request_type === 'text' && r.node.content === '.') {
@@ -269,7 +270,7 @@ const FeedRequestsTable = ({
                     projectMedia={{
                       title: requestTitle,
                       description: '',
-                      picture: r.node.media?.picture,
+                      picture: requestPicture,
                     }}
                   />
                   <TableCell>

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -410,4 +410,5 @@ FeedRequestsTableQuery.propTypes = {
   searchUrlPrefix: PropTypes.string.isRequired,
 };
 
+export { FeedRequestsTable };
 export default FeedRequestsTableQuery;

--- a/src/app/components/feed/FeedRequestsTable.test.js
+++ b/src/app/components/feed/FeedRequestsTable.test.js
@@ -4,10 +4,6 @@ import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
 
 describe('<FeedRequestsTable />', () => {
   it('UploadedAudio should use default image as thumbnail', () => {
-    const media = {
-      type: 'UploadedAudio',
-      file_path: 'foobar',
-    };
     const feed = {
       requests: {
         edges: [

--- a/src/app/components/feed/FeedRequestsTable.test.js
+++ b/src/app/components/feed/FeedRequestsTable.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { FeedRequestsTable } from './FeedRequestsTable';
+import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
+
+describe('<FeedRequestsTable />', () => {
+  it('UploadedAudio should use default image as thumbnail', () => {
+    const media = {
+      type: 'UploadedAudio',
+      file_path: 'foobar',
+    };
+    const feed = {
+      requests: {
+        edges: [
+          {
+            node: {
+              id: 123,
+              title: 'audio request',
+              request_type: 'audio',
+              last_submitted_at: '2022-10-27T21:16:25.802Z',
+              requests_count: 1,
+              subscriptions_count: 0,
+            },
+          },
+        ],
+      },
+    };
+    const component = mountWithIntlProvider((
+      <FeedRequestsTable
+        tabs={() => {}}
+        feed={feed}
+        searchUrlPrefix="feed"
+        sort=""
+        sortType="asc"
+        onChangeSort={() => {}}
+        onChangeSortType={() => {}}
+        onGoToTheNextPage={() => {}}
+        onGoToThePreviousPage={() => {}}
+        rangeStart={1}
+        rangeEnd={50}
+      />
+    ));
+    expect(component.html()).toMatch('/images/image_placeholder.svg');
+  });
+});

--- a/src/app/components/feed/MediaCardCondensed.js
+++ b/src/app/components/feed/MediaCardCondensed.js
@@ -134,12 +134,13 @@ MediaCardCondensed.propTypes = {
 
 MediaCardCondensed.defaultProps = {
   title: null,
-  details: null,
+  details: [],
   description: null,
   picture: null,
   url: null,
 };
 
+export { MediaCardCondensed };
 export default createFragmentContainer(MediaCardCondensed, graphql`
   fragment MediaCardCondensed_media on Media {
     dbid

--- a/src/app/components/feed/MediaCardCondensed.js
+++ b/src/app/components/feed/MediaCardCondensed.js
@@ -93,12 +93,12 @@ const MediaCardCondensed = ({
     >
       <Box display="flex">
         {
-          media?.picture || picture ?
+          media?.picture || picture || media.type === 'UploadedAudio' ?
             <img
               alt=""
               className={classes.image}
               onError={(e) => { e.target.onerror = null; e.target.src = defaultImage; }}
-              src={media?.picture || picture}
+              src={media?.picture || picture || defaultImage}
             /> : null
         }
         <div className={classes.text}>
@@ -143,6 +143,7 @@ MediaCardCondensed.defaultProps = {
 export default createFragmentContainer(MediaCardCondensed, graphql`
   fragment MediaCardCondensed_media on Media {
     dbid
+    type
     quote
     picture
     url

--- a/src/app/components/feed/MediaCardCondensed.test.js
+++ b/src/app/components/feed/MediaCardCondensed.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MediaCardCondensed } from './MediaCardCondensed';
+import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
+
+describe('<MediaCardCondensed />', () => {
+  it('UploadedAudio should use default image as thumbnail', () => {
+    const media = {
+      type: 'UploadedAudio',
+      file_path: 'foobar',
+    };
+    const component = mountWithIntlProvider((
+      <MediaCardCondensed
+        title="audio-Test-Feed-1"
+        media={media}
+      />
+    ));
+    expect(component.html()).toMatch('/images/image_placeholder.svg');
+  });
+});

--- a/src/app/components/feed/MediaPreview.js
+++ b/src/app/components/feed/MediaPreview.js
@@ -9,9 +9,11 @@ const MediaPreview = ({ media }) => {
     media.type === 'UploadedVideo' ||
     media.type === 'UploadedAudio' ||
     (media.url && media.domain === 'youtube.com')) {
+    const coverImage = media.thumbnail_path || '/images/player_cover.svg';
     preview = (
       <MediaPlayerCard
         filePath={media.file_path || media.url}
+        coverImage={coverImage}
       />
     );
   } else if (media.picture) {
@@ -37,5 +39,6 @@ export default createFragmentContainer(MediaPreview, graphql`
     picture
     url
     file_path
+    thumbnail_path
   }
 `);

--- a/src/app/components/feed/MediaPreview.test.js
+++ b/src/app/components/feed/MediaPreview.test.js
@@ -28,6 +28,15 @@ describe('<MediaPreview />', () => {
     expect(component.find(MediaPlayerCard).length).toEqual(1);
   });
 
+  it('UploadedAudio should use default coverImage', () => {
+    const media = {
+      type: 'UploadedAudio',
+      file_path: 'foobar',
+    };
+    const component = mountWithIntlProvider(<MediaPreview media={media} />);
+    expect(component.html()).toMatch('/images/player_cover.svg');
+  });
+
   it('should show player for Youtube links', () => {
     const media = {
       type: 'Link',


### PR DESCRIPTION
This commit fixes some small media display issues in the feed:
- Show media text instead of generated media slug for text medias
- display audio icon and cover image on the player

References CHECK-2628

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually on local env and written unit tests for it.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

