### PR TITLE
remove stray non mui 4 typography setting

### DIFF
--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -204,12 +204,6 @@ export const MuiTheme = {
       letterSpacing: '0.15px',
       lineHeight: '20px',
     },
-    body1Accent: {
-      fontSize: '14px',
-      fontWeight: 600,
-      letterSpacing: '0.15px',
-      lineHeight: '20px',
-    },
     body2: {
       fontSize: '12px',
       fontWeight: 400,


### PR DESCRIPTION
## Description

When opening a ticket for the PR #1336 I realized I accidentally included a non MUI v4 typography definition, which will not work until v5. This PR just removes the style definition. Since its not used anywhere else in the code there are no other changes

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manual code search, this was a new/unused style so no inpact

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

