### PR TITLE
Refactoring tipline timeout settings UI

### DIFF
--- a/localization/react-intl/src/app/components/cds/settings-pages/TiplineContentTranslation.json
+++ b/localization/react-intl/src/app/components/cds/settings-pages/TiplineContentTranslation.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "smoochBotContentAndTranslation.placeholder",
+    "description": "Placeholder used in all fields under tipline content and translation settings.",
+    "defaultMessage": "Type custom content or translation here."
+  }
+]

--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotComponent.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotComponent.json
@@ -28,7 +28,7 @@
   {
     "id": "smoochBotComponent.missingInformationBody",
     "description": "Content of dialog that opens when there is a validation error on tipline settings",
-    "defaultMessage": "The step '11. Newsletter opt-in and opt-out' is missing a placeholder."
+    "defaultMessage": "The message 'Newsletter opt-in and opt-out' is missing a placeholder."
   },
   {
     "id": "smoochBotComponent.back",

--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotContentAndTranslation.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotContentAndTranslation.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": "smoochBotContentAndTranslation.placeholder",
-    "description": "Placeholder used in all fields under tipline content and translation settings.",
-    "defaultMessage": "Type custom content or translation here."
-  },
-  {
     "id": "smoochBotContentAndTranslation.greetingsTitle",
     "description": "Title of a customizable string of the tipline bot.",
     "defaultMessage": "Greetings"
@@ -22,47 +17,17 @@
   {
     "id": "smoochBotContentAndTranslation.submissionPromptTitle",
     "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Submission prompt"
+    "defaultMessage": "Content prompt"
   },
   {
     "id": "smoochBotContentAndTranslation.submissionPromptDescription",
     "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "The message asking the user to submit content for a fact-check."
+    "defaultMessage": "This message prompts the user to submit content for a fact-check."
   },
   {
     "id": "smoochBotContentAndTranslation.submissionPromptDefault",
     "description": "Default value for a customizable string of the tipline bot.",
     "defaultMessage": "Please enter the question, link, picture, or video that you want to be fact-checked."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.submissionCanceledTitle",
-    "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Submission canceled"
-  },
-  {
-    "id": "smoochBotContentAndTranslation.submissionCanceledDescription",
-    "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "This message is sent when user cancels the submission of content."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.submissionCanceledDefault",
-    "description": "Default value for a customizable string of the tipline bot.",
-    "defaultMessage": "OK! Your submission is canceled."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.addMoreInformationTitle",
-    "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Submit content"
-  },
-  {
-    "id": "smoochBotContentAndTranslation.addMoreInformationDescription",
-    "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "This message is sent to user after they send content, to make sure all the information they want to submit has been provided."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.addMoreInformationDefault",
-    "description": "Default value for a customizable string of the tipline bot.",
-    "defaultMessage": "Are you ready to submit?"
   },
   {
     "id": "smoochBotContentAndTranslation.moreContentPromptTitle",
@@ -80,6 +45,21 @@
     "defaultMessage": "Please add more content."
   },
   {
+    "id": "smoochBotContentAndTranslation.addMoreInformationTitle",
+    "description": "Title of a customizable string of the tipline bot.",
+    "defaultMessage": "Submission prompt"
+  },
+  {
+    "id": "smoochBotContentAndTranslation.addMoreInformationDescription",
+    "description": "Description of a customizable string of the tipline bot.",
+    "defaultMessage": "This message is sent to user after they send content, to make sure all the information they want to submit has been provided."
+  },
+  {
+    "id": "smoochBotContentAndTranslation.addMoreInformationDefault",
+    "description": "Default value for a customizable string of the tipline bot.",
+    "defaultMessage": "Are you ready to submit?"
+  },
+  {
     "id": "smoochBotContentAndTranslation.submissionReceivedTitle",
     "description": "Title of a customizable string of the tipline bot.",
     "defaultMessage": "Submission received"
@@ -87,12 +67,12 @@
   {
     "id": "smoochBotContentAndTranslation.submissionReceivedDescription",
     "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "The confirmation sent to the user after a valid query from the user has been received, while the bot is retrieving content."
+    "defaultMessage": "The confirmation sent to the user after the content is submitted."
   },
   {
     "id": "smoochBotContentAndTranslation.submissionReceivedDefault",
     "description": "Default value for a customizable string of the tipline bot.",
-    "defaultMessage": "Thank you! Looking for fact-checks, it may take a minute."
+    "defaultMessage": "No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked."
   },
   {
     "id": "smoochBotContentAndTranslation.noSearchResultTitle",
@@ -112,32 +92,17 @@
   {
     "id": "smoochBotContentAndTranslation.feedbackTitle",
     "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Feedback"
+    "defaultMessage": "Feedback prompt"
   },
   {
     "id": "smoochBotContentAndTranslation.feedbackDescription",
     "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "When fact-checks are returned to the user, the bot automatically follows up to ask if the results are satisfactory."
+    "defaultMessage": "After fact-checks are returned to the user, the bot automatically follows up to ask if the results are satisfactory."
   },
   {
     "id": "smoochBotContentAndTranslation.feedbackDefault",
     "description": "Default value for a customizable string of the tipline bot.",
     "defaultMessage": "Are these fact-checks answering your question?"
-  },
-  {
-    "id": "smoochBotContentAndTranslation.negativeFeedbackTitle",
-    "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Negative feedback"
-  },
-  {
-    "id": "smoochBotContentAndTranslation.negativeFeedbackDescription",
-    "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "If the user is not satisfied, this message informs the user that the content has been sent to journalists."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.negativeFeedbackDefault",
-    "description": "Default value for a customizable string of the tipline bot.",
-    "defaultMessage": "Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published."
   },
   {
     "id": "smoochBotContentAndTranslation.positiveFeedbackTitle",
@@ -153,6 +118,21 @@
     "id": "smoochBotContentAndTranslation.positiveFeedbackDefault",
     "description": "Default value for a customizable string of the tipline bot.",
     "defaultMessage": "Thank you! Spread the word about this tipline to help us fight misinformation! *insert_entry_point_link*"
+  },
+  {
+    "id": "smoochBotContentAndTranslation.negativeFeedbackTitle",
+    "description": "Title of a customizable string of the tipline bot.",
+    "defaultMessage": "Negative feedback"
+  },
+  {
+    "id": "smoochBotContentAndTranslation.negativeFeedbackDescription",
+    "description": "Description of a customizable string of the tipline bot.",
+    "defaultMessage": "If the user is not satisfied, this message informs the user that the content has been sent to journalists."
+  },
+  {
+    "id": "smoochBotContentAndTranslation.negativeFeedbackDefault",
+    "description": "Default value for a customizable string of the tipline bot.",
+    "defaultMessage": "Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published."
   },
   {
     "id": "smoochBotContentAndTranslation.newsletterTitle",
@@ -177,7 +157,7 @@
   {
     "id": "smoochBotContentAndTranslation.optionNotAvailableDescription",
     "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "The message sent if the user response to a menu is not a valid menu scenario."
+    "defaultMessage": "The message sent if the user response is not a valid option."
   },
   {
     "id": "smoochBotContentAndTranslation.optionNotAvailableDefault",
@@ -185,24 +165,34 @@
     "defaultMessage": "I'm sorry, I didn't understand your message."
   },
   {
+    "id": "smoochBotContentAndTranslation.timeoutTitle",
+    "description": "Title of a customizable string of the tipline bot.",
+    "defaultMessage": "Conversation time out"
+  },
+  {
+    "id": "smoochBotContentAndTranslation.timeoutDescription",
+    "description": "Description of a customizable string of the tipline bot.",
+    "defaultMessage": "After 15 minutes of activity, this message is sent to users to close the conversation."
+  },
+  {
+    "id": "smoochBotContentAndTranslation.timeoutDefault",
+    "description": "Default value for a customizable string of the tipline bot.",
+    "defaultMessage": "Thank you for reaching out to us! Type any key to start a new conversation."
+  },
+  {
     "id": "smoochBotContentAndTranslation.noticeOfInactivityTitle",
     "description": "Title of a customizable string of the tipline bot.",
-    "defaultMessage": "Notice of inactivity"
+    "defaultMessage": "Inactive bot"
   },
   {
     "id": "smoochBotContentAndTranslation.noticeOfInactivityDescription",
     "description": "Description of a customizable string of the tipline bot.",
-    "defaultMessage": "This message is sent to any user that has sent a message to the tipline when the Check Message bot is set to inactive."
+    "defaultMessage": "If the tipline is set to inactive, this message is sent in response to any user message."
   },
   {
     "id": "smoochBotContentAndTranslation.noticeOfInactivityDefault",
     "description": "Default value for a customizable string of the tipline bot.",
     "defaultMessage": "Our bot is currently inactive. Please visit *insert URL* to read the latest fact-checks."
-  },
-  {
-    "id": "smoochBotContentAndTranslation.subtitle",
-    "description": "Subtitle displayed in tipline settings page for content and translation.",
-    "defaultMessage": "Replace or translate the default content for each standard bot message."
   },
   {
     "id": "smoochBotContentAndTranslation.error",

--- a/localization/react-intl/src/app/components/team/SmoochBot/localizables.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/localizables.json
@@ -28,10 +28,6 @@
     "defaultMessage": "Newsletter"
   },
   {
-    "id": "smoochBot.labelNoAction",
-    "defaultMessage": "No action from user"
-  },
-  {
     "id": "smoochBot.labelOptionNotAvailable",
     "defaultMessage": "Option not available"
   },
@@ -54,11 +50,11 @@
   {
     "id": "smoochBot.labelContent",
     "description": "Button label in tipline settings page",
-    "defaultMessage": "Content and translation"
+    "defaultMessage": "Content & translation"
   },
   {
     "id": "smoochBot.labelNewsletterV2",
-    "defaultMessage": "Newsletter content"
+    "defaultMessage": "Newsletter"
   },
   {
     "id": "smoochBot.descriptionGreeting",
@@ -95,10 +91,6 @@
   {
     "id": "smoochBot.descriptionNewsletter3",
     "defaultMessage": "2. Select a day and time of the week"
-  },
-  {
-    "id": "smoochBot.descriptionNoAction",
-    "defaultMessage": "This message will be sent to users if, after a conversation is initiated, they do not select either option: receive a resource or submit content to verify. This message will also be sent to users who submitted content without waiting for the query prompt."
   },
   {
     "id": "smoochBot.descriptionOptionNotAvailable",

--- a/src/app/components/cds/settings-pages/TiplineContentTranslation.js
+++ b/src/app/components/cds/settings-pages/TiplineContentTranslation.js
@@ -1,0 +1,166 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import { injectIntl, intlShape, defineMessages } from 'react-intl';
+import {
+  Box,
+  Typography,
+  TextField,
+} from '@material-ui/core';
+import {
+  brandBackgroundCDS,
+  grayBorderCDS,
+  textPrimary,
+  textSecondary,
+  otherErrorMainCDS,
+} from '../../../styles/js/shared';
+
+const StyledTextField = withStyles({
+  root: {
+    '& .MuiOutlinedInput-input::placeholder': {
+      color: textSecondary,
+      opacity: 1,
+    },
+    '& .MuiFormHelperText-root.Mui-error': {
+      color: otherErrorMainCDS,
+      marginLeft: 0,
+      fontSize: 12,
+      fontWeight: 400,
+    },
+    '& .MuiOutlinedInput-root': {
+      '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+        borderColor: otherErrorMainCDS,
+      },
+      '& fieldset': {
+        borderColor: grayBorderCDS,
+        borderWidth: 1,
+      },
+      '&:hover fieldset': {
+        borderColor: grayBorderCDS,
+        borderWidth: 1,
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: grayBorderCDS,
+        borderWidth: 1,
+      },
+    },
+  },
+})(TextField);
+
+const useStyles = makeStyles(theme => ({
+  // FIXME: Once Typography is implemented according to specs from the design system, this custom style can be removed
+  title: {
+    fontWeight: 600,
+    fontSize: 14,
+  },
+  // FIXME: Once Typography is implemented according to specs from the design system, this custom style can be removed
+  description: {
+    fontWeight: 400,
+    fontSize: 12,
+  },
+  defaultString: {
+    borderTopLeftRadius: theme.spacing(1),
+    borderTopRightRadius: theme.spacing(1),
+    border: `1px solid ${grayBorderCDS}`,
+    borderBottom: 0,
+    background: brandBackgroundCDS,
+    padding: '12px 10px',
+  },
+  // FIXME: Once Typography is implemented according to specs from the design system, this custom style can be removed
+  default: {
+    fontWeight: 400,
+    fontSize: 14,
+  },
+  customString: {
+    borderTop: 0,
+    outline: 0,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    fontSize: 14,
+    fontWeight: 400,
+    color: textPrimary,
+  },
+}));
+
+const messages = defineMessages({
+  placeholder: {
+    id: 'smoochBotContentAndTranslation.placeholder',
+    defaultMessage: 'Type custom content or translation here.',
+    description: 'Placeholder used in all fields under tipline content and translation settings.',
+  },
+});
+
+const TiplineContentTranslation = ({
+  intl,
+  identifier,
+  title,
+  description,
+  defaultValue,
+  onUpdate,
+  value,
+  error,
+  extra,
+}) => {
+  const classes = useStyles();
+  return (
+    <Box>
+
+      {/* Text and description about this field */}
+      <Typography variant="body1" className={classes.title}>
+        {title}
+      </Typography>
+      <Typography variant="body2" className={classes.description}>
+        {description}
+      </Typography>
+
+      <Box mt={1}>
+
+        {/* Default value */}
+        <Box p={1} className={classes.defaultString}>
+          <Typography variant="body1" className={classes.default}>
+            {defaultValue}
+          </Typography>
+        </Box>
+
+        {/* Text field for custom value */}
+        <StyledTextField
+          key={identifier}
+          InputProps={{ className: classes.customString }}
+          variant="outlined"
+          placeholder={intl.formatMessage(messages.placeholder)}
+          rowsMax={Infinity}
+          rows={1}
+          defaultValue={value}
+          onBlur={(e) => { onUpdate(e.target.value); }}
+          error={Boolean(error)}
+          helperText={error}
+          multiline
+          fullWidth
+        />
+
+        {extra}
+
+      </Box>
+    </Box>
+  );
+};
+
+TiplineContentTranslation.defaultProps = {
+  value: null, // Custom value
+  error: null,
+  extra: null,
+};
+
+TiplineContentTranslation.propTypes = {
+  intl: intlShape.isRequired,
+  identifier: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
+  description: PropTypes.node.isRequired,
+  defaultValue: PropTypes.node.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  value: PropTypes.string,
+  error: PropTypes.node,
+  extra: PropTypes.node,
+};
+
+export default injectIntl(TiplineContentTranslation);

--- a/src/app/components/cds/settings-pages/TiplineContentTranslation.test.js
+++ b/src/app/components/cds/settings-pages/TiplineContentTranslation.test.js
@@ -9,7 +9,7 @@ describe('<TiplineContentTranslation />', () => {
       title={<span>Foo</span>}
       description={<span>Bar</span>}
       defaultValue="Test"
-      onUpdate={(newValue) => {}}
+      onUpdate={() => {}}
     />);
     expect(wrapper.find('textarea').hostNodes()).toHaveLength(2);
   });

--- a/src/app/components/cds/settings-pages/TiplineContentTranslation.test.js
+++ b/src/app/components/cds/settings-pages/TiplineContentTranslation.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import TiplineContentTranslation from './TiplineContentTranslation';
+
+describe('<TiplineContentTranslation />', () => {
+  it('should render TiplineContentTranslation component', () => {
+    const wrapper = mountWithIntl(<TiplineContentTranslation
+      identifier="test"
+      title={<span>Foo</span>}
+      description={<span>Bar</span>}
+      defaultValue="Test"
+      onUpdate={(newValue) => {}}
+    />);
+    expect(wrapper.find('textarea').hostNodes()).toHaveLength(2);
+  });
+});

--- a/src/app/components/team/SmoochBot/SmoochBotComponent.js
+++ b/src/app/components/team/SmoochBot/SmoochBotComponent.js
@@ -218,7 +218,7 @@ const SmoochBotComponent = ({
         body={(
           <FormattedMessage
             id="smoochBotComponent.missingInformationBody"
-            defaultMessage="The step '11. Newsletter opt-in and opt-out' is missing a placeholder."
+            defaultMessage="The message 'Newsletter opt-in and opt-out' is missing a placeholder."
             description="Content of dialog that opens when there is a validation error on tipline settings"
           />
         )}

--- a/src/app/components/team/SmoochBot/SmoochBotContentAndTranslation.js
+++ b/src/app/components/team/SmoochBot/SmoochBotContentAndTranslation.js
@@ -1,52 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
-import { injectIntl, intlShape, defineMessages, FormattedMessage } from 'react-intl';
-import TextField from '@material-ui/core/TextField';
-import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import { FormattedMessage } from 'react-intl';
+import TiplineContentTranslation from '../../cds/settings-pages/TiplineContentTranslation';
 import UploadFile from '../../UploadFile';
-import { labelsV2 } from './localizables';
-import { opaqueBlack23 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
-  defaultString: {
-    borderTopLeftRadius: theme.spacing(0.5),
-    borderTopRightRadius: theme.spacing(0.5),
-    border: `1px solid ${opaqueBlack23}`,
-    borderBottom: 0,
-    background: '#F6F6F6',
-  },
-  customString: {
-    borderTop: 0,
-    outline: 0,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    fontSize: '0.875rem',
-  },
-  error: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    display: 'flex',
-    alignItems: 'center',
+  container: {
+    overflow: 'auto',
+    paddingRight: theme.spacing(2),
+    maxHeight: 'calc(100vh - 310px)',
   },
 }));
-
-const messages = defineMessages({
-  placeholder: {
-    id: 'smoochBotContentAndTranslation.placeholder',
-    defaultMessage: 'Type custom content or translation here.',
-    description: 'Placeholder used in all fields under tipline content and translation settings.',
-  },
-});
 
 const SmoochBotContentAndTranslation = ({
   value,
   onChangeMessage,
   onChangeStateMessage,
   onChangeImage,
-  intl,
 }) => {
   const classes = useStyles();
 
@@ -69,21 +41,9 @@ const SmoochBotContentAndTranslation = ({
     {
       key: 'submission_prompt',
       state: 'query',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.submissionPromptTitle" defaultMessage="Submission prompt" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.submissionPromptDescription" defaultMessage="The message asking the user to submit content for a fact-check." description="Description of a customizable string of the tipline bot." />,
+      title: <FormattedMessage id="smoochBotContentAndTranslation.submissionPromptTitle" defaultMessage="Content prompt" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.submissionPromptDescription" defaultMessage="This message prompts the user to submit content for a fact-check." description="Description of a customizable string of the tipline bot." />,
       default: <FormattedMessage id="smoochBotContentAndTranslation.submissionPromptDefault" defaultMessage="Please enter the question, link, picture, or video that you want to be fact-checked." description="Default value for a customizable string of the tipline bot." />,
-    },
-    {
-      key: 'cancelled',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.submissionCanceledTitle" defaultMessage="Submission canceled" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.submissionCanceledDescription" defaultMessage="This message is sent when user cancels the submission of content." description="Description of a customizable string of the tipline bot." />,
-      default: <FormattedMessage id="smoochBotContentAndTranslation.submissionCanceledDefault" defaultMessage="OK! Your submission is canceled." description="Default value for a customizable string of the tipline bot." />,
-    },
-    {
-      key: 'ask_if_ready_state',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationTitle" defaultMessage="Submit content" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationDescription" defaultMessage="This message is sent to user after they send content, to make sure all the information they want to submit has been provided." description="Description of a customizable string of the tipline bot." />,
-      default: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationDefault" defaultMessage="Are you ready to submit?" description="Default value for a customizable string of the tipline bot." />,
     },
     {
       key: 'add_more_details_state',
@@ -92,10 +52,16 @@ const SmoochBotContentAndTranslation = ({
       default: <FormattedMessage id="smoochBotContentAndTranslation.moreContentPromptDefault" defaultMessage="Please add more content." description="Default value for a customizable string of the tipline bot." />,
     },
     {
+      key: 'ask_if_ready_state',
+      title: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationTitle" defaultMessage="Submission prompt" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationDescription" defaultMessage="This message is sent to user after they send content, to make sure all the information they want to submit has been provided." description="Description of a customizable string of the tipline bot." />,
+      default: <FormattedMessage id="smoochBotContentAndTranslation.addMoreInformationDefault" defaultMessage="Are you ready to submit?" description="Default value for a customizable string of the tipline bot." />,
+    },
+    {
       key: 'search_state',
       title: <FormattedMessage id="smoochBotContentAndTranslation.submissionReceivedTitle" defaultMessage="Submission received" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.submissionReceivedDescription" defaultMessage="The confirmation sent to the user after a valid query from the user has been received, while the bot is retrieving content." description="Description of a customizable string of the tipline bot." />,
-      default: <FormattedMessage id="smoochBotContentAndTranslation.submissionReceivedDefault" defaultMessage="Thank you! Looking for fact-checks, it may take a minute." description="Default value for a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.submissionReceivedDescription" defaultMessage="The confirmation sent to the user after the content is submitted." description="Description of a customizable string of the tipline bot." />,
+      default: <FormattedMessage id="smoochBotContentAndTranslation.submissionReceivedDefault" defaultMessage="No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked." description="Default value for a customizable string of the tipline bot." />,
     },
     {
       key: 'search_no_results',
@@ -105,21 +71,21 @@ const SmoochBotContentAndTranslation = ({
     },
     {
       key: 'search_result_state',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.feedbackTitle" defaultMessage="Feedback" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.feedbackDescription" defaultMessage="When fact-checks are returned to the user, the bot automatically follows up to ask if the results are satisfactory." description="Description of a customizable string of the tipline bot." />,
+      title: <FormattedMessage id="smoochBotContentAndTranslation.feedbackTitle" defaultMessage="Feedback prompt" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.feedbackDescription" defaultMessage="After fact-checks are returned to the user, the bot automatically follows up to ask if the results are satisfactory." description="Description of a customizable string of the tipline bot." />,
       default: <FormattedMessage id="smoochBotContentAndTranslation.feedbackDefault" defaultMessage="Are these fact-checks answering your question?" description="Default value for a customizable string of the tipline bot." />,
-    },
-    {
-      key: 'search_submit',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackTitle" defaultMessage="Negative feedback" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackDescription" defaultMessage="If the user is not satisfied, this message informs the user that the content has been sent to journalists." description="Description of a customizable string of the tipline bot." />,
-      default: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackDefault" defaultMessage="Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published." description="Default value for a customizable string of the tipline bot." />,
     },
     {
       key: 'search_result_is_relevant',
       title: <FormattedMessage id="smoochBotContentAndTranslation.positiveFeedbackTitle" defaultMessage="Positive feedback" description="Title of a customizable string of the tipline bot." />,
       description: <FormattedMessage id="smoochBotContentAndTranslation.positiveFeedbackDescription" defaultMessage="If the user is satisfied, this message's purpose is to thank them for their feedback." description="Description of a customizable string of the tipline bot." />,
       default: <FormattedMessage id="smoochBotContentAndTranslation.positiveFeedbackDefault" defaultMessage="Thank you! Spread the word about this tipline to help us fight misinformation! *insert_entry_point_link*" description="Default value for a customizable string of the tipline bot." />,
+    },
+    {
+      key: 'search_submit',
+      title: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackTitle" defaultMessage="Negative feedback" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackDescription" defaultMessage="If the user is not satisfied, this message informs the user that the content has been sent to journalists." description="Description of a customizable string of the tipline bot." />,
+      default: <FormattedMessage id="smoochBotContentAndTranslation.negativeFeedbackDefault" defaultMessage="Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published." description="Default value for a customizable string of the tipline bot." />,
     },
     {
       key: 'newsletter_optin_optout',
@@ -130,80 +96,62 @@ const SmoochBotContentAndTranslation = ({
     {
       key: 'smooch_message_smooch_bot_option_not_available',
       title: <FormattedMessage id="smoochBotContentAndTranslation.optionNotAvailableTitle" defaultMessage="Option not available" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.optionNotAvailableDescription" defaultMessage="The message sent if the user response to a menu is not a valid menu scenario." description="Description of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.optionNotAvailableDescription" defaultMessage="The message sent if the user response is not a valid option." description="Description of a customizable string of the tipline bot." />,
       default: <FormattedMessage id="smoochBotContentAndTranslation.optionNotAvailableDefault" defaultMessage="I'm sorry, I didn't understand your message." description="Default value for a customizable string of the tipline bot." />,
     },
     {
+      key: 'timeout',
+      title: <FormattedMessage id="smoochBotContentAndTranslation.timeoutTitle" defaultMessage="Conversation time out" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.timeoutDescription" defaultMessage="After 15 minutes of activity, this message is sent to users to close the conversation." description="Description of a customizable string of the tipline bot." />,
+      default: <FormattedMessage id="smoochBotContentAndTranslation.timeoutDefault" defaultMessage="Thank you for reaching out to us! Type any key to start a new conversation." description="Default value for a customizable string of the tipline bot." />,
+    },
+    {
       key: 'smooch_message_smooch_bot_disabled',
-      title: <FormattedMessage id="smoochBotContentAndTranslation.noticeOfInactivityTitle" defaultMessage="Notice of inactivity" description="Title of a customizable string of the tipline bot." />,
-      description: <FormattedMessage id="smoochBotContentAndTranslation.noticeOfInactivityDescription" defaultMessage="This message is sent to any user that has sent a message to the tipline when the Check Message bot is set to inactive." description="Description of a customizable string of the tipline bot." />,
+      title: <FormattedMessage id="smoochBotContentAndTranslation.noticeOfInactivityTitle" defaultMessage="Inactive bot" description="Title of a customizable string of the tipline bot." />,
+      description: <FormattedMessage id="smoochBotContentAndTranslation.noticeOfInactivityDescription" defaultMessage="If the tipline is set to inactive, this message is sent in response to any user message." description="Description of a customizable string of the tipline bot." />,
       default: <FormattedMessage id="smoochBotContentAndTranslation.noticeOfInactivityDefault" defaultMessage="Our bot is currently inactive. Please visit *insert URL* to read the latest fact-checks." description="Default value for a customizable string of the tipline bot." />,
     },
   ];
 
   return (
-    <React.Fragment>
-      <Typography variant="subtitle2" component="div">{labelsV2.smooch_content}</Typography>
-
-      <Typography component="div" variant="body2">
-        <FormattedMessage
-          id="smoochBotContentAndTranslation.subtitle"
-          defaultMessage="Replace or translate the default content for each standard bot message."
-          description="Subtitle displayed in tipline settings page for content and translation."
-        />
-      </Typography>
-
-      { strings.map((string, i) => (
-        <Box my={2}>
-          <Typography component="div" variant="body2">
-            <strong>{i + 1}. {string.title}</strong><br />
-            {string.description}
-          </Typography>
-          { string.key === 'newsletter_optin_optout' && value[string.key] && !/{subscription_status}/.test(value[string.key]) ?
-            <Typography variant="body2" component="div" color="error" className={classes.error}>
-              <InfoOutlinedIcon />
-              {' '}
-              <FormattedMessage id="smoochBotContentAndTranslation.error" defaultMessage="The placeholder {subscription_status} is missing from your custom content or translation" description="Error message displayed on the tipline settings page when the placeholder is not present" />
-            </Typography> : null }
-          <Box mt={1}>
-            <Box p={1} className={classes.defaultString}>
-              <Typography component="div" variant="body2">
-                {string.default}
-              </Typography>
-            </Box>
-            <TextField
-              key={string.key}
-              InputProps={{ className: classes.customString }}
-              variant="outlined"
-              placeholder={intl.formatMessage(messages.placeholder)}
-              rowsMax={Infinity}
-              rows={3}
-              defaultValue={string.state ? value[`smooch_state_${string.state}`].smooch_menu_message : value[string.key]}
-              onBlur={(e) => {
-                const newValue = e.target.value;
-                if (string.state) {
-                  onChangeStateMessage(string.state, newValue);
-                } else {
-                  onChangeMessage(string.key, newValue);
-                }
-              }}
-              error={string.key === 'newsletter_optin_optout' && value[string.key] && !/{subscription_status}/.test(value[string.key])}
-              multiline
-              fullWidth
-            />
-            { string.key === 'smooch_message_smooch_bot_greetings' ?
-              <Box>
-                <UploadFile
-                  type="image"
-                  value={greetingImage}
-                  onChange={onChangeImage}
-                  onError={() => {}}
-                />
-              </Box> : null }
-          </Box>
+    <Box className={classes.container}>
+      { strings.map(string => (
+        <Box mb={4} key={string.key}>
+          <TiplineContentTranslation
+            key={string.key}
+            identifier={string.key}
+            title={string.title}
+            description={string.description}
+            defaultValue={string.default}
+            value={string.state ? value[`smooch_state_${string.state}`].smooch_menu_message : value[string.key]}
+            error={
+              string.key === 'newsletter_optin_optout' && value[string.key] && !/{subscription_status}/.test(value[string.key]) ?
+                <FormattedMessage id="smoochBotContentAndTranslation.error" defaultMessage="The placeholder {subscription_status} is missing from your custom content or translation" description="Error message displayed on the tipline settings page when the placeholder is not present" />
+                : null
+            }
+            onUpdate={(newValue) => {
+              if (string.state) {
+                onChangeStateMessage(string.state, newValue);
+              } else {
+                onChangeMessage(string.key, newValue);
+              }
+            }}
+            extra={
+              string.key === 'smooch_message_smooch_bot_greetings' ?
+                <Box>
+                  <UploadFile
+                    type="image"
+                    value={greetingImage}
+                    onChange={onChangeImage}
+                    onError={() => {}}
+                  />
+                </Box>
+                : null
+            }
+          />
         </Box>
       ))}
-    </React.Fragment>
+    </Box>
   );
 };
 
@@ -216,7 +164,6 @@ SmoochBotContentAndTranslation.propTypes = {
   onChangeMessage: PropTypes.func.isRequired,
   onChangeStateMessage: PropTypes.func.isRequired,
   onChangeImage: PropTypes.func.isRequired,
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(SmoochBotContentAndTranslation);
+export default SmoochBotContentAndTranslation;

--- a/src/app/components/team/SmoochBot/localizables.js
+++ b/src/app/components/team/SmoochBot/localizables.js
@@ -11,7 +11,6 @@ const labels = {
   smooch_message_smooch_bot_message_confirmed: <FormattedMessage id="smoochBot.labelQueryReceived" defaultMessage="Query received" />,
   smooch_state_subscription: <FormattedMessage id="smoochBot.labelSubscription" defaultMessage="Subscription opt-in" />,
   smooch_newsletter: <FormattedMessage id="smoochBot.labelNewsletter" defaultMessage="Newsletter" />,
-  smooch_message_smooch_bot_no_action: <FormattedMessage id="smoochBot.labelNoAction" defaultMessage="No action from user" />,
   smooch_message_smooch_bot_option_not_available: <FormattedMessage id="smoochBot.labelOptionNotAvailable" defaultMessage="Option not available" />,
   smooch_message_smooch_bot_result_changed: <FormattedMessage id="smoochBot.labelReportUpdated" defaultMessage="Report updated" />,
   smooch_message_smooch_bot_message_type_unsupported: <FormattedMessage id="smoochBot.labelInvalidFormat" defaultMessage="Invalid format" />,
@@ -20,10 +19,9 @@ const labels = {
 };
 
 const labelsV2 = {
-  smooch_content: <FormattedMessage id="smoochBot.labelContent" defaultMessage="Content and translation" description="Button label in tipline settings page" />,
+  smooch_content: <FormattedMessage id="smoochBot.labelContent" defaultMessage="Content & translation" description="Button label in tipline settings page" />,
   smooch_main_menu: <FormattedMessage id="smoochBot.labelMainMenu" defaultMessage="Main menu" />,
-  smooch_newsletter: <FormattedMessage id="smoochBot.labelNewsletterV2" defaultMessage="Newsletter content" />,
-  smooch_message_smooch_bot_no_action: <FormattedMessage id="smoochBot.labelNoAction" defaultMessage="No action from user" />,
+  smooch_newsletter: <FormattedMessage id="smoochBot.labelNewsletterV2" defaultMessage="Newsletter" />,
 };
 
 const descriptions = {
@@ -42,7 +40,6 @@ const descriptions = {
       <FormattedMessage id="smoochBot.descriptionNewsletter3" defaultMessage="2. Select a day and time of the week" />
     </React.Fragment>
   ),
-  smooch_message_smooch_bot_no_action: <FormattedMessage id="smoochBot.descriptionNoAction" defaultMessage="This message will be sent to users if, after a conversation is initiated, they do not select either option: receive a resource or submit content to verify. This message will also be sent to users who submitted content without waiting for the query prompt." />,
   smooch_message_smooch_bot_option_not_available: <FormattedMessage id="smoochBot.descriptionOptionNotAvailable" defaultMessage="The message sent if the user response to a menu is not a valid menu scenario." />,
   smooch_message_smooch_bot_result_changed: <FormattedMessage id="smoochBot.descriptionReportUpdated" defaultMessage="The message sent to the user when status of a report has changed. The report must be completed for this message to be sent." />,
   smooch_message_smooch_bot_message_type_unsupported: <FormattedMessage id="smoochBot.descriptionInvalidFormat" defaultMessage="An automatic message sent to the user when they have sent a file that is not supported by Check." />,

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -25,6 +25,9 @@ export const brandLightCDS = '#CFDFFF';
 export const alertLightCDS = '#FFF8ED';
 export const alertSecondaryCDS = '#A66300';
 export const alertMainCDS = '#E78A00';
+export const brandBackgroundCDS = '#F1F5F6';
+export const grayBorderCDS = '#CDD0D1';
+export const otherErrorMainCDS = '#F44336';
 
 // Material blacks
 // TODO make these opaque!


### PR DESCRIPTION
## Description

Refactoring tipline "Content and Translation" settings page.

* "No action from user" removed from left sidebar and it's now an option under "Content & Translation"
* Copy update for some options on "Content & Translation" page
* Refactored "Content and Translation" page in order to follow the Design System
* New Design System component implemented (including unit test): `<TiplineContentTranslation />`

Reference: CHECK-2747.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I added a unit test for the new component `<TiplineContentTranslation />`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

