### PR TITLE
A couple of UI/UX improvements for tipline settings page.

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.json
@@ -10,6 +10,11 @@
     "defaultMessage": "Button text - 24 characters limit"
   },
   {
+    "id": "smoochBotMainMenuOption.labelError",
+    "description": "Error message displayed when user tries to save tipline menu option with a blank label",
+    "defaultMessage": "Please add text to label the button"
+  },
+  {
     "id": "smoochBotMainMenuOption.description",
     "description": "Description field label on dialog that opens to add a new option to tipline bot main menu",
     "defaultMessage": "Description - 72 characters limit"
@@ -48,6 +53,11 @@
     "id": "smoochBotMainMenuOption.resources",
     "description": "List subheader displayed on dialog that opens to add a new option to tipline bot main menu",
     "defaultMessage": "Resources"
+  },
+  {
+    "id": "smoochBotMainMenuOption.responseError",
+    "description": "Error message displayed when user tries to save tipline option with empty response",
+    "defaultMessage": "Please choose a response"
   },
   {
     "id": "smoochBotMainMenuOption.save",

--- a/src/app/components/team/SmoochBot/SmoochBotComponent.js
+++ b/src/app/components/team/SmoochBot/SmoochBotComponent.js
@@ -135,6 +135,11 @@ const SmoochBotComponent = ({
     }
     setCurrentLanguage(newValue);
   };
+
+  // Workspace languages for which there is a tipline workflow
+  const workflowLanguages = settings?.smooch_workflows?.map(w => w.smooch_workflow_language) || [];
+  const validLanguages = languages.filter(l => workflowLanguages.includes(l)) || [];
+
   // If only on language, no margin left. If more than one language the language selector is displayed, so we add a margin.
   return (
     <Box display="flex" justifyContent="left" className="smooch-bot-component" ml={installation && bot && languages.length > 1 ? 0 : 6}>
@@ -178,7 +183,7 @@ const SmoochBotComponent = ({
                 currentUser={currentUser}
                 userRole={userRole}
                 currentLanguage={currentLanguage}
-                languages={languages}
+                languages={validLanguages}
                 enabledIntegrations={installation.smooch_enabled_integrations}
                 newsletterInformation={installation.smooch_newsletter_information}
               /> :

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { withStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
@@ -8,8 +9,33 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import Select from '@material-ui/core/Select';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
+import {
+  otherErrorMainCDS,
+} from '../../../styles/js/shared';
+
+const errorFieldStyles = {
+  root: {
+    '& .MuiFormHelperText-root.Mui-error': {
+      color: otherErrorMainCDS,
+      marginLeft: 0,
+      fontSize: 12,
+      fontWeight: 400,
+    },
+    '& .MuiOutlinedInput-root': {
+      '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+        borderColor: otherErrorMainCDS,
+        borderWidth: 2,
+      },
+    },
+  },
+};
+
+const StyledTextField = withStyles(errorFieldStyles)(TextField);
+
+const StyledFormControl = withStyles(errorFieldStyles)(FormControl);
 
 const SmoochBotMainMenuOption = ({
   currentTitle,
@@ -23,9 +49,13 @@ const SmoochBotMainMenuOption = ({
   const [text, setText] = React.useState(currentTitle);
   const [description, setDescription] = React.useState(currentDescription);
   const [value, setValue] = React.useState(currentValue);
+  const [submitted, setSubmitted] = React.useState(false);
 
   const handleSave = () => {
-    onSave(text, description, value);
+    setSubmitted(true);
+    if (text && value) {
+      onSave(text, description, value);
+    }
   };
 
   const handleCancel = () => {
@@ -44,7 +74,7 @@ const SmoochBotMainMenuOption = ({
       }
       body={(
         <Box>
-          <TextField
+          <StyledTextField
             label={
               <FormattedMessage
                 id="smoochBotMainMenuOption.label"
@@ -56,6 +86,15 @@ const SmoochBotMainMenuOption = ({
             onBlur={(e) => { setText(e.target.value); }}
             inputProps={{ maxLength: 24 }}
             variant="outlined"
+            error={submitted && !text}
+            helperText={
+              submitted && !text ?
+                <FormattedMessage
+                  id="smoochBotMainMenuOption.labelError"
+                  defaultMessage="Please add text to label the button"
+                  description="Error message displayed when user tries to save tipline menu option with a blank label"
+                /> : null
+            }
             fullWidth
           />
 
@@ -88,7 +127,7 @@ const SmoochBotMainMenuOption = ({
             </Typography>
           </Box>
 
-          <FormControl variant="outlined" fullWidth>
+          <StyledFormControl variant="outlined" error={submitted && !value} fullWidth>
             <InputLabel>
               <FormattedMessage
                 id="smoochBotMainMenuOption.response"
@@ -148,7 +187,15 @@ const SmoochBotMainMenuOption = ({
                 </MenuItem>
               ))}
             </Select>
-          </FormControl>
+            { (submitted && !value) ?
+              <FormHelperText>
+                <FormattedMessage
+                  id="smoochBotMainMenuOption.responseError"
+                  defaultMessage="Please choose a response"
+                  description="Error message displayed when user tries to save tipline option with empty response"
+                />
+              </FormHelperText> : null }
+          </StyledFormControl>
         </Box>
       )}
       proceedLabel={<FormattedMessage id="smoochBotMainMenuOption.save" defaultMessage="Save" description="Button label to save new tipline menu option" />}


### PR DESCRIPTION
* On the languages menu preview, just list languages for which there is a tipline workflow configured
* Show error when trying to save a menu option without label or response

Fixes CV2-2690.