### PR TITLE
Match colors in codebase to Figma design system [CV2-2801]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11790,7 +11790,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -15064,7 +15064,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11790,7 +11790,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -15064,7 +15064,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:browsers:parallel": "cd test && PARALLEL_SPLIT_TEST_PROCESSES=2 parallel_split_test spec/browser_spec.rb && cd ..",
     "test:ff": "cd test && bundle exec rspec --fail-fast && cd ..",
     "test:bins": "grep -rI 'bin[0-9]' test/spec | grep -v '#' | sed 's/.*\\(bin[0-9]\\).*/\\1/g' | sort | uniq -c",
-    "linter": "",
+    "linter": "eslint --cache --max-warnings=0 src/app",
     "test:integration:lint": "cd test/spec && bundle install && bundle exec rubocop && cd ..",
     "tests": "cd test && ./run-tests.sh"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:browsers:parallel": "cd test && PARALLEL_SPLIT_TEST_PROCESSES=2 parallel_split_test spec/browser_spec.rb && cd ..",
     "test:ff": "cd test && bundle exec rspec --fail-fast && cd ..",
     "test:bins": "grep -rI 'bin[0-9]' test/spec | grep -v '#' | sed 's/.*\\(bin[0-9]\\).*/\\1/g' | sort | uniq -c",
-    "linter": "eslint --cache --max-warnings=0 src/app",
+    "linter": "",
     "test:integration:lint": "cd test/spec && bundle install && bundle exec rubocop && cd ..",
     "tests": "cd test && ./run-tests.sh"
   },

--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -10,13 +10,13 @@ import {
   ContentColumn,
   units,
   black54,
-  white,
+  otherWhite,
 } from '../styles/js/shared';
 
 const Message = styled.div`
   padding: ${units(1)};
   color: ${black54};
-  background-color: ${white};
+  background-color: ${otherWhite};
   > div {
     display: flex;
     align-items: center;

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -9,7 +9,7 @@ import reactStringReplace from 'react-string-replace';
 import Message from './Message';
 import { withClientSessionId } from '../ClientSessionId';
 import { safelyParseJSON, createFriendlyErrorMessage } from '../helpers';
-import { checkBlue, white, black54 } from '../styles/js/shared';
+import { brandMain, otherWhite, black54 } from '../styles/js/shared';
 
 /**
  * A global message, already translated for the user.
@@ -68,7 +68,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
 
 const useSnackBarStyles = makeStyles({
   info: {
-    backgroundColor: `${checkBlue} !important`,
+    backgroundColor: `${brandMain} !important`,
   },
   icon: {
     color: 'white !important',
@@ -83,7 +83,7 @@ const useSnackBarStyles = makeStyles({
       alignItems: 'flex-start',
     },
     '& a': {
-      color: white,
+      color: otherWhite,
       textDecoration: 'underline',
       cursor: 'pointer',
       '&:not([href])': {
@@ -94,7 +94,7 @@ const useSnackBarStyles = makeStyles({
         textDecoration: 'underline',
       },
       '&:visited': {
-        color: white,
+        color: otherWhite,
       },
       '&:hover': {
         color: black54,
@@ -147,10 +147,10 @@ const useStyles = makeStyles({
     zIndex: '1000',
   },
   link: {
-    color: white,
+    color: otherWhite,
     textDecoration: 'underline',
     '&:visited': {
-      color: white,
+      color: otherWhite,
     },
   },
 });

--- a/src/app/components/Header.js
+++ b/src/app/components/Header.js
@@ -11,11 +11,11 @@ import {
   mediaQuery,
   headerHeight,
   Row,
-  brandSecondary,
+  brandBackground,
 } from '../styles/js/shared';
 
 const HeaderBar = styled.div`
-  background-color: ${brandSecondary};
+  background-color: ${brandBackground};
   display: flex;
   align-items: center;
   padding: 0 ${units(2)};

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -20,7 +20,7 @@ import {
   black54,
   StyledSubHeader,
   StyledCard,
-  checkBlue,
+  brandMain,
 } from '../styles/js/shared';
 
 const styles = {
@@ -218,7 +218,7 @@ class Login extends React.Component {
             <Message
               message={this.state.message}
               style={this.state.registrationSubmitted ? {
-                backgroundColor: checkBlue,
+                backgroundColor: brandMain,
               } : null}
             />
             {this.state.registrationSubmitted ?

--- a/src/app/components/Message.js
+++ b/src/app/components/Message.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
-  white,
+  otherWhite,
   black54,
   gutterSmall,
   gutterMedium,
@@ -14,14 +14,14 @@ import {
 const StyledMessage = styled(FadeIn)`
   background: ${black54};
   border-radius: ${defaultBorderRadius};
-  color: ${white};
+  color: ${otherWhite};
   margin: ${gutterMedium} auto;
   padding: ${gutterSmall} ${gutterLarge};
   position: relative;
   text-align: center;
 
   a {
-    color: ${white} !important;
+    color: ${otherWhite} !important;
     text-decoration: underline;
   }
 `;

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -41,12 +41,12 @@ import { stringHelper } from '../../customHelpers';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 import {
   units,
-  white,
+  otherWhite,
   opaqueBlack16,
   black38,
   black54,
   black87,
-  checkBlue,
+  brandMain,
   borderWidthLarge,
   caption,
   breakWordStyles,
@@ -126,7 +126,7 @@ const StyledAnnotationWrapper = styled.section`
       border-radius: 100%;
       content: '';
       height: ${units(1)};
-      outline: ${dotSize} solid ${white};
+      outline: ${dotSize} solid ${otherWhite};
       position: absolute;
       top: ${units(2)};
       width: ${units(1)};
@@ -140,7 +140,7 @@ const StyledAnnotationWrapper = styled.section`
   }
 
   .annotation__card-activity-move-to-trash {
-    background: ${checkBlue};
+    background: ${brandMain};
     color: #fff;
     border-radius: ${defaultBorderRadius};
 

--- a/src/app/components/annotations/Comment.js
+++ b/src/app/components/annotations/Comment.js
@@ -34,9 +34,9 @@ import {
   black87,
   caption,
   breakWordStyles,
-  separationGray,
+  grayBorderMain,
   Row,
-  checkBlue,
+  brandMain,
 } from '../../styles/js/shared';
 
 const StyledAnnotationCardWrapper = styled.div`
@@ -232,7 +232,7 @@ class Comment extends Component {
                 href={commentContent.file_path}
                 target="_blank"
                 rel="noreferrer noopener"
-                color={checkBlue}
+                color={brandMain}
                 className="annotation__card-file"
               >
                 {commentContent.file_name}
@@ -250,7 +250,7 @@ class Comment extends Component {
         <StyledAnnotationCardWrapper>
           <Box
             py={2}
-            borderBottom={`1px ${separationGray} solid`}
+            borderBottom={`1px ${grayBorderMain} solid`}
             className="annotation__card-text annotation__card-activity-comment"
           >
             { authorName ?

--- a/src/app/components/cds/alerts-and-prompts/SuccessAlert.js
+++ b/src/app/components/cds/alerts-and-prompts/SuccessAlert.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CheckCircleOutlineOutlinedIcon from '@material-ui/icons/CheckCircleOutlineOutlined';
 import {
-  validationLightCDS,
-  validationSecondaryCDS,
+  validationLight,
+  validationSecondary,
 } from '../../../styles/js/shared';
 import Alert from './Alert';
 
@@ -11,9 +11,9 @@ const SuccessAlert = ({ title, content }) => (
   <Alert
     title={title}
     content={content}
-    primaryColor={validationLightCDS}
-    secondaryColor={validationSecondaryCDS}
-    icon={<CheckCircleOutlineOutlinedIcon style={{ color: validationSecondaryCDS }} />}
+    primaryColor={validationLight}
+    secondaryColor={validationSecondary}
+    icon={<CheckCircleOutlineOutlinedIcon style={{ color: validationSecondary }} />}
   />
 );
 

--- a/src/app/components/cds/alerts-and-prompts/WarningAlert.js
+++ b/src/app/components/cds/alerts-and-prompts/WarningAlert.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import {
-  alertLightCDS,
-  alertSecondaryCDS,
-  alertMainCDS,
+  alertLight,
+  alertSecondary,
+  alertMain,
 } from '../../../styles/js/shared';
 import Alert from './Alert';
 
@@ -12,9 +12,9 @@ const WarningAlert = ({ title, content }) => (
   <Alert
     title={title}
     content={content}
-    primaryColor={alertLightCDS}
-    secondaryColor={alertSecondaryCDS}
-    icon={<ErrorOutlineIcon style={{ color: alertMainCDS }} />}
+    primaryColor={alertLight}
+    secondaryColor={alertSecondary}
+    icon={<ErrorOutlineIcon style={{ color: alertMain }} />}
   />
 );
 

--- a/src/app/components/cds/buttons-checkboxes-chips/CounterButton.js
+++ b/src/app/components/cds/buttons-checkboxes-chips/CounterButton.js
@@ -6,8 +6,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import {
-  brandSecondaryCDS,
-  brandMainCDS,
+  brandSecondary,
+  brandMain,
   textPrimary,
 } from '../../../styles/js/shared';
 
@@ -16,18 +16,18 @@ const useStyles = makeStyles({
     display: 'block',
     padding: '0 8px',
     '&:hover': {
-      color: brandSecondaryCDS,
+      color: brandSecondary,
       backgroundColor: 'inherit',
     },
     '&:active': {
-      color: brandMainCDS,
+      color: brandMain,
     },
   },
   zeroCount: {
     color: textPrimary,
   },
   moreThanZeroCount: {
-    color: brandMainCDS,
+    color: brandMain,
   },
 });
 

--- a/src/app/components/cds/buttons-checkboxes-chips/MainButton.js
+++ b/src/app/components/cds/buttons-checkboxes-chips/MainButton.js
@@ -6,8 +6,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import {
-  brandSecondaryCDS,
-  brandMainCDS,
+  brandSecondary,
+  brandMain,
 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
@@ -16,11 +16,11 @@ const useStyles = makeStyles(theme => ({
     marginRight: theme.spacing(2),
     borderRadius: theme.spacing(1),
     '&:hover': {
-      color: brandSecondaryCDS,
+      color: brandSecondary,
       backgroundColor: 'inherit',
     },
     '&:active': {
-      color: brandMainCDS,
+      color: brandMain,
     },
   },
 }));

--- a/src/app/components/cds/media-cards/MediaCardCondensed.js
+++ b/src/app/components/cds/media-cards/MediaCardCondensed.js
@@ -7,12 +7,12 @@ import {
 import ExternalLink from '../../ExternalLink';
 import ParsedText from '../../ParsedText';
 import BulletSeparator from '../../layout/BulletSeparator';
-import { brandSecondary } from '../../../styles/js/shared';
+import { brandBorder } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: 8,
     color: 'black',
     backgroundColor: 'white',
@@ -32,7 +32,7 @@ const useStyles = makeStyles(theme => ({
     height: 96,
     width: 96,
     objectFit: 'cover',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     marginRight: theme.spacing(1.5),
     alignSelf: 'center',
   },

--- a/src/app/components/cds/requests-annotations/Request.js
+++ b/src/app/components/cds/requests-annotations/Request.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import ParsedText from '../../ParsedText';
 import BulletSeparator from '../../layout/BulletSeparator';
-import { separationGray } from '../../../styles/js/shared';
+import { grayBorderMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
-    borderBottom: `1px ${separationGray} solid`,
+    borderBottom: `1px ${grayBorderMain} solid`,
     padding: `${theme.spacing(3)}px ${theme.spacing(1)}px`,
   },
   name: {

--- a/src/app/components/cds/settings-pages/TiplineContentTranslation.js
+++ b/src/app/components/cds/settings-pages/TiplineContentTranslation.js
@@ -8,11 +8,11 @@ import {
   TextField,
 } from '@material-ui/core';
 import {
-  brandBackgroundCDS,
-  grayBorderCDS,
+  brandBackground,
+  grayBorderMain,
   textPrimary,
   textSecondary,
-  otherErrorMainCDS,
+  errorMain,
 } from '../../../styles/js/shared';
 
 const StyledTextField = withStyles({
@@ -22,25 +22,25 @@ const StyledTextField = withStyles({
       opacity: 1,
     },
     '& .MuiFormHelperText-root.Mui-error': {
-      color: otherErrorMainCDS,
+      color: errorMain,
       marginLeft: 0,
       fontSize: 12,
       fontWeight: 400,
     },
     '& .MuiOutlinedInput-root': {
       '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-        borderColor: otherErrorMainCDS,
+        borderColor: errorMain,
       },
       '& fieldset': {
-        borderColor: grayBorderCDS,
+        borderColor: grayBorderMain,
         borderWidth: 1,
       },
       '&:hover fieldset': {
-        borderColor: grayBorderCDS,
+        borderColor: grayBorderMain,
         borderWidth: 1,
       },
       '&.Mui-focused fieldset': {
-        borderColor: grayBorderCDS,
+        borderColor: grayBorderMain,
         borderWidth: 1,
       },
     },
@@ -61,9 +61,9 @@ const useStyles = makeStyles(theme => ({
   defaultString: {
     borderTopLeftRadius: theme.spacing(1),
     borderTopRightRadius: theme.spacing(1),
-    border: `1px solid ${grayBorderCDS}`,
+    border: `1px solid ${grayBorderMain}`,
     borderBottom: 0,
-    background: brandBackgroundCDS,
+    background: brandBackground,
     padding: '12px 10px',
   },
   // FIXME: Once Typography is implemented according to specs from the design system, this custom style can be removed

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -30,7 +30,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import ProjectsListItem from './ProjectsListItem';
 import NewProject from './NewProject';
 import Can from '../../Can';
-import { brandSecondary } from '../../../styles/js/shared';
+import { brandLight } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const useStyles = makeStyles(theme => ({
@@ -45,7 +45,7 @@ const useStyles = makeStyles(theme => ({
     minWidth: 0,
   },
   projectsComponentCollectionExpanded: {
-    background: brandSecondary,
+    background: brandLight,
   },
   projectsComponentNestedList: {
     paddingLeft: theme.spacing(3),

--- a/src/app/components/drawer/Projects/ProjectsListItem.js
+++ b/src/app/components/drawer/Projects/ProjectsListItem.js
@@ -9,7 +9,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import RootRef from '@material-ui/core/RootRef';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
-import { brandSecondary } from '../../../styles/js/shared';
+import { brandLight } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   projectsListItemLabel: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
     textOverflow: 'ellipsis',
   },
   projectsListItemActive: {
-    background: brandSecondary,
+    background: brandLight,
   },
   projectsListItemActiveText: {
     fontWeight: 'bold',

--- a/src/app/components/feed/FeedClusterPage.js
+++ b/src/app/components/feed/FeedClusterPage.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import FeedRequestedMedia from './FeedRequestedMedia';
 import RequestCards from './RequestCards';
 import ErrorBoundary from '../error/ErrorBoundary';
-import { Column, backgroundMain, separationGray } from '../../styles/js/shared';
+import { Column, brandBackground, grayBorderMain } from '../../styles/js/shared';
 
 const StyledTwoColumnLayout = styled.div`
   display: flex;
@@ -14,11 +14,11 @@ const StyledTwoColumnLayout = styled.div`
   max-width: 100vw;
 
   .media__column {
-    background-color: ${backgroundMain};
+    background-color: ${brandBackground};
   }
 
   .requests__column {
-    border-left: 1px solid ${separationGray};
+    border-left: 1px solid ${grayBorderMain};
   }
 `;
 

--- a/src/app/components/feed/FeedFilters.js
+++ b/src/app/components/feed/FeedFilters.js
@@ -17,7 +17,7 @@ import NumericRangeFilter from '../search/NumericRangeFilter';
 import DateRangeFilter from '../search/DateRangeFilter';
 import MultiSelectFilter from '../search/MultiSelectFilter';
 import { withSetFlashMessage } from '../FlashMessage';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   flex: {
@@ -25,7 +25,7 @@ const useStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
   },
   saveButton: {
-    color: checkBlue,
+    color: brandMain,
   },
 }));
 

--- a/src/app/components/feed/FeedItemComponent.js
+++ b/src/app/components/feed/FeedItemComponent.js
@@ -36,6 +36,7 @@ import { parseStringUnixTimestamp, getStatus } from '../../helpers';
 import TimeBefore from '../TimeBefore';
 import {
   brandBackground,
+  brandBorder,
   brandSecondary,
   brandMain,
   opaqueBlack54,
@@ -52,14 +53,14 @@ const useStyles = makeStyles(theme => ({
   },
   claimsColumn: {
     backgroundColor: 'white',
-    borderRight: `1px solid ${brandSecondary}`,
+    borderRight: `1px solid ${brandBorder}`,
     width: 360,
     minWidth: 360,
     maxWidth: 360,
   },
   middleColumn: {
     backgroundColor: 'white',
-    borderRight: `1px solid ${brandSecondary}`,
+    borderRight: `1px solid ${brandBorder}`,
   },
   mediasColumn: {
     width: 590,
@@ -73,13 +74,13 @@ const useStyles = makeStyles(theme => ({
     height: 80,
     width: 80,
     objectFit: 'cover',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     float: 'left',
     marginRight: theme.spacing(1),
   },
   cardMain: {
     boxShadow: 'none',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(1),
     marginBottom: theme.spacing(1),
     padding: theme.spacing(2),
@@ -87,7 +88,7 @@ const useStyles = makeStyles(theme => ({
   },
   cardDetail: {
     boxShadow: 'none',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(1),
     marginBottom: theme.spacing(1),
     padding: theme.spacing(2),

--- a/src/app/components/feed/FeedItemComponent.js
+++ b/src/app/components/feed/FeedItemComponent.js
@@ -35,9 +35,9 @@ import NextPreviousLinks from '../media/NextPreviousLinks';
 import { parseStringUnixTimestamp, getStatus } from '../../helpers';
 import TimeBefore from '../TimeBefore';
 import {
-  backgroundMain,
+  brandBackground,
   brandSecondary,
-  checkBlue,
+  brandMain,
   opaqueBlack54,
   opaqueBlack38,
   Column,
@@ -48,7 +48,7 @@ import { withSetFlashMessage } from '../FlashMessage';
 const defaultImage = '/images/image_placeholder.svg';
 const useStyles = makeStyles(theme => ({
   main: {
-    backgroundColor: backgroundMain,
+    backgroundColor: brandBackground,
   },
   claimsColumn: {
     backgroundColor: 'white',
@@ -155,7 +155,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(2),
   },
   teamName: {
-    color: checkBlue,
+    color: brandMain,
   },
   boxes: {
     gap: `${theme.spacing(1)}px`,

--- a/src/app/components/feed/FeedRequestedMediaDialog.js
+++ b/src/app/components/feed/FeedRequestedMediaDialog.js
@@ -15,7 +15,7 @@ import { ImportButton } from './ImportDialog';
 import MediaCard from './MediaCard';
 import RequestCards from './RequestCards';
 import MediaTypeDisplayName from '../media/MediaTypeDisplayName';
-import { separationGray, textPrimary } from '../../styles/js/shared';
+import { grayBorderMain, textPrimary } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   column: {
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     minHeight: '500px',
   },
   dialogTitle: {
-    borderBottom: `1px solid ${separationGray}`,
+    borderBottom: `1px solid ${grayBorderMain}`,
   },
 }));
 

--- a/src/app/components/feed/MediaCard.js
+++ b/src/app/components/feed/MediaCard.js
@@ -6,12 +6,12 @@ import MediaPreview from './MediaPreview';
 import ExternalLink from '../ExternalLink';
 import ParsedText from '../ParsedText';
 import BulletSeparator from '../layout/BulletSeparator';
-import { brandSecondary } from '../../styles/js/shared';
+import { brandBorder } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: 8,
     backgroundColor: 'white',
     marginBottom: theme.spacing(1),

--- a/src/app/components/feed/MediaCardCondensed.js
+++ b/src/app/components/feed/MediaCardCondensed.js
@@ -9,7 +9,7 @@ import FeedRequestedMediaDialog from './FeedRequestedMediaDialog';
 import ExternalLink from '../ExternalLink';
 import ParsedText from '../ParsedText';
 import BulletSeparator from '../layout/BulletSeparator';
-import { brandSecondary } from '../../styles/js/shared';
+import { brandBorder } from '../../styles/js/shared';
 
 // Modelled after src/app/components/media/Similarity/MediaItem.js
 
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
   root: {
     cursor: 'pointer',
     width: '100%',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: 8,
     color: 'black',
     backgroundColor: 'white',
@@ -31,7 +31,7 @@ const useStyles = makeStyles(theme => ({
     height: 96,
     width: 96,
     objectFit: 'cover',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     marginRight: theme.spacing(1.5),
   },
   text: {

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
-import { opaqueBlack87, black32, checkBlue, opaqueBlack38, units, white } from '../../styles/js/shared.js';
+import { opaqueBlack87, black32, brandMain, opaqueBlack38, units, otherWhite } from '../../styles/js/shared.js';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
     backgroundColor: props.contentWarning ? opaqueBlack87 : 'transparent',
     zIndex: 100,
-    color: 'white',
+    color: otherWhite,
   }),
   icon: props => ({
     fontSize: '40px',
@@ -57,9 +57,9 @@ const useStyles = makeStyles(theme => ({
   button: props => ({
     pointerEvents: 'auto',
     bottom: 0,
-    color: 'white',
+    color: otherWhite,
     minWidth: theme.spacing(22),
-    backgroundColor: props.contentWarning ? 'black' : checkBlue,
+    backgroundColor: props.contentWarning ? 'black' : brandMain,
     border: '2px solid white',
     '& :hover': {
       backgroundColor: 'unset',
@@ -102,7 +102,7 @@ const AspectRatioComponent = ({
           <IconButton
             onClick={onClickExpand}
             style={{
-              color: white,
+              color: otherWhite,
               backgroundColor: black32,
               position: 'absolute',
               right: '0',

--- a/src/app/components/layout/SpecialBlueCard.js
+++ b/src/app/components/layout/SpecialBlueCard.js
@@ -5,8 +5,8 @@ import CardContent from '@material-ui/core/CardContent';
 import { encodeSvgDataUri } from '../../helpers';
 
 import {
-  checkBlue,
-  white,
+  brandMain,
+  otherWhite,
   title1,
   units,
   breakpointMobile,
@@ -22,7 +22,7 @@ const StyledCardIcon = styled.div`
 `;
 
 const StyledMdCard = styled(Card)`
-  background-color: ${checkBlue} !important;
+  background-color: ${brandMain} !important;
   ${props => props.svg ? `background-image: url("${encodeSvgDataUri(props.svg)}");` : null}
   background-repeat: no-repeat;
   background-size: auto;
@@ -35,7 +35,7 @@ const StyledMdCard = styled(Card)`
   margin-bottom: ${units(2)};
   padding-top: 0;
   span, p, a, svg {
-    color: ${white} !important;
+    color: ${otherWhite} !important;
   }
 `;
 
@@ -45,7 +45,7 @@ const BackgroundImageRow = styled.div`
 
 const StyledMdCardTitle = styled.h2`
   font: ${title1};
-  color: ${white};
+  color: ${otherWhite};
   margin-bottom: ${units(1)};
 `;
 

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -18,8 +18,8 @@ import CheckContext from '../../CheckContext';
 
 import {
   units,
-  brandSecondary,
-  brandBackground,
+  brandBorder,
+  grayBackground,
   Column,
 } from '../../styles/js/shared';
 
@@ -30,7 +30,7 @@ const StyledThreeColumnLayout = styled.div`
 
   /* Middle column */
   .media__column {
-    background-color: ${brandBackground};
+    background-color: ${grayBackground};
   }
 
   /* Middle column */
@@ -46,7 +46,8 @@ const StyledThreeColumnLayout = styled.div`
 
   /* Right Column */
   .media__annotations-column {
-    border-left: 2px solid ${brandSecondary};
+    border-left: 1px solid ${brandBorder};
+    border-top: 1px solid ${brandBorder};
     padding-top: 0;
     padding-left: 0;
     padding-right: 0;
@@ -55,7 +56,7 @@ const StyledThreeColumnLayout = styled.div`
     /* Container of tabs */
     .media__annotations-tabs {
       background-color: white;
-      border-bottom: 1px solid ${brandSecondary};
+      border-bottom: 1px solid ${brandBorder};
       padding-top: ${units(0.5)};
     }
   }
@@ -65,7 +66,8 @@ const AnalysisColumn = styled.div`
   width: 420px;
   flex-grow: 0;
   padding: 0 ${units(2)} ${units(2)} ${units(2)};
-  border-right: 1px solid ${brandSecondary};
+  border-right: 1px solid ${brandBorder};
+  border-top: 1px solid ${brandBorder};
   max-height: calc(100vh - 64px);
   overflow-y: auto;
 `;

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -19,7 +19,7 @@ import CheckContext from '../../CheckContext';
 import {
   units,
   brandSecondary,
-  backgroundMain,
+  brandBackground,
   Column,
 } from '../../styles/js/shared';
 
@@ -30,7 +30,7 @@ const StyledThreeColumnLayout = styled.div`
 
   /* Middle column */
   .media__column {
-    background-color: ${backgroundMain};
+    background-color: ${brandBackground};
   }
 
   /* Middle column */

--- a/src/app/components/media/MediaDetail.js
+++ b/src/app/components/media/MediaDetail.js
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import MediaExpanded from './MediaExpanded';
 
 import {
-  brandSecondary,
+  brandBorder,
 } from '../../styles/js/shared';
 
 const StyledMainCard = styled.div`
   .media-detail {
     box-shadow: none;
-    border: 1px solid ${brandSecondary};
+    border: 1px solid ${brandBorder};
     border-radius: 8px;
   }
 `;

--- a/src/app/components/media/MediaExpandedArchives.js
+++ b/src/app/components/media/MediaExpandedArchives.js
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import ExternalLink from '../ExternalLink';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles({
   url: {
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
         TODO define with Pierre if all links are to be blue
         and style accordingly on the app theme instead of locally
       */
-      color: checkBlue,
+      color: brandMain,
       textDecoration: 'underline',
     },
   },

--- a/src/app/components/media/MediaExpandedUrl.js
+++ b/src/app/components/media/MediaExpandedUrl.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import ExternalLink from '../ExternalLink';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
         TODO define with Pierre if all links are to be blue
         and style accordingly on the app theme instead of locally
       */
-      color: checkBlue,
+      color: brandMain,
       textDecoration: 'underline',
     },
   },

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -17,7 +17,7 @@ import {
   black87,
   black54,
   units,
-  brandSecondary,
+  brandBorder,
 } from '../../styles/js/shared';
 
 const StyledAnnotationRow = styled.div`
@@ -26,7 +26,7 @@ const StyledAnnotationRow = styled.div`
   .annotation-header-row {
     padding: ${units(1)} ${units(3)};
     margin: 0;
-    border-bottom: 1px solid ${brandSecondary};
+    border-bottom: 1px solid ${brandBorder};
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/app/components/media/MediasLoading.js
+++ b/src/app/components/media/MediasLoading.js
@@ -8,7 +8,7 @@ import {
   black05,
   borderWidthSmall,
   defaultBorderRadius,
-  white,
+  otherWhite,
 } from '../../styles/js/shared';
 
 const gridUnit = units(1.5);
@@ -28,7 +28,7 @@ const StyledLoadingInner = styled(ContentColumn)`
 `;
 
 const StyledLoadingCard = styled.div`
-  background: ${white};
+  background: ${otherWhite};
   border: ${borderWidthSmall} solid ${black05};
   border-radius: ${defaultBorderRadius};
   margin: ${gridUnit} 0;

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
@@ -19,7 +19,7 @@ import {
 } from './reportDesignerHelpers';
 import { getStatus, getStatusStyle, safelyParseJSON } from '../../../helpers';
 import { stringHelper } from '../../../customHelpers';
-import { checkBlue, backgroundMain } from '../../../styles/js/shared';
+import { brandMain, brandBackground } from '../../../styles/js/shared';
 import CreateReportDesignMutation from '../../../relay/mutations/CreateReportDesignMutation';
 import UpdateReportDesignMutation from '../../../relay/mutations/UpdateReportDesignMutation';
 import CheckArchivedFlags from '../../../CheckArchivedFlags';
@@ -30,7 +30,7 @@ const useStyles = makeStyles(theme => ({
     height: 'calc(100vh - 60px)',
     overflow: 'auto',
     padding: theme.spacing(2),
-    backgroundColor: backgroundMain,
+    backgroundColor: brandBackground,
   },
   preview: {
     borderRight: '1px solid #DFE4F4',
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   helpIcon: {
-    color: checkBlue,
+    color: brandMain,
   },
 }));
 

--- a/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
@@ -9,7 +9,7 @@ import WarningIcon from '@material-ui/icons/Warning';
 import ParsedText from '../../ParsedText';
 import ReportDesignerImagePreview from './ReportDesignerImagePreview';
 import { formatDate } from './reportDesignerHelpers';
-import { alertRed, opaqueBlack87 } from '../../../styles/js/shared';
+import { errorMain, opaqueBlack87 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
   },
   icon: {
     fontSize: '80px',
-    color: alertRed,
+    color: errorMain,
   },
 }));
 

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
@@ -15,17 +15,17 @@ import IconPause from '@material-ui/icons/Pause';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import ReportDesignerConfirmableButton from './ReportDesignerConfirmableButton';
 import MediaStatus from '../MediaStatus';
-import { completedGreen, inProgressYellow, brandSecondary, checkBlue } from '../../../styles/js/shared';
+import { validationMain, alertMain, brandSecondary, brandMain } from '../../../styles/js/shared';
 import { getStatus } from '../../../helpers';
 import { languageLabel } from '../../../LanguageRegistry';
 
 const useStyles = makeStyles(theme => ({
   publish: {
-    background: completedGreen,
+    background: validationMain,
     color: 'white',
   },
   pause: {
-    background: inProgressYellow,
+    background: alertMain,
     color: 'white',
   },
   confirmation: {
@@ -41,9 +41,9 @@ const useStyles = makeStyles(theme => ({
   correctionLink: {
     display: 'inline-flex',
     gap: `${theme.spacing(0.5)}px`,
-    color: checkBlue,
+    color: brandMain,
     '&:visited': {
-      color: checkBlue,
+      color: brandMain,
     },
     '&:hover': {
       textDecoration: 'none',

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -11,7 +11,7 @@ import LayersIcon from '@material-ui/icons/Layers';
 import TimeBefore from '../../TimeBefore';
 import MediaTypeDisplayName from '../MediaTypeDisplayName';
 import { parseStringUnixTimestamp, truncateLength } from '../../../helpers';
-import { brandSecondary, checkBlue, inProgressYellow, black32 } from '../../../styles/js/shared';
+import { brandSecondary, brandMain, alertMain, black32 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -79,16 +79,16 @@ const useStyles = makeStyles(theme => ({
     textOverflow: 'ellipsis',
   },
   reportPublished: {
-    color: checkBlue,
+    color: brandMain,
   },
   reportPaused: {
-    color: inProgressYellow,
+    color: alertMain,
   },
   reportUnpublished: {
     color: black32,
   },
   by: {
-    color: checkBlue,
+    color: brandMain,
   },
 }));
 

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -11,11 +11,11 @@ import LayersIcon from '@material-ui/icons/Layers';
 import TimeBefore from '../../TimeBefore';
 import MediaTypeDisplayName from '../MediaTypeDisplayName';
 import { parseStringUnixTimestamp, truncateLength } from '../../../helpers';
-import { brandSecondary, brandMain, alertMain, black32 } from '../../../styles/js/shared';
+import { brandSecondary, brandBorder, brandMain, alertMain, black32 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: 8,
     color: 'black',
     marginBottom: theme.spacing(1),
@@ -52,7 +52,7 @@ const useStyles = makeStyles(theme => ({
     height: 80,
     width: 80,
     objectFit: 'cover',
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
   },
   sep: {
     marginLeft: theme.spacing(0.5),

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import MediaRelationship from './MediaRelationship';
 import MediaItem from './MediaItem'; // eslint-disable-line no-unused-vars
 import { can } from '../../Can';
-import { brandLightCDS } from '../../../styles/js/shared';
+import { brandLight } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     top: -theme.spacing(2.5),
     left: -theme.spacing(2),
     opacity: 0,
-    background: brandLightCDS,
+    background: brandLight,
     height: 0,
     width: `calc(100% + ${theme.spacing(4)}px)`,
     display: 'block',

--- a/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Box } from '@material-ui/core';
 import {
   brandSecondary,
-  backgroundMain,
+  brandBackground,
 } from '../../../styles/js/shared';
 import MediaSimilarityBarAdd from './MediaSimilarityBarAdd';
 import CounterButton from '../../cds/buttons-checkboxes-chips/CounterButton';
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
     borderBottom: `1px solid ${brandSecondary}`,
     position: 'sticky',
     top: theme.spacing(-2),
-    background: backgroundMain,
+    background: brandBackground,
     zIndex: 200,
   },
   spacing: {

--- a/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
@@ -4,8 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box } from '@material-ui/core';
 import {
-  brandSecondary,
-  brandBackground,
+  brandBorder,
+  grayBackground,
 } from '../../../styles/js/shared';
 import MediaSimilarityBarAdd from './MediaSimilarityBarAdd';
 import CounterButton from '../../cds/buttons-checkboxes-chips/CounterButton';
@@ -15,10 +15,11 @@ const useStyles = makeStyles(theme => ({
     padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
     margin: theme.spacing(-2),
     marginBottom: theme.spacing(2),
-    borderBottom: `1px solid ${brandSecondary}`,
+    borderBottom: `1px solid ${brandBorder}`,
+    borderTop: `1px solid ${brandBorder}`,
     position: 'sticky',
     top: theme.spacing(-2),
-    background: brandBackground,
+    background: grayBackground,
     zIndex: 200,
   },
   spacing: {

--- a/src/app/components/media/Similarity/MediaSuggestionReview.js
+++ b/src/app/components/media/Similarity/MediaSuggestionReview.js
@@ -19,8 +19,8 @@ import {
 } from '@material-ui/icons';
 import {
   brandSecondary,
-  completedGreen,
-  alertRed,
+  validationMain,
+  errorMain,
 } from '../../../styles/js/shared.js';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 import GenericUnknownErrorMessage from '../../GenericUnknownErrorMessage';
@@ -47,11 +47,11 @@ const useStyles = makeStyles(theme => ({
     float: 'right',
   },
   accept: {
-    color: completedGreen,
+    color: validationMain,
     padding: '4px',
   },
   reject: {
-    color: alertRed,
+    color: errorMain,
     padding: '4px',
   },
 }));

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -41,7 +41,7 @@ import {
   brandMain,
   validationMain,
   errorMain,
-  brandSecondary,
+  brandBorder,
   black54,
   brandBackground,
 } from '../../../styles/js/shared';
@@ -88,7 +88,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(0.5),
   },
   media: {
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: 8,
     color: 'black',
     backgroundColor: 'white',
@@ -108,7 +108,7 @@ const useStyles = makeStyles(theme => ({
     color: black54,
   },
   suggestionsNoMediaBox: {
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(1),
     paddingTop: theme.spacing(5),
     paddingBottom: theme.spacing(5),
@@ -118,7 +118,7 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'right',
   },
   card: {
-    border: `1px solid ${brandSecondary}`,
+    border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(2),
     color: 'black',
     backgroundColor: 'white',

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -38,18 +38,18 @@ import globalStrings from '../../../globalStrings';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 import {
   Column,
-  checkBlue,
-  completedGreen,
-  alertRed,
+  brandMain,
+  validationMain,
+  errorMain,
   brandSecondary,
   black54,
-  brandBackgroundCDS,
+  brandBackground,
 } from '../../../styles/js/shared';
 import BulkArchiveProjectMediaMutation from '../../../relay/mutations/BulkArchiveProjectMediaMutation';
 
 const useStyles = makeStyles(theme => ({
   containerBox: {
-    backgroundColor: brandBackgroundCDS,
+    backgroundColor: brandBackground,
     borderRadius: theme.spacing(2),
     position: 'relative',
   },
@@ -71,17 +71,17 @@ const useStyles = makeStyles(theme => ({
     right: 0,
   },
   helpIcon: {
-    color: checkBlue,
+    color: brandMain,
   },
   disabled: {
     opacity: 0.5,
   },
   accept: {
-    color: completedGreen,
+    color: validationMain,
     padding: theme.spacing(0.5),
   },
   reject: {
-    color: alertRed,
+    color: errorMain,
     padding: theme.spacing(0.5),
   },
   spamTrash: {

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -5,7 +5,7 @@ import { DatePicker } from '@material-ui/pickers';
 import InputBase from '@material-ui/core/InputBase';
 import { withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
-import { FlexRow, units, opaqueBlack07, checkBlue } from '../../styles/js/shared';
+import { FlexRow, units, opaqueBlack07, brandMain } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -30,7 +30,7 @@ const StyledInputBaseDate = withStyles(theme => ({
 
 const Styles = {
   dateRangeFilterSelected: {
-    backgroundColor: checkBlue,
+    backgroundColor: brandMain,
     color: 'white',
     height: 24,
     margin: '6px 3px',

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -13,7 +13,7 @@ import { withStyles } from '@material-ui/core/styles';
 import DateRangeIcon from '@material-ui/icons/DateRange';
 import CloseIcon from '@material-ui/icons/Close';
 import RemoveableWrapper from './RemoveableWrapper';
-import { FlexRow, units, opaqueBlack07, checkBlue } from '../../styles/js/shared';
+import { FlexRow, units, opaqueBlack07, brandMain } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -54,11 +54,11 @@ const StyledInputBaseDropdown = withStyles(theme => ({
     },
   },
   input: {
-    backgroundColor: checkBlue,
+    backgroundColor: brandMain,
     color: 'white',
     paddingLeft: theme.spacing(1),
     '&:focus': {
-      backgroundColor: checkBlue,
+      backgroundColor: brandMain,
       borderRadius: 4,
     },
     padding: '4px 0 4px',
@@ -73,7 +73,7 @@ const Styles = {
     padding: '0 4px 0 0',
   },
   dateRangeFilterSelected: {
-    backgroundColor: checkBlue,
+    backgroundColor: brandMain,
     color: 'white',
     height: 'auto',
     borderRadius: 4,

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -11,7 +11,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { MultiSelector } from '@meedan/check-ui';
 import RemoveableWrapper from './RemoveableWrapper';
 import SelectButton from './SelectButton';
-import { checkBlue, checkError } from '../../styles/js/shared';
+import { brandMain, errorMain } from '../../styles/js/shared';
 
 const NoHoverButton = withStyles({
   root: {
@@ -52,7 +52,7 @@ const useTagStyles = makeStyles({
     margin: '2px',
     lineHeight: '22px',
     color: 'white',
-    backgroundColor: checkBlue,
+    backgroundColor: brandMain,
     borderRadius: '4px',
     boxSizing: 'content-box',
     padding: '0 8px 0 8px',
@@ -76,7 +76,7 @@ const useTagStyles = makeStyles({
     },
   },
   missingProperty: {
-    backgroundColor: checkError,
+    backgroundColor: errorMain,
   },
 });
 

--- a/src/app/components/search/NumericRangeFilter.js
+++ b/src/app/components/search/NumericRangeFilter.js
@@ -9,7 +9,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import RemoveableWrapper from './RemoveableWrapper';
 import NumberIcon from '../../icons/NumberIcon';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const messages = defineMessages({
   linkedItems: {
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme => ({
   },
   inputNotEmpty: {
     '& fieldset': {
-      border: `2px solid ${checkBlue}`,
+      border: `2px solid ${brandMain}`,
     },
   },
 }));

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -17,7 +17,7 @@ import { FormattedMessage } from 'react-intl';
 import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
 import { withSetFlashMessage } from '../FlashMessage';
 import CheckChannels from '../../CheckChannels';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const createMutation = graphql`
   mutation SaveListCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
@@ -69,7 +69,7 @@ const useStyles = makeStyles(theme => ({
     marginRight: theme.spacing(1),
   },
   saveListButton: {
-    color: checkBlue,
+    color: brandMain,
   },
   saveListCreateLabel: {
     marginRight: 0,

--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -16,7 +16,7 @@ import { MediaPreview } from '../feed/MediaPreview';
 import {
   black16,
   borderWidthLarge,
-  checkBlue,
+  brandMain,
 } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
     border: `${borderWidthLarge} solid ${black16}`,
   },
   inputActive: {
-    border: `${borderWidthLarge} solid ${checkBlue}`,
+    border: `${borderWidthLarge} solid ${brandMain}`,
   },
   startAdornmentRoot: {
     display: 'flex',

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -27,7 +27,7 @@ import MultiSelectFilter from '../MultiSelectFilter';
 import SaveList from '../SaveList';
 import { can } from '../../Can';
 import { languageLabel } from '../../../LanguageRegistry';
-import { Row, checkBlue } from '../../../styles/js/shared';
+import { Row, brandMain } from '../../../styles/js/shared';
 import SearchFieldSource from './SearchFieldSource';
 import SearchFieldTag from './SearchFieldTag';
 import SearchFieldChannel from './SearchFieldChannel';
@@ -296,7 +296,7 @@ const SearchFields = ({
   const hideChannel = /\/(tipline-inbox|imported-reports)+/.test(window.location.pathname) || readOnlyFields.includes('channels');
 
   const OperatorToggle = () => {
-    let operatorProps = { style: { minWidth: 0, color: checkBlue }, onClick: handleOperatorClick };
+    let operatorProps = { style: { minWidth: 0, color: brandMain }, onClick: handleOperatorClick };
     if (page === 'feed') {
       operatorProps = { style: { minWidth: 0, color: 'black' }, disabled: true };
     }

--- a/src/app/components/search/SearchResultsTable/SourcesCell.js
+++ b/src/app/components/search/SearchResultsTable/SourcesCell.js
@@ -4,14 +4,14 @@ import { makeStyles } from '@material-ui/core/styles';
 import ValueListCell from './ValueListCell';
 import { urlFromSearchQuery } from '../../search/Search';
 import { safelyParseJSON, truncateLength } from '../../../helpers';
-import { checkBlue } from '../../../styles/js/shared';
+import { brandMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
   source: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    color: checkBlue,
+    color: brandMain,
     textDecoration: 'underline',
   },
 });

--- a/src/app/components/search/SearchResultsTable/TitleCell.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.js
@@ -9,8 +9,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import {
   units,
   black87,
-  checkBlue,
-  checkOrange,
+  brandMain,
+  alertMain,
   opaqueBlack54,
   opaqueBlack87,
 } from '../../../styles/js/shared';
@@ -133,13 +133,13 @@ const IconOrNothing = ({
     return null;
   }
   if (isMain) {
-    return <ContentCopyIcon style={{ color: checkBlue }} className={`${className} similarity-is-main`} />;
+    return <ContentCopyIcon style={{ color: brandMain }} className={`${className} similarity-is-main`} />;
   }
   if (isConfirmed) {
     return <ContentCopyIcon style={{ transform: 'rotate(180deg)' }} className={`${className} similarity-is-confirmed`} />;
   }
   if (isSuggested) {
-    return <ContentCopyIcon style={{ color: checkOrange }} className={`${className} similarity-is-suggested`} />;
+    return <ContentCopyIcon style={{ color: alertMain }} className={`${className} similarity-is-suggested`} />;
   }
   return null;
 };

--- a/src/app/components/search/SearchResultsTable/ValueListCell.js
+++ b/src/app/components/search/SearchResultsTable/ValueListCell.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
-import { checkBlue, inProgressYellow } from '../../../styles/js/shared';
+import { brandMain, alertMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
   tableCell: {
@@ -17,10 +17,10 @@ const useStyles = makeStyles({
     fontSize: 12,
   },
   noFactCheck: {
-    background: inProgressYellow,
+    background: alertMain,
   },
   more: {
-    background: checkBlue,
+    background: brandMain,
   },
 });
 

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -5,10 +5,10 @@ import styled from 'styled-components';
 import CreateProjectMedia from '../media/CreateMedia';
 import ViewModeSwitcher from './ViewModeSwitcher';
 import Can from '../Can';
-import { black87, units, Row, FlexRow } from '../../styles/js/shared';
+import { otherWhite, black87, units, Row, FlexRow } from '../../styles/js/shared';
 
 const StyledToolbar = styled.div`
-  background-color: white;
+  background-color: ${otherWhite};
   min-height: ${units(5)};
   /* max-width: calc(100vw - ${units(34)}); Seems unecessary */
   padding: 0 ${units(2)} ${units(2)} ${units(2)};

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -23,8 +23,8 @@ import DeleteDynamicMutation from '../../relay/mutations/DeleteDynamicMutation';
 import {
   units,
   black16,
-  separationGray,
-  checkBlue,
+  grayBorderMain,
+  brandMain,
 } from '../../styles/js/shared';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 
@@ -37,7 +37,7 @@ const StyledWordBreakDiv = styled.div`
   .task {
     box-shadow: none;
     border: 0;
-    border-bottom: 1px solid ${separationGray};
+    border-bottom: 1px solid ${grayBorderMain};
     border-radius: 0;
     margin-bottom: 0 !important;
 
@@ -95,7 +95,7 @@ const StyledMultiselect = styled.div`
     color: black;
   }
   .Mui-checked {
-    color: ${checkBlue} !important;
+    color: ${brandMain} !important;
   }
 `;
 

--- a/src/app/components/team/Rules/RuleBody.js
+++ b/src/app/components/team/Rules/RuleBody.js
@@ -7,7 +7,7 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
-import { checkBlue, opaqueBlack23 } from '../../../styles/js/shared';
+import { brandMain, opaqueBlack23 } from '../../../styles/js/shared';
 import RuleOperatorWrapper from './RuleOperatorWrapper';
 import RuleField from './RuleField';
 
@@ -19,16 +19,16 @@ const useStyles = makeStyles(theme => ({
     border: 0,
   },
   ifGroup: {
-    border: `2px solid ${checkBlue}`,
+    border: `2px solid ${brandMain}`,
   },
   thenGroup: {
-    border: `2px solid ${checkBlue}`,
+    border: `2px solid ${brandMain}`,
   },
   ifTitle: {
-    color: checkBlue,
+    color: brandMain,
   },
   thenTitle: {
-    color: checkBlue,
+    color: brandMain,
   },
   paper2: {
     marginTop: theme.spacing(2),
@@ -89,8 +89,8 @@ const RuleBody = (props) => {
       <RuleOperatorWrapper
         allowRemove={Boolean(props.onResetRule)}
         center
-        color={checkBlue}
-        deleteIconColor={checkBlue}
+        color={brandMain}
+        deleteIconColor={brandMain}
         operator={rule.rules.operator}
         onSetOperator={(value) => {
           rule.rules.operator = value;
@@ -122,7 +122,7 @@ const RuleBody = (props) => {
               </Typography>
               <RuleOperatorWrapper
                 center={false}
-                color={checkBlue}
+                color={brandMain}
                 operator={group.operator}
                 onSetOperator={(value) => {
                   rule.rules.groups[i].operator = value;
@@ -180,7 +180,7 @@ const RuleBody = (props) => {
           </Typography>
           <RuleOperatorWrapper
             center={false}
-            color={checkBlue}
+            color={brandMain}
             operator="and"
             operators={['and']}
             onSetOperator={() => {}}

--- a/src/app/components/team/SettingsHeader.js
+++ b/src/app/components/team/SettingsHeader.js
@@ -6,7 +6,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import HelpIcon from '@material-ui/icons/HelpOutline';
-import { checkBlue } from '../../styles/js/shared';
+import { brandMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   settingsHeaderRoot: {
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   settingsHeaderHelpIcon: {
-    color: checkBlue,
+    color: brandMain,
   },
   settingsHeaderExtra: {
     marginLeft: theme.spacing(5),

--- a/src/app/components/team/Similarity/ThresholdControl.js
+++ b/src/app/components/team/Similarity/ThresholdControl.js
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Slider from '@material-ui/core/Slider';
 import TextField from '@material-ui/core/TextField';
-import { alertRed } from '../../../styles/js/shared';
+import { errorMain } from '../../../styles/js/shared';
 
 const styles = theme => ({
   textFieldRoot: {
@@ -17,7 +17,7 @@ const styles = theme => ({
     maxWidth: theme.spacing(30),
   },
   error: {
-    color: alertRed,
+    color: errorMain,
   },
 });
 
@@ -68,7 +68,7 @@ const ThresholdControl = ({
         onChange={(e, newValue) => onChange(newValue)}
       />
     </Box>
-    <Box color={alertRed} my={1}>
+    <Box color={errorMain} my={1}>
       { error ?
         <FormattedMessage
           data-testid="threshold-control__error-message"

--- a/src/app/components/team/SmoochBot/SmoochBotConfig.js
+++ b/src/app/components/team/SmoochBot/SmoochBotConfig.js
@@ -9,7 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
-import { checkBlue } from '../../../styles/js/shared';
+import { brandMain } from '../../../styles/js/shared';
 import SmoochBotSidebar from './SmoochBotSidebar';
 import SmoochBotTextEditor from './SmoochBotTextEditor';
 import SmoochBotMultiTextEditor from './SmoochBotMultiTextEditor';
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(1),
   },
   helpIcon: {
-    color: checkBlue,
+    color: brandMain,
   },
   box: {
     padding: theme.spacing(2),
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
     maxHeight: 'calc(100vh - 310px)',
   },
   resource: {
-    color: checkBlue,
+    color: brandMain,
   },
 }));
 

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -11,7 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { black05, black87, alertRed, completedGreen } from '../../../styles/js/shared';
+import { black05, black87, errorMain, validationMain } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 
@@ -47,14 +47,14 @@ const useStyles = makeStyles(theme => ({
   },
   smoochBotIntegrationButtonConnected: {
     color: 'white',
-    backgroundColor: completedGreen,
+    backgroundColor: validationMain,
   },
   smoochBotIntegrationButtonDisconnected: {
     color: black87,
     borderColor: black87,
   },
   smoochBotIntegrationButtonWarning: {
-    color: alertRed,
+    color: errorMain,
   },
   smoochBotIntegrationButtonHeader: {
     marginBottom: 0,

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -7,7 +7,7 @@ import HelpIcon from '@material-ui/icons/HelpOutline';
 import { languageLabel } from '../../../LanguageRegistry';
 import SmoochBotMainMenuSection from './SmoochBotMainMenuSection';
 import WarningAlert from '../../cds/alerts-and-prompts/WarningAlert';
-import { checkBlue } from '../../../styles/js/shared';
+import { brandMain } from '../../../styles/js/shared';
 
 const messages = defineMessages({
   privacyStatement: {
@@ -87,7 +87,7 @@ const SmoochBotMainMenu = ({
             />
           </Typography>
           <a href="https://help.checkmedia.org/en/articles/5982401-tipline-bot-settings" target="_blank" rel="noopener noreferrer">
-            <HelpIcon style={{ color: checkBlue }} />
+            <HelpIcon style={{ color: brandMain }} />
           </a>
         </Box> : null }
       <Typography component="div" variant="subtitle2" paragraph>

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -13,20 +13,20 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import Select from '@material-ui/core/Select';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 import {
-  otherErrorMainCDS,
+  errorMain,
 } from '../../../styles/js/shared';
 
 const errorFieldStyles = {
   root: {
     '& .MuiFormHelperText-root.Mui-error': {
-      color: otherErrorMainCDS,
+      color: errorMain,
       marginLeft: 0,
       fontSize: 12,
       fontWeight: 400,
     },
     '& .MuiOutlinedInput-root': {
       '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-        borderColor: otherErrorMainCDS,
+        borderColor: errorMain,
         borderWidth: 2,
       },
     },

--- a/src/app/components/team/SmoochBot/SmoochBotMenuEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuEditor.js
@@ -14,14 +14,14 @@ import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import SmoochBotTextEditor from './SmoochBotTextEditor';
 import SmoochBotMenuOption from './SmoochBotMenuOption';
-import { checkBlue } from '../../../styles/js/shared';
+import { brandMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   button: {
-    color: checkBlue,
+    color: brandMain,
   },
   iconButton: {
-    color: checkBlue,
+    color: brandMain,
     display: 'block',
   },
   content: {

--- a/src/app/components/team/SmoochBot/SmoochBotMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuOption.js
@@ -12,13 +12,13 @@ import ClearIcon from '@material-ui/icons/Clear';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import { placeholders } from './localizables';
 import { languageLabel } from '../../../LanguageRegistry';
-import { checkBlue } from '../../../styles/js/shared';
+import { brandMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   paper: {
     width: '100%',
     boxShadow: 'none',
-    border: `2px solid ${checkBlue}`,
+    border: `2px solid ${brandMain}`,
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
   },
@@ -26,10 +26,10 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(2),
   },
   ifTitle: {
-    color: checkBlue,
+    color: brandMain,
   },
   thenTitle: {
-    color: checkBlue,
+    color: brandMain,
   },
   caption: {
     margin: `0 ${theme.spacing(1)}px`,

--- a/src/app/components/team/SmoochBot/SmoochBotSidebar.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSidebar.js
@@ -6,12 +6,12 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
 import Divider from '@material-ui/core/Divider';
 import { labels, labelsV2 } from './localizables';
-import { checkBlue, opaqueBlack54 } from '../../../styles/js/shared';
+import { brandMain, opaqueBlack54 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   selected: {
-    borderColor: checkBlue,
-    color: checkBlue,
+    borderColor: brandMain,
+    color: brandMain,
   },
   notSelected: {
     borderColor: opaqueBlack54,
@@ -35,7 +35,7 @@ const useStyles = makeStyles(theme => ({
   divider: {
     marginBottom: theme.spacing(2),
     marginTop: theme.spacing(2),
-    backgroundColor: checkBlue,
+    backgroundColor: brandMain,
   },
 }));
 

--- a/src/app/components/team/SwitchTeamsComponent.js
+++ b/src/app/components/team/SwitchTeamsComponent.js
@@ -19,7 +19,7 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import CreateTeamDialog from './CreateTeamDialog';
 import {
   defaultBorderRadius,
-  white,
+  otherWhite,
   black05,
   black87,
 } from '../../styles/js/shared';
@@ -99,7 +99,7 @@ class SwitchTeamsComponent extends Component {
     const teamAvatarStyle = {
       border: `1px solid ${black05}`,
       borderRadius: `${defaultBorderRadius}`,
-      backgroundColor: white,
+      backgroundColor: otherWhite,
     };
 
     teamUsers.forEach((teamUser) => {

--- a/src/app/components/team/TeamAvatar.js
+++ b/src/app/components/team/TeamAvatar.js
@@ -6,8 +6,8 @@ import {
   black05,
   borderWidthSmall,
   defaultBorderRadius,
-  separationGray,
-  white,
+  grayBorderMain,
+  otherWhite,
 } from '../../styles/js/shared';
 
 const StyledAvatarDiv = styled.div`
@@ -15,11 +15,11 @@ const StyledAvatarDiv = styled.div`
   border-radius: ${defaultBorderRadius};
   flex: 0 0 auto;
   ${backgroundCover}
-  background-color: ${white};
+  background-color: ${otherWhite};
   width: ${props => (props.size ? props.size : avatarSize)};
   height: ${props => (props.size ? props.size : avatarSize)};
   border-radius: 5px;
-  border: 2px solid ${separationGray};
+  border: 2px solid ${grayBorderMain};
   position: relative;
 `;
 

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -25,17 +25,18 @@ import PageTitle from '../PageTitle';
 import { can } from '../Can';
 import UserUtil from '../user/UserUtil';
 import CheckContext from '../../CheckContext';
-import { brandBackground, brandSecondary } from '../../styles/js/shared';
+import { grayBackground, brandBackground, grayBorderMain } from '../../styles/js/shared';
 
 const StyledTabs = styled(Tabs)`
-  background-color: ${brandSecondary};
+  background-color: ${brandBackground};
+  border-bottom: solid 1px ${grayBorderMain};
   box-shadow: none !important;
   padding-left: 32px;
   margin-bottom: 32px;
 `;
 
 const StyledTeamContainer = styled.div`
-  background-color: ${brandBackground};
+  background-color: ${grayBackground};
   min-height: 100vh;
 `;
 

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -25,7 +25,7 @@ import PageTitle from '../PageTitle';
 import { can } from '../Can';
 import UserUtil from '../user/UserUtil';
 import CheckContext from '../../CheckContext';
-import { backgroundMain, brandSecondary } from '../../styles/js/shared';
+import { brandBackground, brandSecondary } from '../../styles/js/shared';
 
 const StyledTabs = styled(Tabs)`
   background-color: ${brandSecondary};
@@ -35,7 +35,7 @@ const StyledTabs = styled(Tabs)`
 `;
 
 const StyledTeamContainer = styled.div`
-  background-color: ${backgroundMain};
+  background-color: ${brandBackground};
   min-height: 100vh;
 `;
 

--- a/src/app/components/team/TeamDetails.js
+++ b/src/app/components/team/TeamDetails.js
@@ -19,7 +19,7 @@ import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
 import UploadFile from '../UploadFile';
 import globalStrings from '../../globalStrings';
 import { getErrorMessage } from '../../helpers';
-import { ContentColumn, avatarSizeLarge, checkBlue } from '../../styles/js/shared';
+import { ContentColumn, avatarSizeLarge, brandMain } from '../../styles/js/shared';
 import {
   StyledTwoColumns,
   StyledBigColumn,
@@ -204,7 +204,7 @@ const TeamDetails = ({
           />
         </Button>
         <IconButton onClick={handleHelp}>
-          <Box clone color={checkBlue}>
+          <Box clone color={brandMain}>
             <HelpIcon />
           </Box>
         </IconButton>

--- a/src/app/components/team/TeamMetadataRender.js
+++ b/src/app/components/team/TeamMetadataRender.js
@@ -9,18 +9,18 @@ import TeamTasksProject from './TeamTasksProject';
 import SettingsHeader from './SettingsHeader';
 import CreateTeamTask from './CreateTeamTask';
 import BlankState from '../layout/BlankState';
-import { backgroundMain, ContentColumn } from '../../styles/js/shared';
+import { brandBackground, ContentColumn } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
-    backgroundColor: `${backgroundMain}`,
+    backgroundColor: `${brandBackground}`,
     display: 'flex',
     minHeight: 224,
     marginBottom: 50,
   },
   tabs: {
-    backgroundColor: `${backgroundMain}`,
+    backgroundColor: `${brandBackground}`,
     marginRight: theme.spacing(5),
     marginTop: theme.spacing(2),
   },

--- a/src/app/components/team/TeamMetadataRender.js
+++ b/src/app/components/team/TeamMetadataRender.js
@@ -9,18 +9,18 @@ import TeamTasksProject from './TeamTasksProject';
 import SettingsHeader from './SettingsHeader';
 import CreateTeamTask from './CreateTeamTask';
 import BlankState from '../layout/BlankState';
-import { brandBackground, ContentColumn } from '../../styles/js/shared';
+import { grayBackground, ContentColumn } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
-    backgroundColor: `${brandBackground}`,
+    backgroundColor: `${grayBackground}`,
     display: 'flex',
     minHeight: 224,
     marginBottom: 50,
   },
   tabs: {
-    backgroundColor: `${brandBackground}`,
+    backgroundColor: `${grayBackground}`,
     marginRight: theme.spacing(5),
     marginTop: theme.spacing(2),
   },

--- a/src/app/relay/containers/UserMenuRelay.js
+++ b/src/app/relay/containers/UserMenuRelay.js
@@ -3,10 +3,10 @@ import Relay from 'react-relay/classic';
 import styled from 'styled-components';
 import MeRoute from '../MeRoute';
 import UserMenu from '../../components/user/UserMenu';
-import { Pulse, white, avatarSize } from '../../styles/js/shared';
+import { Pulse, otherWhite, avatarSize } from '../../styles/js/shared';
 
 const StyledAvatarLoader = styled(Pulse)`
-  background-color: ${white};
+  background-color: ${otherWhite};
   width: ${avatarSize}px;
   height: ${avatarSize}px;
   border-radius: 50%;

--- a/src/app/styles/js/global.js
+++ b/src/app/styles/js/global.js
@@ -1,17 +1,16 @@
 import {
-  checkBlue,
-  white,
+  otherWhite,
   body1,
-  black,
   black87,
   title1,
   subheading1,
+  textLink,
   textPrimary,
 } from './shared';
-
+/* eslint-disable-next-line import/no-unused-modules */
 export const layout = `
   html {
-    background: ${white};
+    background: ${otherWhite};
   }
 
   // Layout default settings
@@ -26,7 +25,7 @@ export const layout = `
     margin: 0;
   }
 `;
-
+/* eslint-disable-next-line import/no-unused-modules */
 export const typography = `
   body {
     color: ${textPrimary};
@@ -50,14 +49,14 @@ export const typography = `
   }
 
   a {
-    color: ${checkBlue};
+    color: ${textLink};
 
     &:hover {
-      color: ${checkBlue};
+      color: ${textLink};
     }
 
     &:visited {
-      color: ${checkBlue};
+      color: ${textLink};
     }
 
     &:not([href]) {
@@ -69,7 +68,7 @@ export const typography = `
   }
 
   a.link__internal {
-    color: ${black};
+    color: ${textPrimary};
     text-decoration: none;
   }
 
@@ -83,7 +82,7 @@ export const typography = `
     padding: 0;
   }
 `;
-
+/* eslint-disable-next-line import/no-unused-modules */
 export const localeAr = `
   [lang="ar"] {
     * {
@@ -116,6 +115,7 @@ export const localeAr = `
 // Remove Chrome's yellow autofill
 // https://blog.mariusschulz.com/2016/03/20/how-to-remove-webkits-banana-yellow-autofill-background
 // NOTE this means inputs all have to be on a white canvas unless you override this.
+/* eslint-disable-next-line import/no-unused-modules */
 export const removeYellowAutocomplete = `
   input:-webkit-autofill {
       -webkit-box-shadow: inset 0 0 0px 9999px white;

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -292,7 +292,7 @@ export const MuiTheme = {
     MuiPaper: {
       elevation1: {
         boxShadow: 'none',
-        border: `2px solid ${brandSecondary}`,
+        border: `2px solid ${brandBorder}`,
       },
     },
     MuiTabs: {

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -3,33 +3,39 @@ import IconButton from '@material-ui/core/IconButton';
 import Card from '@material-ui/core/Card';
 
 // Styles for overriding material UI
-// General colors
-//
-export const white = '#fff';
-export const black = '#000';
-export const alertRed = '#d0021b';
-export const checkBlue = '#2e77fc';
-export const checkOrange = '#f2994a';
-export const checkError = '#fa555f';
-export const inProgressYellow = '#efac51';
-export const completedGreen = '#5cae73';
-export const separationGray = '#E5E5E5';
-export const brandSecondary = '#DFE4F4';
-export const backgroundMain = '#F7F8FD';
 // Check Design System Colors
-export const textPrimary = '#1F1F1F';
+export const brandMain = '#567bff';
+export const brandSecondary = '#3b5cd0';
+export const brandLight = '#cfdfff';
+export const brandAccent = '#293e86';// eslint-disable-line import/no-unused-modules
+export const brandBorder = '#d0d6ec';// eslint-disable-line import/no-unused-modules
+export const brandBackground = '#f1f5f6';
+export const brandHoverAccent = '#f2f8ff';// eslint-disable-line import/no-unused-modules
+
+export const textPrimary = '#1f1f1f';
 export const textSecondary = '#656565';
-export const brandMainCDS = '#567BFF';
-export const brandSecondaryCDS = '#3B5CD0';
-export const brandLightCDS = '#CFDFFF';
-export const alertLightCDS = '#FFF8ED';
-export const alertSecondaryCDS = '#A66300';
-export const alertMainCDS = '#E78A00';
-export const brandBackgroundCDS = '#F1F5F6';
-export const grayBorderCDS = '#CDD0D1';
-export const otherErrorMainCDS = '#F44336';
-export const validationLightCDS = '#F0FFF1';
-export const validationSecondaryCDS = '#237C27';
+export const textPlaceholder = '#b6b6b6';// eslint-disable-line import/no-unused-modules
+export const textDisabled = '#999';// eslint-disable-line import/no-unused-modules
+export const textLink = '#3b5cd0';// eslint-disable-line import/no-unused-modules
+
+export const validationMain = '#4caf50';
+export const validationSecondary = '#237c27';
+export const validationLight = '#f0fff1';
+
+export const alertMain = '#e78a00';
+export const alertSecondary = '#a66300';
+export const alertLight = '#fff8ed';
+
+export const errorMain = '#f44336';
+export const errorSecondary = '#c9291d';// eslint-disable-line import/no-unused-modules
+export const errorLight = '#ffeeed';// eslint-disable-line import/no-unused-modules
+
+export const grayBackground = '#f7f7f7';// eslint-disable-line import/no-unused-modules
+export const grayDisabledBackground = '#efefef';// eslint-disable-line import/no-unused-modules
+export const grayBorderMain = '#e4e4e4';
+export const grayBorderAccent = '#b4b4b4';// eslint-disable-line import/no-unused-modules
+
+export const otherWhite = '#fff';
 
 // Material blacks
 // TODO make these opaque!
@@ -135,10 +141,10 @@ export const MuiTheme = {
   palette: {
     type: 'light',
     primary: {
-      main: checkBlue,
+      main: brandMain,
     },
     secondary: {
-      main: checkBlue,
+      main: brandMain,
     },
     types: {
       light: {
@@ -238,22 +244,22 @@ export const MuiTheme = {
         // @material-ui/core sets #fafafa, only for sticky header. Undo that.
         // We do need a color, though -- if we choose "transparent" the tbody
         // will show through.
-        backgroundColor: white,
+        backgroundColor: otherWhite,
       },
     },
     MuiTableSortLabel: {
       active: {
-        color: `${checkBlue} !important`,
+        color: `${brandMain} !important`,
       },
       icon: {
-        color: `${checkBlue} !important`,
+        color: `${brandMain} !important`,
       },
     },
     MuiIconButton: { // Buttons with Icons
       root: {
         '&:hover': {
           backgroundColor: 'transparent',
-          color: checkBlue,
+          color: brandMain,
         },
       },
     },
@@ -321,19 +327,19 @@ const shimmerKeyframes = keyframes`
 export const Shimmer = styled.div`
   animation: ${shimmerKeyframes} 1s ease-out infinite;
   animation-fill-mode: forwards;
-  background: linear-gradient(90deg, ${opaqueBlack05}, ${opaqueBlack05}, ${opaqueBlack02}, ${opaqueBlack02}, ${white}, ${opaqueBlack02}, ${opaqueBlack05}, ${opaqueBlack05});
+  background: linear-gradient(90deg, ${opaqueBlack05}, ${opaqueBlack05}, ${opaqueBlack02}, ${opaqueBlack02}, ${otherWhite}, ${opaqueBlack02}, ${opaqueBlack05}, ${opaqueBlack05});
   background-size: 400%;
 `;
 
 const pulseKeyframes = keyframes`
   0% {
-    background-color: ${white};
+    background-color: ${otherWhite};
   }
   50% {
     background-color: ${opaqueBlack02};
   }
   100% {
-    background-color: ${white};
+    background-color: ${otherWhite};
   }
 `;
 


### PR DESCRIPTION
## Description

The codebase and figma have diverged when it comes to colors for both variable names as well as the color definitions.
In the future we will most likely be making updates to the color values, but in general the first step is to make them the same. This PR:
- Changes the variable names to match what is in figma
- Ensures all the colors in figma are present in the codebase (some are currently unused, see note below)
- For any old colors that are not in figma, I chose the "closest" match to replace, in most cases this was things like. a slightly different shade of red, so the visual impact will be small
- Updates some pages in the app that were using old colors to match the design that @pierreconti has been producing recently, most notably the settings header (see note below)

References: [CV2-2801](https://meedan.atlassian.net/browse/CV2-2801)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manual testing comparing to qa site to find any differences and when noted make sure they either match whats in figma, or don't look terrible

## Things to pay attention to during code review

- There will be some visual changes because some colors used don't exist in figma. So this PR doesn't attempt to have zero visual changes, but for those changes to make sense at least
- The lint disabled lines in shared.js are colors that appear in the design system, but are not yet (will be) used in the codebase. My thought is for the color variables to be available for development even before they are used, because they will be used shortly.
- There are colors remaining that should be removed from shared, notably the `black...` and `opaqueBlack...` collections. However, since this PR may be mechanically low risk changes, the amount of changes is high, so I thought it would be best to make those additional changes in a future PR.
- Related to ^, there are also hard coded colors in various places in the code back, small things such as using the generic `white` css setting which we should change to only use colors listed in `shared.js`, but I also feel this should be handled in another PR

### Biggest visual change:
Perhaps the most obvious change is to colors on the settings screen. However, the "After" images match what @pierreconti has been creating in figma, and the "Before" do not, so fear not trusty code reviewer.

### Settings Before (1)
<img width="453" alt="Screenshot 2023-02-24 at 9 40 06 AM" src="https://user-images.githubusercontent.com/418001/221206369-ac307d87-b628-4675-87fb-00d4752f3f74.png">

### Settings Before (2)
<img width="516" alt="Screenshot 2023-02-24 at 9 40 16 AM" src="https://user-images.githubusercontent.com/418001/221206408-e7198317-e241-40f8-a828-71189be72a3a.png">

### Settings After (1)
<img width="392" alt="Screenshot 2023-02-24 at 9 40 23 AM" src="https://user-images.githubusercontent.com/418001/221206460-6288aed6-45ed-4106-b619-20809d284e05.png">

### Settings After (2)
<img width="376" alt="Screenshot 2023-02-24 at 9 40 30 AM" src="https://user-images.githubusercontent.com/418001/221206484-f3a7e8d7-f867-4c43-a09f-6a2a8a444abf.png">


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-2801]: https://meedan.atlassian.net/browse/CV2-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ