### PR TITLE
validate that URLs are not allowed for signature fields on report settings page

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamReport/TeamReportComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamReport/TeamReportComponent.json
@@ -48,12 +48,24 @@
     "defaultMessage": "WhatsApp number"
   },
   {
+    "id": "teamReportComponent.facebookFieldError",
+    "defaultMessage": "Please use the page name instead of the full URL"
+  },
+  {
     "id": "teamReportComponent.facebook",
     "defaultMessage": "Facebook page name"
   },
   {
+    "id": "teamReportComponent.twitterFieldError",
+    "defaultMessage": "Please use the account name instead of the full URL"
+  },
+  {
     "id": "teamReportComponent.twitter",
     "defaultMessage": "Twitter account name"
+  },
+  {
+    "id": "teamReportComponent.telegramFieldError",
+    "defaultMessage": "Please use the bot username instead of the full URL"
   },
   {
     "id": "teamReportComponent.telegram",

--- a/src/app/components/team/TeamReport/TeamReportComponent.js
+++ b/src/app/components/team/TeamReport/TeamReportComponent.js
@@ -39,6 +39,7 @@ const TeamReportComponent = ({ team, setFlashMessage }) => {
   const [currentLanguage, setCurrentLanguage] = React.useState(defaultLanguage);
   const [reports, setReports] = React.useState(JSON.parse(JSON.stringify(team.get_report || {})));
   const [saving, setSaving] = React.useState(false);
+  const [errorField, setErrorField] = React.useState(null);
   const report = reports[currentLanguage] || {};
   const languages = team.get_languages ? JSON.parse(team.get_languages) : [defaultLanguage];
 
@@ -70,6 +71,25 @@ const TeamReportComponent = ({ team, setFlashMessage }) => {
         description="Banner displayed when report settings are saved successfully"
       />
     ), 'success');
+  };
+
+  const isUrl = (string) => {
+    try {
+      return Boolean(new URL(string));
+    } catch (e) {
+      return false;
+    }
+  };
+
+  const validateSignatureField = (field, value) => {
+    const newReports = { ...reports };
+    if (!isUrl(value)) {
+      handleChange(field, value);
+      setErrorField(null);
+    } else {
+      newReports[currentLanguage][field] = '';
+      setErrorField(field);
+    }
   };
 
   const handleSave = () => {
@@ -290,7 +310,15 @@ const TeamReportComponent = ({ team, setFlashMessage }) => {
                   key={`facebook-${currentLanguage}`}
                   value={report.facebook || ''}
                   disabled={!report.use_signature}
-                  onChange={(e) => { handleChange('facebook', e.target.value); }}
+                  onChange={e => validateSignatureField('facebook', e.target.value)}
+                  error={errorField === 'facebook'}
+                  helperText={errorField === 'facebook' ?
+                    <FormattedMessage
+                      id="teamReportComponent.facebookFieldError"
+                      defaultMessage="Please use the page name instead of the full URL"
+                    />
+                    : null
+                  }
                   label={
                     <FormattedMessage
                       id="teamReportComponent.facebook"
@@ -314,7 +342,15 @@ const TeamReportComponent = ({ team, setFlashMessage }) => {
                   key={`twitter-${currentLanguage}`}
                   value={report.twitter || ''}
                   disabled={!report.use_signature}
-                  onChange={(e) => { handleChange('twitter', e.target.value); }}
+                  onChange={e => validateSignatureField('twitter', e.target.value)}
+                  error={errorField === 'twitter'}
+                  helperText={errorField === 'twitter' ?
+                    <FormattedMessage
+                      id="teamReportComponent.twitterFieldError"
+                      defaultMessage="Please use the account name instead of the full URL"
+                    />
+                    : null
+                  }
                   label={
                     <FormattedMessage
                       id="teamReportComponent.twitter"
@@ -339,7 +375,15 @@ const TeamReportComponent = ({ team, setFlashMessage }) => {
                   key={`telegram-${currentLanguage}`}
                   value={report.telegram || ''}
                   disabled={!report.use_signature}
-                  onChange={(e) => { handleChange('telegram', e.target.value); }}
+                  onChange={e => validateSignatureField('telegram', e.target.value)}
+                  error={errorField === 'telegram'}
+                  helperText={errorField === 'telegram' ?
+                    <FormattedMessage
+                      id="teamReportComponent.telegramFieldError"
+                      defaultMessage="Please use the bot username instead of the full URL"
+                    />
+                    : null
+                  }
                   label={
                     <FormattedMessage
                       id="teamReportComponent.telegram"


### PR DESCRIPTION
## Description

validate that URLs are not allowed for Facebook, Telegram and Twitter fields on report settings page and display a error message on these fields

Reference: CHECK-2874

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

