### PR TITLE
Remove archive.is from the list of archiving options

### DIFF
--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -771,7 +771,6 @@ class Annotation extends Component {
 
       // TODO Replace with Pender-supplied names.
       const archivers = {
-        archive_is_response: 'Archive.is',
         archive_org_response: 'Archive.org',
         perma_cc_response: 'Perma.cc',
         video_archiver_response: 'Video Archiver',

--- a/src/app/components/media/MediaExpandedArchives.js
+++ b/src/app/components/media/MediaExpandedArchives.js
@@ -24,7 +24,6 @@ const useStyles = makeStyles({
 
 // TODO Replace with Pender-supplied names.
 const archivers = {
-  archive_is_response: 'Archive.is',
   archive_org_response: 'Archive.org',
   perma_cc_response: 'Perma.cc',
   video_archiver_response: 'Video Archiver',

--- a/src/app/components/media/MediaExpandedArchives.test.js
+++ b/src/app/components/media/MediaExpandedArchives.test.js
@@ -8,7 +8,7 @@ describe('<MediaExpandedArchives />', () => {
       data: {
         fields: [
           {
-            field_name: 'archive_is_response',
+            field_name: 'archive_org_response',
             value_json: {
               location: 'https://example.com/archive',
             },
@@ -23,7 +23,7 @@ describe('<MediaExpandedArchives />', () => {
       projectMedia={projectMedia}
     />);
 
-    expect(wrapper.find('ExternalLink').text()).toBe('Archive.is');
+    expect(wrapper.find('ExternalLink').text()).toBe('Archive.org');
     expect(wrapper.find('ExternalLink').childAt(0).render().attr('href')).toBe('https://example.com/archive');
   });
 });

--- a/src/app/components/team/KeepBot.js
+++ b/src/app/components/team/KeepBot.js
@@ -20,18 +20,6 @@ const KeepBot = ({
       <FormGroup>
         <FormControlLabel
           control={<Checkbox
-            checked={value.archive_archive_is_enabled}
-            onChange={() => handleChange('archive_archive_is_enabled')}
-            name="checkedA"
-          />}
-          label={intl.formatMessage({
-            id: 'keepBot.archiveIs',
-            defaultMessage: 'Enable Archive.is',
-            description: 'Label for a setting that causes a bot to enable the "Archive.is" service (name of a third party provider, should not be localized)',
-          })}
-        />
-        <FormControlLabel
-          control={<Checkbox
             checked={value.archive_archive_org_enabled}
             onChange={() => handleChange('archive_archive_org_enabled')}
             name="checkedB"


### PR DESCRIPTION
## Description

We removed Archive.is as an archiving option in [Oct 2020](https://github.com/meedan/check-api/commit/4b746ed64f356232c15445b3dd89200ab09acb7c), but hadn't yet done clean up and removed it elsewhere in the code bases. This PR removes it from the user interface, since it was still listed as available as an option for install in Keep.

References: [CHECK-2165](https://meedan.atlassian.net/browse/CHECK-2165)

Darius and Alex, I've tagged you both for review because I wasn't sure who would be best to check it.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

For availability of Archive.is as an archiving option, I:
1. Starting up dev server, and [visited integrations](http://localhost:3333/test/settings/integrations) for a workspace in which I'm an admin.
2. I enabled Keep, and clicked the slider to reveal possible options
3. Saw that archive.is was no longer an option

Integration tests running here [in progress]: https://app.travis-ci.com/github/meedan/check-web/builds/258027308

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- Is there anything else I'm missing in removing this archiving function? I mainly identified what to change based on search and replace

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ x I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [x] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

