### PR TITLE
remove hard-coded in defining number of fields and fix errbit error

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
@@ -181,7 +181,7 @@ const SmoochBotNewsletterEditor = ({
   const handleChangeBulletPoint = (i, text) => {
     if (!bulletPoints[i] || bulletPoints[i] !== text) {
       const newBulletPoints = bulletPoints.slice();
-      newBulletPoints[i] = text.replaceAll('\n', ' ');
+      newBulletPoints[i] = text?.replace('\n', ' ');
       const newBody = newBulletPoints.join('\n\n');
       onChange('smooch_newsletter_body', newBody);
     }
@@ -189,7 +189,7 @@ const SmoochBotNewsletterEditor = ({
 
   const handleChangeNumberOfBulletPoints = (value) => {
     const newBody = [];
-    [...Array(3).keys()].forEach((i) => {
+    [...Array(value).keys()].forEach((i) => {
       if (i < value) {
         newBody.push(bulletPoints[i]);
       }


### PR DESCRIPTION
## Description

fix number of bullet to save article values by removing hard coded;
fix TypeError: "a.replaceAll is not a function" by using "replace" function instead of "replaceAll" as this method is available in Node versions 15 and up and the current version we are using Node v12.16.1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility

Reference: CHECK-2723

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

