### PR TITLE
Add postgres as dependency for Pender, since sqlite removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     volumes:
       - "./pender:/app"
     depends_on:
+      - postgres
       - redis
       - minio
     environment:


### PR DESCRIPTION
## Description

We're now using postgres for Pender instead of Sqlite, in order to match our deployed and development environments. As a result, we now need to declare a dependency on postgres for Pender in any docker compose files that might spin up the container.

This should be merged as soon as possible, since these dependency changes are on Pender develop and check-web integration tests may fail on develop without it.

References: CV2-2668

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I'm honestly not sure how best to test this besides running in CI, because I don't think we use the docker-compose.yml file in check-web anywhere but in CI and the integration test setup is pretty difficult to run locally (I believe our cookbook article doesn't use the check-web docker-compose).

[This branch](https://github.com/meedan/check-web/tree/CV2-2668-upgrade-pender-to-rails-6-1-and-ruby-3-0) is intended to run those integration tests (has a copy of this commit on it), but integration tests are backed up right now due to some tunneling issues.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)