### PR TITLE
Typography to match figma design system

### DIFF
--- a/src/app/components/cds/buttons-checkboxes-chips/CounterButton.js
+++ b/src/app/components/cds/buttons-checkboxes-chips/CounterButton.js
@@ -45,7 +45,7 @@ const CounterButton = ({ label, count, onClick }) => {
         {label}
       </Typography>
       <br />
-      <Typography variant="h2">
+      <Typography variant="subtitle2">
         {count}
       </Typography>
     </Button>

--- a/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialogComponent.js
+++ b/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialogComponent.js
@@ -56,7 +56,7 @@ const MediaAndRequestsDialogComponent = ({
       PaperProps={{ classes: { root: classes.dialog } }}
     >
       <DialogTitle>
-        <Typography variant="h1">
+        <Typography variant="h6">
           <FormattedMessage
             id="cds.mediaAndRequestsDialog.matchedMedia"
             defaultMessage="Media"

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -407,7 +407,7 @@ const MediaSuggestionsComponent = ({
   if (relationships.length === 0) {
     return (
       <Box className={classes.card}>
-        <Typography variant="h2">0 suggestion</Typography>
+        <Typography variant="subtitle2">0 suggestion</Typography>
       </Box>
     );
   }

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -156,7 +156,6 @@ export const MuiTheme = {
       fontSize: '12px',
       fontWeight: 400,
     },
-    // The "Big title" variant in Check Design System
     h1: {
       letterSpacing: '0.15px',
       lineHeight: '150%',
@@ -164,7 +163,6 @@ export const MuiTheme = {
       fontWeight: 500,
       color: textPrimary,
     },
-    // The "Title" variant in Check Design System
     h2: {
       letterSpacing: '0.15px',
       lineHeight: '150%',

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -5,8 +5,8 @@ import Card from '@material-ui/core/Card';
 // Styles for overriding material UI
 // General colors
 //
-export const white = '#ffffff';
-export const black = '#000000';
+export const white = '#fff';
+export const black = '#000';
 export const alertRed = '#d0021b';
 export const checkBlue = '#2e77fc';
 export const checkOrange = '#f2994a';
@@ -149,33 +149,93 @@ export const MuiTheme = {
     },
   },
   typography: {
-    overline: {
-      textTransform: 'uppercase',
-      letterSpacing: '1px',
-      lineHeight: '266%',
-      fontSize: '12px',
-      fontWeight: 400,
-    },
     h1: {
-      letterSpacing: '0.15px',
-      lineHeight: '150%',
-      fontSize: '20px',
-      fontWeight: 500,
-      color: textPrimary,
+      fontSize: '96px',
+      fontWeight: 300,
+      letterSpacing: '-1.5px',
+      lineHeight: '112px',
     },
     h2: {
-      letterSpacing: '0.15px',
-      lineHeight: '150%',
-      fontSize: '16px',
-      fontWeight: 500,
+      fontSize: '60px',
+      fontWeight: 300,
+      letterSpacing: '-0.5px',
+      lineHeight: '72px',
+    },
+    h3: {
+      fontSize: '48px',
+      fontWeight: 400,
+      letterSpacing: '0px',
+      lineHeight: '56px',
+    },
+    h4: {
+      fontSize: '34px',
+      fontWeight: 400,
+      letterSpacing: '0.25px',
+      lineHeight: '42px',
+    },
+    h5: {
       color: 'currentcolor',
+      fontSize: '24px',
+      fontWeight: 400,
+      letterSpacing: '0px',
+      lineHeight: '32px',
+    },
+    h6: {
+      fontSize: '20px',
+      fontWeight: 500,
+      letterSpacing: '0.15px',
+      lineHeight: '32px',
+    },
+    subtitle1: {
+      fontSize: '16px',
+      fontWeight: 400,
+      letterSpacing: '0.15px',
+      lineHeight: '28px',
+    },
+    subtitle2: {
+      fontSize: '15px',
+      fontWeight: 500,
+      letterSpacing: '0.1px',
+      lineHeight: '24px',
+    },
+    body1: {
+      fontSize: '14px',
+      fontWeight: 400,
+      letterSpacing: '0.15px',
+      lineHeight: '20px',
+    },
+    body1Accent: {
+      fontSize: '14px',
+      fontWeight: 600,
+      letterSpacing: '0.15px',
+      lineHeight: '20px',
+    },
+    body2: {
+      fontSize: '12px',
+      fontWeight: 400,
+      letterSpacing: '0.15px',
+      lineHeight: '17px',
     },
     button: {
-      fontWeight: 500,
+      color: 'currentcolor',
       fontSize: '14px',
-      lineHeight: '24px',
+      fontWeight: 500,
       letterSpacing: '0.4px',
+      lineHeight: '24px',
       textTransform: 'none',
+    },
+    caption: {
+      fontSize: '12px',
+      fontWeight: 400,
+      letterSpacing: '0.4px',
+      lineHeight: '20px',
+    },
+    overline: {
+      fontSize: '12px',
+      fontWeight: 400,
+      letterSpacing: '1px',
+      lineHeight: '32px',
+      textTransform: 'uppercase',
     },
   },
   overrides: { // Override of all material UI components. Information at https://material-ui.com/api/{component}


### PR DESCRIPTION
## Description

The Check Design System will be going through some improvements/refinements, one will be to have a better collection of typography. The first step was to include all of the options that come standard with mui. This PR:
- Adds all of the [typography settings that are in Figma](https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Check-Design-System?node-id=3106%3A36342&t=A6erSmK7CLgwy7UT-4), which will be used going forward so there is a 1-1 relationship with the codebase.
- Updates references to the few uses of the typography to a better choice with the current system. For instance, the "old" `h1` was visually more appropriate to be `h6`
- In the future if the typography is adjusted (most likely will happen) in figma, then I will update the references in the codebase again.
- I also just wanted to get a first PR out to be one of the cool kids at Meedan! 

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Since there were only a few changes, I manually inspected the changes

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

