### PR TITLE
List languages from data in data dashboard

### DIFF
--- a/src/app/components/team/TeamData/TeamDataComponent.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.js
@@ -175,24 +175,27 @@ const TeamDataComponent = ({
   slug,
   data,
   defaultLanguage,
-  languages,
 }) => {
   const classes = useStyles();
   const defaultOrder = 'Month';
-  const [currentLanguage, setCurrentLanguage] = React.useState(defaultLanguage);
   const [order, setOrder] = React.useState('asc');
   const [orderBy, setOrderBy] = React.useState(defaultOrder);
 
   const headers = data ? Object.keys(data[0]).filter(header => !['ID', 'Org', 'Language', 'Platform'].includes(header)) : null;
 
+  const languages = [];
   const platforms = [];
   if (data) {
     data.forEach((row) => {
       if (platforms.indexOf(row.Platform) === -1) {
         platforms.push(row.Platform);
       }
+      if (languages.indexOf(row.Language) === -1) {
+        languages.push(row.Language);
+      }
     });
   }
+  const [currentLanguage, setCurrentLanguage] = React.useState(defaultLanguage || languages[0]);
   const [currentPlatform, setCurrentPlatform] = React.useState(platforms[0]);
 
   const helpMessages = {
@@ -270,11 +273,11 @@ const TeamDataComponent = ({
                   ))}
                 </Select> : null }
             </FormControl>
-            { JSON.parse(languages)?.length > 1 ?
+            { languages.length > 1 ?
               <LanguageSwitcher
                 component="dropdown"
                 currentLanguage={currentLanguage}
-                languages={JSON.parse(languages)}
+                languages={languages}
                 onChange={setCurrentLanguage}
               /> : null }
           </Box>
@@ -357,14 +360,12 @@ const TeamDataComponent = ({
 TeamDataComponent.defaultProps = {
   data: null,
   defaultLanguage: null,
-  languages: '[]',
 };
 
 TeamDataComponent.propTypes = {
   slug: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.object), // or null
   defaultLanguage: PropTypes.string, // or null
-  languages: PropTypes.string, // JSON-encoded array of languages, or null
   intl: intlShape.isRequired,
 };
 

--- a/src/app/components/team/TeamData/TeamDataComponent.test.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.test.js
@@ -17,7 +17,13 @@ describe('<TeamDataComponent />', () => {
   it('should render table if there is data', () => {
     const wrapper = mountWithIntl(<TeamDataComponent
       slug="test"
-      data={[{ Month: 'January 2022', Conversations: 123, Language: 'en', Platform: 'WhatsApp', ID: 1 }]}
+      data={[{
+        Month: 'January 2022',
+        Conversations: 123,
+        Language: 'en',
+        Platform: 'WhatsApp',
+        ID: 1,
+      }]}
       params={{}}
       route={{ action: 'settings' }}
     />);
@@ -27,8 +33,20 @@ describe('<TeamDataComponent />', () => {
 
   it('should list languages from data', () => {
     const data  = [
-      { Month: 'January 2022', Conversations: 123, Language: 'en', Platform: 'WhatsApp', ID: '1' },
-      { Month: 'February 2022', Conversations: 456, Language: 'es', Platform: 'WhatsApp', ID: '2' },
+      {
+        Month: 'January 2022',
+        Conversations: 123,
+        Language: 'en',
+        Platform: 'WhatsApp',
+        ID: '1',
+      },
+      {
+        Month: 'February 2022',
+        Conversations: 456,
+        Language: 'es',
+        Platform: 'WhatsApp',
+        ID: '2',
+      },
     ];
 
     let wrapper = mountWithIntl(<TeamDataComponent

--- a/src/app/components/team/TeamData/TeamDataComponent.test.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.test.js
@@ -32,7 +32,7 @@ describe('<TeamDataComponent />', () => {
   });
 
   it('should list languages from data', () => {
-    const data  = [
+    const data = [
       {
         Month: 'January 2022',
         Conversations: 123,

--- a/src/app/components/team/TeamData/TeamDataComponent.test.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.test.js
@@ -3,8 +3,9 @@ import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import TeamDataComponent from './TeamDataComponent';
 
 describe('<TeamDataComponent />', () => {
-  it('Should not render table if there is no data', () => {
+  it('should not render table if there is no data', () => {
     const wrapper = mountWithIntl(<TeamDataComponent
+      slug="test"
       data={null}
       params={{}}
       route={{ action: 'settings' }}
@@ -13,13 +14,38 @@ describe('<TeamDataComponent />', () => {
     expect(wrapper.find('.team-data-component__no-data').hostNodes()).toHaveLength(1);
   });
 
-  it('Should render table if there is data', () => {
+  it('should render table if there is data', () => {
     const wrapper = mountWithIntl(<TeamDataComponent
-      data={[{ Month: 'January 2022', Conversations: 123 }]}
+      slug="test"
+      data={[{ Month: 'January 2022', Conversations: 123, Language: 'en', Platform: 'WhatsApp', ID: 1 }]}
       params={{}}
       route={{ action: 'settings' }}
     />);
     expect(wrapper.find('.team-data-component__with-data').hostNodes()).toHaveLength(1);
     expect(wrapper.find('.team-data-component__no-data').hostNodes()).toHaveLength(0);
+  });
+
+  it('should list languages from data', () => {
+    const data  = [
+      { Month: 'January 2022', Conversations: 123, Language: 'en', Platform: 'WhatsApp', ID: '1' },
+      { Month: 'February 2022', Conversations: 456, Language: 'es', Platform: 'WhatsApp', ID: '2' },
+    ];
+
+    let wrapper = mountWithIntl(<TeamDataComponent
+      slug="test"
+      data={data}
+      params={{}}
+      route={{ action: 'settings' }}
+    />);
+    expect(wrapper.html()).toMatch('English');
+
+    wrapper = mountWithIntl(<TeamDataComponent
+      slug="test"
+      data={data}
+      defaultLanguage="es"
+      params={{}}
+      route={{ action: 'settings' }}
+    />);
+    expect(wrapper.html()).toMatch('Español');
   });
 });

--- a/src/app/components/team/TeamData/index.js
+++ b/src/app/components/team/TeamData/index.js
@@ -13,7 +13,6 @@ const renderQuery = ({ error, props }) => {
         slug={team.slug}
         data={team.data_report}
         defaultLanguage={team.get_language}
-        languages={team.get_languages}
       />
     );
   }
@@ -31,7 +30,6 @@ const TeamData = props => (
           id
           slug
           get_language
-          get_languages
           data_report
         }
       }


### PR DESCRIPTION
## Description

Today, the data dashboard displays data by language. The language options in the drop-down are the workspace languages. So, if some language is deleted from the workspace settings, then the data for that language won’t be displayed anymore. We can avoid that by listing the language options from the languages we have data for.

Fixes CV2-2698.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I implemented a unit test for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

