### PR TITLE
Different confirmation message when re-publishing a report if workspace is configured for single-language reports

### DIFF
--- a/localization/react-intl/src/app/components/media/ReportDesigner/ReportDesignerTopBar.json
+++ b/localization/react-intl/src/app/components/media/ReportDesigner/ReportDesignerTopBar.json
@@ -62,7 +62,7 @@
   },
   {
     "id": "reportDesigner.confirmPublishText2",
-    "defaultMessage": "All future users who request this item will receive this version of the report while it remains published."
+    "defaultMessage": "Future users who request this item will receive this version of the report while it remains published."
   },
   {
     "id": "reportDesigner.confirmRepublishResendText",
@@ -71,6 +71,10 @@
   {
     "id": "reportDesigner.correction",
     "defaultMessage": "correction"
+  },
+  {
+    "id": "reportDesigner.republishAndResendSingleLanguage",
+    "defaultMessage": "Also send this updated report only to users who requested this item in {reportLanguage}."
   },
   {
     "id": "reportDesigner.republishAndResend",

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
@@ -257,7 +257,7 @@ const ReportDesignerTopBar = (props) => {
                       <Typography paragraph>
                         <FormattedMessage
                           id="reportDesigner.confirmPublishText2"
-                          defaultMessage="All future users who request this item will receive this version of the report while it remains published."
+                          defaultMessage="Future users who request this item will receive this version of the report while it remains published."
                         />
                       </Typography> : null }
 
@@ -297,25 +297,33 @@ const ReportDesignerTopBar = (props) => {
                             />
                           }
                           label={
-                            <FormattedMessage
-                              id="reportDesigner.republishAndResend"
-                              defaultMessage="{demand, plural, one {Also send this updated report as a {correctionLink} to the user who has received the previous version of this report.} other {Also send this updated report as a {correctionLink} to the # users who have received the previous version of this report.}}"
-                              values={{
-                                demand: media.demand,
-                                correctionLink: (
-                                  <React.Fragment>
-                                    <a href="https://help.checkmedia.org" rel="noopener noreferrer" className={classes.correctionLink} target="_blank">
-                                      <FormattedMessage
-                                        id="reportDesigner.correction"
-                                        defaultMessage="correction"
-                                      />
-                                      {' '}
-                                      <HelpIcon />
-                                    </a>
-                                  </React.Fragment>
-                                ),
-                              }}
-                            />
+                            media.team?.get_languages?.length > 1 && data.options?.language && data.options.language !== 'und' && media.team?.alegre_bot?.alegre_settings?.single_language_fact_checks_enabled ?
+                              <FormattedMessage
+                                id="reportDesigner.republishAndResendSingleLanguage"
+                                defaultMessage="Also send this updated report only to users who requested this item in {reportLanguage}."
+                                values={{
+                                  reportLanguage: languageLabel(data?.options?.language),
+                                }}
+                              /> :
+                              <FormattedMessage
+                                id="reportDesigner.republishAndResend"
+                                defaultMessage="{demand, plural, one {Also send this updated report as a {correctionLink} to the user who has received the previous version of this report.} other {Also send this updated report as a {correctionLink} to the # users who have received the previous version of this report.}}"
+                                values={{
+                                  demand: media.demand,
+                                  correctionLink: (
+                                    <React.Fragment>
+                                      <a href="https://help.checkmedia.org" rel="noopener noreferrer" className={classes.correctionLink} target="_blank">
+                                        <FormattedMessage
+                                          id="reportDesigner.correction"
+                                          defaultMessage="correction"
+                                        />
+                                        {' '}
+                                        <HelpIcon />
+                                      </a>
+                                    </React.Fragment>
+                                  ),
+                                }}
+                              />
                           }
                         />
                       </Box> : null }

--- a/src/app/components/media/ReportDesigner/index.js
+++ b/src/app/components/media/ReportDesigner/index.js
@@ -57,6 +57,9 @@ const ReportDesignerContainer = Relay.createContainer(ReportDesignerComponent, {
           get_report
           get_report_design_image_template
           verification_statuses
+          alegre_bot: team_bot_installation(bot_identifier: "alegre") {
+            alegre_settings
+          }
         }
       }
     `,


### PR DESCRIPTION
## Description

If the "Similarity" settings for a workspace has the setting "Only send fact-checks in the same language as the conversation language" turned on, then present a different message on the report publishing confirmation modal in order to be clear that the new report is going to be sent only to users who requested in the same language as the report language.

Fixes CHECK-2844.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

