### PR TITLE
A couple of changes for fact-check and report language behavior.

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaFactCheck.json
+++ b/localization/react-intl/src/app/components/media/MediaFactCheck.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": "mediaFactCheck.errorWithLanguage",
-    "description": "Caption that informs that a fact-check could not be saved and that the fields have to be filled",
-    "defaultMessage": "Title, description and language have to be filled"
-  },
-  {
     "id": "mediaFactCheck.error",
     "description": "Caption that informs that a fact-check could not be saved and that the fields have to be filled",
     "defaultMessage": "Title and description have to be filled"

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -67,7 +67,7 @@ const MediaFactCheck = ({ projectMedia }) => {
     };
     values[field] = value;
     if (hasPermission) {
-      if (factCheck && values.language && values.language !== 'und') {
+      if (factCheck) {
         setSaving(true);
         commitMutation(Relay.Store, {
           mutation: graphql`
@@ -106,7 +106,7 @@ const MediaFactCheck = ({ projectMedia }) => {
             setError(true);
           },
         });
-      } else if (values.title && values.summary && values.language && values.language !== 'und') {
+      } else if (values.title && values.summary) {
         setSaving(true);
         commitMutation(Relay.Store, {
           mutation: graphql`
@@ -162,20 +162,13 @@ const MediaFactCheck = ({ projectMedia }) => {
     handleBlur('language', languageCode);
   };
 
-  const errorMessage = languages.length > 1 ? (
+  const errorMessage = (
     <FormattedMessage
-      id="mediaFactCheck.errorWithLanguage"
-      defaultMessage="Title, description and language have to be filled"
+      id="mediaFactCheck.error"
+      defaultMessage="Title and description have to be filled"
       description="Caption that informs that a fact-check could not be saved and that the fields have to be filled"
-    />)
-    :
-    (
-      <FormattedMessage
-        id="mediaFactCheck.error"
-        defaultMessage="Title and description have to be filled"
-        description="Caption that informs that a fact-check could not be saved and that the fields have to be filled"
-      />
-    );
+    />
+  );
 
   return (
     <Box id="media__fact-check">

--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -57,6 +57,7 @@ const ReportDesignerForm = (props) => {
   const data = props.data || { use_text_message: true, text: '' };
   const currentLanguage = data.language;
   const languages = safelyParseJSON(team.get_languages) || [];
+  const default_reports = team.get_report || {};
 
   const handleImageChange = (image) => {
     props.onUpdate('image', image);
@@ -78,7 +79,13 @@ const ReportDesignerForm = (props) => {
 
   const handleLanguageSubmit = (value) => {
     const { languageCode } = value;
-    props.onUpdate('language', languageCode);
+    const updates = { language: languageCode };
+    if (languageCode !== currentLanguage) {
+      const default_report = default_reports[languageCode] || {};
+      updates.use_introduction = !!default_report.use_introduction;
+      updates.introduction = default_report.introduction;
+    }
+    props.onUpdate(updates);
   };
 
   const textFieldProps = {


### PR DESCRIPTION
## Description

* Should be able to save a fact-check without a language.
* When changing the language of a report, use the default introduction settings for that language.

Fixes CHECK-2853 and CHECK-2843.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

How to test: We need to test that the report has the right settings. A report can be created by different ways: either manually (when there is a claim but no fact-check) or as a result of a fact-check being created first. It’s also different if the created fact-check has a language or not. Also, there is a difference if a workspace has one language only or more than one language. So, here is the testing plan (let me know please if I forgot anything):

**Workspace has more than one language:**

- Fact-check created with a language: Report inherits introduction settings from workspace for that language
- Fact-check created without a language: Report has no introduction and has unknown language
- No fact-check created: Report has no introduction and has unknown language
- For all three cases above, if the report or fact-check language is changed, the report introduction is overwritten by the one in the workspace report settings for that language

**Workspace has only one language:**

- Fact-check created or no fact-check created: Report always inherits introduction settings from workspace for the workspace language

## Things to pay attention to during code review

Hopefully I didn't forget any case, as outlined above.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

