### PR TITLE
Support Bhojpuri; Display languages as 'english / native (code)' in L…

### DIFF
--- a/localization/react-intl/src/app/components/team/Languages/AddLanguageAction.json
+++ b/localization/react-intl/src/app/components/team/Languages/AddLanguageAction.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": "addLanguageAction.optionLabel",
-    "defaultMessage": "{languageName} ({languageCode})"
-  },
-  {
     "id": "addLanguageAction.newLanguage",
+    "description": "Label for button that adds a new language to list of supported languages",
     "defaultMessage": "New language"
   },
   {
     "id": "addLanguageAction.title",
+    "description": "Title of language picker dialog",
     "defaultMessage": "Choose a new language"
   },
   {
     "id": "addLanguageAction.selectLanguage",
+    "description": "Label to language selection dropdown",
     "defaultMessage": "Select a language"
   },
   {
     "id": "addLanguageAction.addLanguage",
+    "description": "Label to submit button of language picker dialog",
     "defaultMessage": "Add language"
   }
 ]

--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenu.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenu.json
@@ -32,7 +32,7 @@
   {
     "id": "smoochBotMainMenu.alertTitle",
     "description": "Title of an alert box displayed on tipline main menu settings page when there are more than 10 options.",
-    "defaultMessage": "There are {numberOfOptions} including all languages. Detailed language options will be sent to users when they select the option '🌐 Languages'."
+    "defaultMessage": "There are {numberOfOptions} options including all languages. Detailed language options will be sent to users when they select the option 'Languages'."
   },
   {
     "id": "smoochBotMainMenu.languagesAndPrivacy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11679,7 +11679,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -14696,7 +14696,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -14922,7 +14922,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/LanguageRegistry.js
+++ b/src/app/LanguageRegistry.js
@@ -64,6 +64,10 @@ const LanguageRegistry = {
     name: 'Bihari',
     nativeName: 'भोजपुरी',
   },
+  bho: {
+    name: 'Bhojpuri',
+    nativeName: 'भोजपुरी',
+  },
   bi: {
     name: 'Bislama',
     nativeName: 'Bislama',
@@ -785,6 +789,15 @@ const LanguageRegistry = {
 export function languageLabel(code) {
   const language = LanguageRegistry[code];
   return language ? language.nativeName : code;
+}
+
+function languageLabelEnglish(code) {
+  const language = LanguageRegistry[code];
+  return language ? language.name : code;
+}
+
+export function languageLabelFull(code) {
+  return `${languageLabelEnglish(code)} / ${languageLabel(code)} (${code})`;
 }
 
 export function compareLanguages(defaultCode, a, b) {

--- a/src/app/components/team/Languages/AddLanguageAction.js
+++ b/src/app/components/team/Languages/AddLanguageAction.js
@@ -1,7 +1,6 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { commitMutation, createFragmentContainer, graphql } from 'react-relay/compat';
 import { Store } from 'react-relay/classic';
 import Button from '@material-ui/core/Button';
@@ -16,14 +15,7 @@ import { FormattedGlobalMessage } from '../../MappedMessage';
 import { FlashMessageSetterContext } from '../../FlashMessage';
 import GenericUnknownErrorMessage from '../../GenericUnknownErrorMessage';
 import { safelyParseJSON, getErrorMessageForRelayModernProblem } from '../../../helpers';
-import LanguageRegistry, { compareLanguages, languageLabel } from '../../../LanguageRegistry';
-
-const messages = defineMessages({
-  optionLabel: {
-    id: 'addLanguageAction.optionLabel',
-    defaultMessage: '{languageName} ({languageCode})',
-  },
-});
+import LanguageRegistry, { compareLanguages, languageLabelFull } from '../../../LanguageRegistry';
 
 function submitAddLanguage({
   team,
@@ -60,7 +52,7 @@ function submitAddLanguage({
 }
 
 // FIXME rewrite using LanguagePickerDialog
-const AddLanguageAction = ({ team, intl }) => {
+const AddLanguageAction = ({ team }) => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
   const [value, setValue] = React.useState(null);
@@ -70,12 +62,7 @@ const AddLanguageAction = ({ team, intl }) => {
   const options = Object.keys(LanguageRegistry)
     .filter(code => !languages.includes(code))
     .sort((a, b) => compareLanguages(null, a, b));
-  const getOptionLabel =
-    code => intl.formatMessage(messages.optionLabel, {
-      // FIXME Another helper for english label
-      languageName: `${LanguageRegistry[code].name} / ${languageLabel(code)}`,
-      languageCode: code,
-    });
+  const getOptionLabel = code => languageLabelFull(code);
 
   const handleChange = (e, val) => {
     setValue(val);
@@ -113,6 +100,7 @@ const AddLanguageAction = ({ team, intl }) => {
         <FormattedMessage
           id="addLanguageAction.newLanguage"
           defaultMessage="New language"
+          description="Label for button that adds a new language to list of supported languages"
         />
       </Button>
       <Dialog
@@ -121,7 +109,11 @@ const AddLanguageAction = ({ team, intl }) => {
         fullWidth
       >
         <DialogTitle>
-          <FormattedMessage id="addLanguageAction.title" defaultMessage="Choose a new language" />
+          <FormattedMessage
+            id="addLanguageAction.title"
+            defaultMessage="Choose a new language"
+            description="Title of language picker dialog"
+          />
         </DialogTitle>
         <DialogContent>
           <Autocomplete
@@ -133,10 +125,12 @@ const AddLanguageAction = ({ team, intl }) => {
             value={value}
             renderInput={
               params => (<TextField
+                variant="outlined"
                 label={
                   <FormattedMessage
                     id="addLanguageAction.selectLanguage"
                     defaultMessage="Select a language"
+                    description="Label to language selection dropdown"
                   />
                 }
                 {...params}
@@ -158,7 +152,11 @@ const AddLanguageAction = ({ team, intl }) => {
             onClick={handleSubmit}
             variant="contained"
           >
-            <FormattedMessage id="addLanguageAction.addLanguage" defaultMessage="Add language" />
+            <FormattedMessage
+              id="addLanguageAction.addLanguage"
+              defaultMessage="Add language"
+              description="Label to submit button of language picker dialog"
+            />
           </Button>
         </DialogActions>
       </Dialog>
@@ -171,10 +169,9 @@ AddLanguageAction.propTypes = {
     id: PropTypes.string.isRequired,
     get_languages: PropTypes.string.isRequired,
   }).isRequired,
-  intl: intlShape.isRequired,
 };
 
-export default createFragmentContainer(injectIntl(AddLanguageAction), graphql`
+export default createFragmentContainer(AddLanguageAction, graphql`
   fragment AddLanguageAction_team on Team {
     id
     get_languages

--- a/src/app/components/team/Languages/LanguageListItem.js
+++ b/src/app/components/team/Languages/LanguageListItem.js
@@ -17,7 +17,7 @@ import { FormattedGlobalMessage } from '../../MappedMessage';
 import { FlashMessageSetterContext } from '../../FlashMessage';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 import { safelyParseJSON, getErrorMessageForRelayModernProblem } from '../../../helpers';
-import { languageLabel } from '../../../LanguageRegistry';
+import { languageLabelFull } from '../../../LanguageRegistry';
 
 const messages = defineMessages({
   deleteConfirmationText: {
@@ -182,7 +182,7 @@ const LanguageListItem = ({ code, team, intl }) => {
 
   const listItemText = (
     <Typography variant="h6" component="span">
-      { languageLabel(code) }
+      { languageLabelFull(code) }
     </Typography>
   );
 
@@ -226,14 +226,14 @@ const LanguageListItem = ({ code, team, intl }) => {
                 <FormattedMessage
                   id="statusListItem.translationNeededBody1"
                   defaultMessage="Not all statuses are currently translated into {language}!"
-                  values={{ language: <strong>{languageLabel(code)}</strong> }}
+                  values={{ language: <strong>{languageLabelFull(code)}</strong> }}
                 />
               </Typography>
               <Typography variant="body1" component="p" paragraph>
                 <FormattedMessage
                   id="statusListItem.translationNeededBody2"
                   defaultMessage="Before you can make {language} the default language you must first translate all existing statuses into {language} in the Statuses settings tab."
-                  values={{ language: <strong>{languageLabel(code)}</strong> }}
+                  values={{ language: <strong>{languageLabelFull(code)}</strong> }}
                 />
               </Typography>
             </div>
@@ -245,7 +245,7 @@ const LanguageListItem = ({ code, team, intl }) => {
             <FormattedMessage
               id="statusListItem.translationNeededTitle"
               defaultMessage="You need to translate all statuses into {language}"
-              values={{ language: languageLabel(code) }}
+              values={{ language: languageLabelFull(code) }}
             />
           }
         />
@@ -258,8 +258,8 @@ const LanguageListItem = ({ code, team, intl }) => {
                   id="statusListItem.confirmDefaultBody1"
                   defaultMessage="This will change the default language from {currentDefaultLanguage} to {newDefaultLanguage}."
                   values={{
-                    currentDefaultLanguage: <strong>{languageLabel(defaultLanguage)}</strong>,
-                    newDefaultLanguage: <strong>{languageLabel(code)}</strong>,
+                    currentDefaultLanguage: <strong>{languageLabelFull(defaultLanguage)}</strong>,
+                    newDefaultLanguage: <strong>{languageLabelFull(code)}</strong>,
                   }}
                 />
               </Typography>
@@ -267,7 +267,7 @@ const LanguageListItem = ({ code, team, intl }) => {
                 <FormattedMessage
                   id="statusListItem.confirmDefaultBody2"
                   defaultMessage="{language} will become the default language to respond to users in the Tipline bot, Status or Report if they interact with the bot in any language not on this list, or if there is not a translation available for that language."
-                  values={{ language: <strong>{languageLabel(code)}</strong> }}
+                  values={{ language: <strong>{languageLabelFull(code)}</strong> }}
                 />
               </Typography>
             </div>
@@ -280,14 +280,14 @@ const LanguageListItem = ({ code, team, intl }) => {
             <FormattedMessage
               id="statusListItem.confirmDefaultButton"
               defaultMessage="Set {language} as default"
-              values={{ language: languageLabel(code) }}
+              values={{ language: languageLabelFull(code) }}
             />
           }
           title={
             <FormattedMessage
               id="statusListItem.confirmDefaultTitle"
               defaultMessage="Do you want to set the default language to {language}?"
-              values={{ language: languageLabel(code) }}
+              values={{ language: languageLabelFull(code) }}
             />
           }
         />
@@ -301,19 +301,19 @@ const LanguageListItem = ({ code, team, intl }) => {
                 id="statusListItem.confirmDeleteBody1"
                 defaultMessage="All content in {language} for the 'Tipline', 'Statuses' and 'Report' tabs will be deleted permanently."
                 description="Warning about content being lost after deleting a language"
-                values={{ language: languageLabel(code) }}
+                values={{ language: languageLabelFull(code) }}
               />
             </Typography>
             <Typography variant="body1" component="p" paragraph>
               <FormattedMessage
                 id="statusListItem.confirmDeleteBody2"
                 defaultMessage="Users will receive this content in the default language {language} instead."
-                values={{ language: <strong>{languageLabel(defaultLanguage)}</strong> }}
+                values={{ language: <strong>{languageLabelFull(defaultLanguage)}</strong> }}
               />
             </Typography>
           </div>
         )}
-        typeTextToConfirm={intl.formatMessage(messages.deleteConfirmationText, { language: languageLabel(code) })}
+        typeTextToConfirm={intl.formatMessage(messages.deleteConfirmationText, { language: languageLabelFull(code) })}
         isSaving={isSaving}
         onCancel={() => setDeleteDialogOpen(false)}
         onProceed={submitDelete}
@@ -329,7 +329,7 @@ const LanguageListItem = ({ code, team, intl }) => {
                 id="statusListItem.confirmDeleteDefaultBody"
                 defaultMessage="You cannot delete the default language. You must set a different default language before you can delete {language}."
                 description="Message warning user to set a new default language before deleting the current one"
-                values={{ language: <strong>{languageLabel(defaultLanguage)}</strong> }}
+                values={{ language: <strong>{languageLabelFull(defaultLanguage)}</strong> }}
               />
             </Typography>
           </div>


### PR DESCRIPTION
…anguages settings

## Description

Support Bhojpuri language and display language names in "english / native (code" format on language settings page

References: CHECK-2624

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [x] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

