### PR TITLE
Fix media card title

### DIFF
--- a/src/app/components/media/MediaExpanded.js
+++ b/src/app/components/media/MediaExpanded.js
@@ -35,22 +35,11 @@ const TypographyBlack54 = withStyles({
   },
 })(Typography);
 
-const useStyles = () => ({
+const styles = {
   title: {
-    fontSize: 14,
-    lineHeight: '1.5em',
-    color: 'black',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    textDecoration: 'none',
-    '&:hover': {
-      color: 'black',
-    },
-    '&:visited': {
-      color: 'black',
-    },
+    overflowWrap: 'anywhere',
   },
-});
+};
 
 class MediaExpandedComponent extends Component {
   constructor(props) {
@@ -139,7 +128,7 @@ class MediaExpandedComponent extends Component {
     const isWebPage = media.media.url && data.provider === 'page';
     const isPender = media.media.url && data.provider !== 'page';
     const randomNumber = Math.floor(Math.random() * 1000000);
-    const { mediaUrl, mediaQuery, linkTitle } = this.props;
+    const { mediaUrl, mediaQuery } = this.props;
     const coverImage = media.media.thumbnail_path || '/images/player_cover.svg';
 
     let warningType = null;
@@ -249,10 +238,9 @@ class MediaExpandedComponent extends Component {
         <CardHeader
           className="media-expanded__title"
           title={
-            linkTitle ?
-              <a href={mediaUrl} className={classes ? classes.title : null} target="_blank" rel="noopener noreferrer">
-                <strong>{truncateLength(title, 110)}</strong>
-              </a> : truncateLength(title, 110)
+            <span className={classes.title}>
+              {truncateLength(title, 110)}
+            </span>
           }
         />
         <CardContent style={{ padding: `0 ${units(2)}` }}>
@@ -416,5 +404,5 @@ const MediaExpanded = (props) => {
   );
 };
 
-export default withStyles(useStyles)(MediaExpanded);
+export default withStyles(styles)(MediaExpanded);
 export { MediaExpandedComponent };


### PR DESCRIPTION
## Description

media card title should wrap to not overlap the requests on item page

Reference: CHECK-2788

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

