### PR TITLE
Updating warning message displayed on tipline settings page when there is more than 10 menu options

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenu.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMainMenu.json
@@ -32,7 +32,7 @@
   {
     "id": "smoochBotMainMenu.alertTitle",
     "description": "Title of an alert box displayed on tipline main menu settings page when there are more than 10 options.",
-    "defaultMessage": "There are {numberOfOptions} options including all languages. Detailed language options will be sent to users when they select the option 'Languages'."
+    "defaultMessage": "There are {numberOfOptions} options including all languages on this workspace. Only {numberOfLanguages} languages will be sent to users when they select the 'Languages' option."
   },
   {
     "id": "smoochBotMainMenu.languagesAndPrivacy",

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -107,8 +107,8 @@ const SmoochBotMainMenu = ({
           title={
             <FormattedMessage
               id="smoochBotMainMenu.alertTitle"
-              defaultMessage="There are {numberOfOptions} options including all languages. Detailed language options will be sent to users when they select the option 'Languages'."
-              values={{ numberOfOptions: optionsCount }}
+              defaultMessage="There are {numberOfOptions} options including all languages on this workspace. Only {numberOfLanguages} languages will be sent to users when they select the 'Languages' option."
+              values={{ numberOfOptions: optionsCount, numberOfLanguages: (languages.length + 1) }}
               description="Title of an alert box displayed on tipline main menu settings page when there are more than 10 options."
             />
           }


### PR DESCRIPTION
## Description

Updating warning message displayed on tipline settings page when there is more than 10 menu options.

Fixes CV2-2690.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I just verified the message.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

