### PR TITLE
Fix TypeError: Cannot read properties of null (reading 'target')

### DIFF
--- a/localization/react-intl/src/app/components/search/DateRangeFilter.json
+++ b/localization/react-intl/src/app/components/search/DateRangeFilter.json
@@ -15,7 +15,7 @@
   },
   {
     "id": "search.dateSubmittedHeading",
-    "defaultMessage": "Media submitted"
+    "defaultMessage": "Request submitted"
   },
   {
     "id": "search.dateLastSubmittedHeading",

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -182,9 +182,9 @@ const FeedRequestsTable = ({
               showExpand={false}
               cleanupQuery={query => query}
               handleSubmit={(e) => {
-                const newFilters = { ...filters, keyword: e.target['search-input'].value };
+                const newFilters = { ...filters, keyword: e?.target['search-input']?.value };
                 onChangeFilters(newFilters);
-                e.preventDefault();
+                e?.preventDefault();
               }}
               hideAdvanced
             />
@@ -281,7 +281,7 @@ const FeedRequestsTable = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            { feed?.requests?.edges.map((r) => {
+            { feed?.requests?.edges?.map((r) => {
               let requestTitle = '';
               if (r.node.request_type === 'text') {
                 requestTitle = r.node.media?.quote || r.node.media?.metadata?.title;

--- a/src/app/components/search/SearchKeyword.js
+++ b/src/app/components/search/SearchKeyword.js
@@ -156,7 +156,7 @@ class SearchKeyword extends React.Component {
 
   handleInputChange = (ev, textOverride) => {
     const { keyword, ...newQuery } = this.props.query;
-    const newKeyword = ev.target.value || textOverride;
+    const newKeyword = ev?.target?.value || textOverride;
     if (newKeyword) { // empty string => remove property from query
       newQuery.keyword = newKeyword;
       newQuery.sort = 'score';


### PR DESCRIPTION
## Description

Avoid trying to read properties of null
Reference: CHECK-2688

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

