### PR TITLE
Fix link to "Spam" page in back button

### DIFF
--- a/localization/react-intl/src/app/components/project/ProjectHeader.json
+++ b/localization/react-intl/src/app/components/project/ProjectHeader.json
@@ -4,6 +4,10 @@
     "defaultMessage": "Trash"
   },
   {
+    "id": "projectHeader.Spam",
+    "defaultMessage": "Spam"
+  },
+  {
     "id": "projectHeader.tiplineInbox",
     "defaultMessage": "Tipline inbox"
   },

--- a/src/app/components/project/ProjectHeader.js
+++ b/src/app/components/project/ProjectHeader.js
@@ -24,6 +24,8 @@ class ProjectHeaderComponent extends React.PureComponent {
     let pageTitle;
     if (/\/trash(\/|$)/.test(listUrl)) {
       pageTitle = <FormattedMessage id="projectHeader.trash" defaultMessage="Trash" />;
+    } else if (/\/spam(\/|$)/.test(listUrl)) {
+      pageTitle = <FormattedMessage id="projectHeader.Spam" defaultMessage="Spam" />;
     } else if (/\/tipline-inbox(\/|$)/.test(listUrl)) {
       pageTitle = <FormattedMessage id="projectHeader.tiplineInbox" defaultMessage="Tipline inbox" />;
     } else if (/\/imported-fact-checks(\/|$)/.test(listUrl)) {

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -345,7 +345,7 @@ function SearchResultsComponent({
     const itemIndexInPage = search.medias.edges.findIndex(edge => edge.node === projectMedia);
     const listIndex = getBeginIndex() + itemIndexInPage;
     const urlParams = new URLSearchParams();
-    if (searchUrlPrefix.match('(/trash|/tipline-inbox|/imported-fact-checks|/tipline-inbox|/suggested-matches|(/feed/[0-9]+/(shared|feed)))$')) {
+    if (searchUrlPrefix.match('(/trash|/tipline-inbox|/imported-fact-checks|/tipline-inbox|/suggested-matches|/spam|(/feed/[0-9]+/(shared|feed)))$')) {
       // Usually, `listPath` can be inferred from the route params. With `trash` it can't,
       // so we'll give it to the receiving page. (See <MediaPage>.)
       urlParams.set('listPath', searchUrlPrefix);


### PR DESCRIPTION
## Description
Fix link in back button to redirect user to "Spam" page when on "item" page

Reference: CHECK-2673
## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)


## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

