### PR TITLE
Replace material blacks with design system values

### DIFF
--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -9,13 +9,13 @@ import { mapGlobalMessage } from './MappedMessage';
 import {
   ContentColumn,
   units,
-  black54,
+  opaqueBlack54,
   otherWhite,
 } from '../styles/js/shared';
 
 const Message = styled.div`
   padding: ${units(1)};
-  color: ${black54};
+  color: ${opaqueBlack54};
   background-color: ${otherWhite};
   > div {
     display: flex;
@@ -60,7 +60,7 @@ class BrowserSupport extends Component {
       return (
         <Message>
           <ContentColumn>
-            <IconButton style={{ fontSize: '20px', color: black54 }} onClick={this.close.bind(this)}>
+            <IconButton style={{ fontSize: '20px', color: opaqueBlack54 }} onClick={this.close.bind(this)}>
               <ClearIcon />
             </IconButton>
             <div>

--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -9,13 +9,13 @@ import { mapGlobalMessage } from './MappedMessage';
 import {
   ContentColumn,
   units,
-  opaqueBlack54,
+  textSecondary,
   otherWhite,
 } from '../styles/js/shared';
 
 const Message = styled.div`
   padding: ${units(1)};
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   background-color: ${otherWhite};
   > div {
     display: flex;
@@ -60,7 +60,7 @@ class BrowserSupport extends Component {
       return (
         <Message>
           <ContentColumn>
-            <IconButton style={{ fontSize: '20px', color: opaqueBlack54 }} onClick={this.close.bind(this)}>
+            <IconButton style={{ fontSize: '20px', color: textSecondary }} onClick={this.close.bind(this)}>
               <ClearIcon />
             </IconButton>
             <div>

--- a/src/app/components/CircularProgress.js
+++ b/src/app/components/CircularProgress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
-import { opaqueBlack16, units } from '../styles/js/shared';
+import { grayBorderMain, units } from '../styles/js/shared';
 
 const rotationBuilder = () => {
   const rotation = keyframes`
@@ -69,7 +69,7 @@ const CircularProgress = ({ color }) => (
   </StyledBox>
 );
 CircularProgress.defaultProps = {
-  color: black16,
+  color: grayBorderMain,
 };
 CircularProgress.propTypes = {
   color: PropTypes.string, // or null

--- a/src/app/components/CircularProgress.js
+++ b/src/app/components/CircularProgress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
-import { black16, units } from '../styles/js/shared';
+import { opaqueBlack16, units } from '../styles/js/shared';
 
 const rotationBuilder = () => {
   const rotation = keyframes`

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -9,7 +9,7 @@ import reactStringReplace from 'react-string-replace';
 import Message from './Message';
 import { withClientSessionId } from '../ClientSessionId';
 import { safelyParseJSON, createFriendlyErrorMessage } from '../helpers';
-import { brandMain, otherWhite, opaqueBlack54 } from '../styles/js/shared';
+import { brandMain, otherWhite, textSecondary } from '../styles/js/shared';
 
 /**
  * A global message, already translated for the user.
@@ -90,14 +90,14 @@ const useSnackBarStyles = makeStyles({
         textDecoration: 'underline',
       },
       '&:not([href]):hover': {
-        color: opaqueBlack54,
+        color: textSecondary,
         textDecoration: 'underline',
       },
       '&:visited': {
         color: otherWhite,
       },
       '&:hover': {
-        color: opaqueBlack54,
+        color: textSecondary,
       },
     },
   },

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -9,7 +9,7 @@ import reactStringReplace from 'react-string-replace';
 import Message from './Message';
 import { withClientSessionId } from '../ClientSessionId';
 import { safelyParseJSON, createFriendlyErrorMessage } from '../helpers';
-import { brandMain, otherWhite, black54 } from '../styles/js/shared';
+import { brandMain, otherWhite, opaqueBlack54 } from '../styles/js/shared';
 
 /**
  * A global message, already translated for the user.
@@ -90,14 +90,14 @@ const useSnackBarStyles = makeStyles({
         textDecoration: 'underline',
       },
       '&:not([href]):hover': {
-        color: black54,
+        color: opaqueBlack54,
         textDecoration: 'underline',
       },
       '&:visited': {
         color: otherWhite,
       },
       '&:hover': {
-        color: black54,
+        color: opaqueBlack54,
       },
     },
   },

--- a/src/app/components/Footer.js
+++ b/src/app/components/Footer.js
@@ -3,13 +3,13 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import {
-  opaqueBlack38,
+  textDisabled,
   units,
   caption,
 } from '../styles/js/shared';
 
 const StyledFooter = styled.footer`
-  color: ${opaqueBlack38};
+  color: ${textDisabled};
   font: ${caption};
   margin: ${units(4)} 0;
   padding: ${units(1)} 0;

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -17,7 +17,7 @@ import { getErrorObjects } from '../helpers';
 import CheckError from '../CheckError';
 import {
   units,
-  black54,
+  opaqueBlack54,
   StyledSubHeader,
   StyledCard,
   brandMain,
@@ -35,7 +35,7 @@ const styles = {
   },
   secondaryButton: {
     display: 'block',
-    color: black54,
+    color: opaqueBlack54,
     maxWidth: units(26),
     margin: `${units(2)} auto`,
   },

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -17,7 +17,7 @@ import { getErrorObjects } from '../helpers';
 import CheckError from '../CheckError';
 import {
   units,
-  opaqueBlack54,
+  textSecondary,
   StyledSubHeader,
   StyledCard,
   brandMain,
@@ -35,7 +35,7 @@ const styles = {
   },
   secondaryButton: {
     display: 'block',
-    color: opaqueBlack54,
+    color: textSecondary,
     maxWidth: units(26),
     margin: `${units(2)} auto`,
   },

--- a/src/app/components/Message.js
+++ b/src/app/components/Message.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   otherWhite,
-  black54,
+  opaqueBlack54,
   gutterSmall,
   gutterMedium,
   gutterLarge,
@@ -12,7 +12,7 @@ import {
 } from '../styles/js/shared';
 
 const StyledMessage = styled(FadeIn)`
-  background: ${black54};
+  background: ${opaqueBlack54};
   border-radius: ${defaultBorderRadius};
   color: ${otherWhite};
   margin: ${gutterMedium} auto;

--- a/src/app/components/Message.js
+++ b/src/app/components/Message.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   otherWhite,
-  opaqueBlack54,
+  textSecondary,
   gutterSmall,
   gutterMedium,
   gutterLarge,
@@ -12,7 +12,7 @@ import {
 } from '../styles/js/shared';
 
 const StyledMessage = styled(FadeIn)`
-  background: ${opaqueBlack54};
+  background: ${textSecondary};
   border-radius: ${defaultBorderRadius};
   color: ${otherWhite};
   margin: ${gutterMedium} auto;

--- a/src/app/components/UploadFile.js
+++ b/src/app/components/UploadFile.js
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import CircularProgress from './CircularProgress';
 import { unhumanizeSize } from '../helpers';
 import {
-  opaqueBlack38,
+  textDisabled,
   Row,
   units,
   borderWidthMedium,
@@ -27,8 +27,8 @@ const StyledUploader = styled.div`
     .with-file,
     .without-file {
       align-items: center;
-      border: ${borderWidthMedium} dashed ${opaqueBlack38};
-      color: ${opaqueBlack38};
+      border: ${borderWidthMedium} dashed ${textDisabled};
+      color: ${textDisabled};
       cursor: pointer;
       display: flex;
       height: auto;
@@ -39,7 +39,7 @@ const StyledUploader = styled.div`
     }
 
     #remove-image {
-      color: ${opaqueBlack38};
+      color: ${textDisabled};
       cursor: pointer;
       margin: 0;
     }

--- a/src/app/components/UploadFile.js
+++ b/src/app/components/UploadFile.js
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import CircularProgress from './CircularProgress';
 import { unhumanizeSize } from '../helpers';
 import {
-  black38,
+  opaqueBlack38,
   Row,
   units,
   borderWidthMedium,
@@ -27,8 +27,8 @@ const StyledUploader = styled.div`
     .with-file,
     .without-file {
       align-items: center;
-      border: ${borderWidthMedium} dashed ${black38};
-      color: ${black38};
+      border: ${borderWidthMedium} dashed ${opaqueBlack38};
+      color: ${opaqueBlack38};
       cursor: pointer;
       display: flex;
       height: auto;
@@ -39,7 +39,7 @@ const StyledUploader = styled.div`
     }
 
     #remove-image {
-      color: ${black38};
+      color: ${opaqueBlack38};
       cursor: pointer;
       margin: 0;
     }

--- a/src/app/components/UserConfirmPage.js
+++ b/src/app/components/UserConfirmPage.js
@@ -18,13 +18,13 @@ import {
   units,
   mediaQuery,
   title1,
-  black54,
+  opaqueBlack54,
 } from '../styles/js/shared';
 
 const StyledSubHeader = styled.h2`
   font: ${title1};
   font-weight: 600;
-  color: ${black54};
+  color: ${opaqueBlack54};
   text-align: center;
   margin-top: ${units(2)};
 `;

--- a/src/app/components/UserConfirmPage.js
+++ b/src/app/components/UserConfirmPage.js
@@ -18,13 +18,13 @@ import {
   units,
   mediaQuery,
   title1,
-  opaqueBlack54,
+  textSecondary,
 } from '../styles/js/shared';
 
 const StyledSubHeader = styled.h2`
   font: ${title1};
   font-weight: 600;
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   text-align: center;
   margin-top: ${units(2)};
 `;

--- a/src/app/components/UserMenuItems.js
+++ b/src/app/components/UserMenuItems.js
@@ -7,11 +7,11 @@ import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import ExternalLink from './ExternalLink';
 import { logout } from '../redux/actions';
-import { opaqueBlack87 } from '../styles/js/shared';
+import { textPrimary } from '../styles/js/shared';
 
 const StyledUserMenuItems = styled.div`
   a:link, a:visited, a:hover, a:active {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     text-decoration: none;
   }
 `;

--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -18,7 +18,7 @@ import CreateDynamicMutation from '../../relay/mutations/CreateDynamicMutation';
 import { can } from '../Can';
 import CheckContext from '../../CheckContext';
 import UploadFile from '../UploadFile';
-import { Row, black38, black87, units } from '../../styles/js/shared';
+import { Row, opaqueBlack38, opaqueBlack87, units } from '../../styles/js/shared';
 import { getErrorMessage } from '../../helpers';
 import { stringHelper } from '../../customHelpers';
 import globalStrings from '../../globalStrings';
@@ -337,9 +337,9 @@ class AddAnnotation extends Component {
       justify-content: flex-end;
       .add-annotation__insert-photo {
         svg {
-          path { color: ${black38}; }
+          path { color: ${opaqueBlack38}; }
           &:hover path {
-            color: ${black87};
+            color: ${opaqueBlack87};
             cusor: pointer;
           }
         }

--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -18,7 +18,7 @@ import CreateDynamicMutation from '../../relay/mutations/CreateDynamicMutation';
 import { can } from '../Can';
 import CheckContext from '../../CheckContext';
 import UploadFile from '../UploadFile';
-import { Row, opaqueBlack38, opaqueBlack87, units } from '../../styles/js/shared';
+import { Row, textDisabled, textPrimary, units } from '../../styles/js/shared';
 import { getErrorMessage } from '../../helpers';
 import { stringHelper } from '../../customHelpers';
 import globalStrings from '../../globalStrings';
@@ -337,9 +337,9 @@ class AddAnnotation extends Component {
       justify-content: flex-end;
       .add-annotation__insert-photo {
         svg {
-          path { color: ${opaqueBlack38}; }
+          path { color: ${textDisabled}; }
           &:hover path {
-            color: ${opaqueBlack87};
+            color: ${textPrimary};
             cusor: pointer;
           }
         }

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -43,9 +43,9 @@ import {
   units,
   otherWhite,
   opaqueBlack16,
-  black38,
-  black54,
-  black87,
+  opaqueBlack38,
+  opaqueBlack54,
+  opaqueBlack87,
   brandMain,
   borderWidthLarge,
   caption,
@@ -59,7 +59,7 @@ const dotSize = borderWidthLarge;
 const dotOffset = stripUnit(units(4)) - stripUnit(dotSize);
 
 const StyledDefaultAnnotation = styled.div`
-  color: ${black87};
+  color: ${opaqueBlack87};
   display: flex;
   font: ${caption};
   width: 100%;
@@ -150,7 +150,7 @@ const StyledAnnotationWrapper = styled.section`
   }
 
   .annotation__timestamp {
-    color: ${black38};
+    color: ${opaqueBlack38};
     display: inline;
     flex: 1;
     white-space: pre;
@@ -194,13 +194,13 @@ const StyledAnnotationWrapper = styled.section`
 `;
 
 const StyledAnnotationMetadata = styled(Row)`
-  color: ${black54};
+  color: ${opaqueBlack54};
   flex-flow: wrap row;
   font: ${caption};
   margin-top: ${units(3)};
 
   .annotation__card-author {
-    color: ${black87};
+    color: ${opaqueBlack87};
     padding-${props => (props.theme.dir === 'rtl' ? 'left' : 'right')}: ${units(1)};
   }
 `;
@@ -371,7 +371,7 @@ class Annotation extends Component {
             <MenuItem>
               <a
                 href={`#annotation-${activity.dbid}`}
-                style={{ textDecoration: 'none', color: black87 }}
+                style={{ textDecoration: 'none', color: opaqueBlack87 }}
               >
                 <FormattedMessage
                   id="annotation.permalink"

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -42,10 +42,10 @@ import CheckArchivedFlags from '../../CheckArchivedFlags';
 import {
   units,
   otherWhite,
-  opaqueBlack16,
-  opaqueBlack38,
-  opaqueBlack54,
-  opaqueBlack87,
+  grayBorderMain,
+  textDisabled,
+  textSecondary,
+  textPrimary,
   brandMain,
   borderWidthLarge,
   caption,
@@ -59,7 +59,7 @@ const dotSize = borderWidthLarge;
 const dotOffset = stripUnit(units(4)) - stripUnit(dotSize);
 
 const StyledDefaultAnnotation = styled.div`
-  color: ${opaqueBlack87};
+  color: ${textPrimary};
   display: flex;
   font: ${caption};
   width: 100%;
@@ -122,7 +122,7 @@ const StyledAnnotationWrapper = styled.section`
   &:not(.annotation--card) {
     // The timeline dot
     &::before {
-      background-color: ${opaqueBlack16};
+      background-color: ${grayBorderMain};
       border-radius: 100%;
       content: '';
       height: ${units(1)};
@@ -150,7 +150,7 @@ const StyledAnnotationWrapper = styled.section`
   }
 
   .annotation__timestamp {
-    color: ${opaqueBlack38};
+    color: ${textDisabled};
     display: inline;
     flex: 1;
     white-space: pre;
@@ -194,13 +194,13 @@ const StyledAnnotationWrapper = styled.section`
 `;
 
 const StyledAnnotationMetadata = styled(Row)`
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   flex-flow: wrap row;
   font: ${caption};
   margin-top: ${units(3)};
 
   .annotation__card-author {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     padding-${props => (props.theme.dir === 'rtl' ? 'left' : 'right')}: ${units(1)};
   }
 `;
@@ -371,7 +371,7 @@ class Annotation extends Component {
             <MenuItem>
               <a
                 href={`#annotation-${activity.dbid}`}
-                style={{ textDecoration: 'none', color: opaqueBlack87 }}
+                style={{ textDecoration: 'none', color: textPrimary }}
               >
                 <FormattedMessage
                   id="annotation.permalink"

--- a/src/app/components/annotations/Annotations.js
+++ b/src/app/components/annotations/Annotations.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import AddAnnotation from './AddAnnotation';
 import Annotation from './Annotation';
 import BlankState from '../layout/BlankState';
-import { units, opaqueBlack16, borderWidthMedium } from '../../styles/js/shared';
+import { units, grayBorderMain, borderWidthMedium } from '../../styles/js/shared';
 
 const StyledAnnotations = styled.div`
   display: flex;
@@ -25,7 +25,7 @@ const StyledAnnotations = styled.div`
       ${prop => prop.noLink ? null : `
         // The timeline line
         &::before {
-          background-color: ${opaqueBlack16};
+          background-color: ${grayBorderMain};
           content: '';
           display: block;
           position: absolute;

--- a/src/app/components/annotations/Comment.js
+++ b/src/app/components/annotations/Comment.js
@@ -29,9 +29,9 @@ import globalStrings from '../../globalStrings';
 import { stringHelper } from '../../customHelpers';
 import {
   units,
-  black38,
-  black54,
-  black87,
+  opaqueBlack38,
+  opaqueBlack54,
+  opaqueBlack87,
   caption,
   breakWordStyles,
   grayBorderMain,
@@ -71,7 +71,7 @@ const StyledAnnotationWrapper = styled.section`
   }
 
   .annotation__timestamp {
-    color: ${black38};
+    color: ${opaqueBlack38};
     display: inline;
     flex: 1;
     white-space: pre;
@@ -80,12 +80,12 @@ const StyledAnnotationWrapper = styled.section`
 `;
 
 const StyledAnnotationMetadata = styled(Row)`
-  color: ${black54};
+  color: ${opaqueBlack54};
   flex-flow: wrap row;
   font: ${caption};
 
   .annotation__card-author {
-    color: ${black87};
+    color: ${opaqueBlack87};
     padding-${props => (props.theme.dir === 'rtl' ? 'left' : 'right')}: ${units(1)};
   }
 `;
@@ -186,7 +186,7 @@ class Comment extends Component {
             <MenuItem>
               <a
                 href={`#annotation-${annotation.dbid}`}
-                style={{ textDecoration: 'none', color: black87 }}
+                style={{ textDecoration: 'none', color: opaqueBlack87 }}
               >
                 <FormattedMessage
                   id="annotation.permalink"

--- a/src/app/components/annotations/Comment.js
+++ b/src/app/components/annotations/Comment.js
@@ -29,9 +29,9 @@ import globalStrings from '../../globalStrings';
 import { stringHelper } from '../../customHelpers';
 import {
   units,
-  opaqueBlack38,
-  opaqueBlack54,
-  opaqueBlack87,
+  textDisabled,
+  textSecondary,
+  textPrimary,
   caption,
   breakWordStyles,
   grayBorderMain,
@@ -71,7 +71,7 @@ const StyledAnnotationWrapper = styled.section`
   }
 
   .annotation__timestamp {
-    color: ${opaqueBlack38};
+    color: ${textDisabled};
     display: inline;
     flex: 1;
     white-space: pre;
@@ -80,12 +80,12 @@ const StyledAnnotationWrapper = styled.section`
 `;
 
 const StyledAnnotationMetadata = styled(Row)`
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   flex-flow: wrap row;
   font: ${caption};
 
   .annotation__card-author {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     padding-${props => (props.theme.dir === 'rtl' ? 'left' : 'right')}: ${units(1)};
   }
 `;
@@ -186,7 +186,7 @@ class Comment extends Component {
             <MenuItem>
               <a
                 href={`#annotation-${annotation.dbid}`}
-                style={{ textDecoration: 'none', color: opaqueBlack87 }}
+                style={{ textDecoration: 'none', color: textPrimary }}
               >
                 <FormattedMessage
                   id="annotation.permalink"

--- a/src/app/components/drawer/DrawerHeader.js
+++ b/src/app/components/drawer/DrawerHeader.js
@@ -10,7 +10,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import TeamAvatar from '../team/TeamAvatar';
 import { stringHelper } from '../../customHelpers';
 import {
-  opaqueBlack87,
+  textPrimary,
   subheading1,
   units,
   Text,
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
     flex: '1 1 auto',
     font: subheading1,
     fontWeight: 500,
-    color: opaqueBlack87,
+    color: textPrimary,
     '&:hover': {
       textDecoration: 'underline',
     },

--- a/src/app/components/drawer/DrawerHeader.js
+++ b/src/app/components/drawer/DrawerHeader.js
@@ -10,7 +10,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import TeamAvatar from '../team/TeamAvatar';
 import { stringHelper } from '../../customHelpers';
 import {
-  black87,
+  opaqueBlack87,
   subheading1,
   units,
   Text,
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
     flex: '1 1 auto',
     font: subheading1,
     fontWeight: 500,
-    color: black87,
+    color: opaqueBlack87,
     '&:hover': {
       textDecoration: 'underline',
     },

--- a/src/app/components/feed/FeedItemComponent.js
+++ b/src/app/components/feed/FeedItemComponent.js
@@ -39,8 +39,8 @@ import {
   brandBorder,
   brandSecondary,
   brandMain,
-  opaqueBlack54,
-  opaqueBlack38,
+  textSecondary,
+  textDisabled,
   Column,
 } from '../../styles/js/shared';
 import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
@@ -121,7 +121,7 @@ const useStyles = makeStyles(theme => ({
     minWidth: '150px',
   },
   cardSubhead: {
-    color: opaqueBlack54,
+    color: textSecondary,
     fontSize: '0.85em',
     fontWeight: 500,
   },
@@ -416,7 +416,7 @@ const FeedItemComponent = ({
                               date: (
                                 claim?.project_media?.report_status === 'published' ?
                                   <TimeBefore date={parseStringUnixTimestamp(claim.project_media.report?.data?.last_published)} /> :
-                                  <span style={{ color: opaqueBlack38 }}>
+                                  <span style={{ color: textDisabled }}>
                                     <FormattedMessage id="feedItem.notPublished" defaultMessage="Not published yet" />
                                   </span>
                               ),
@@ -442,7 +442,7 @@ const FeedItemComponent = ({
                     />
                     <CardContent>
                       <Box mt={2}>
-                        <span style={{ color: opaqueBlack38 }}>
+                        <span style={{ color: textDisabled }}>
                           <FormattedMessage
                             id="feedItem.noClaim"
                             defaultMessage="No claim added yet"

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -28,22 +28,22 @@ import ErrorBoundary from '../error/ErrorBoundary';
 import MediasLoading from '../media/MediasLoading';
 import SearchKeyword from '../search/SearchKeyword';
 import ProjectBlankState from '../project/ProjectBlankState';
-import { opaqueBlack03, opaqueBlack87 } from '../../styles/js/shared';
+import { grayBackground, textPrimary } from '../../styles/js/shared';
 
 const useStyles = makeStyles({
   root: {
     cursor: 'pointer',
-    background: opaqueBlack03,
+    background: grayBackground,
     textDecoration: 'none',
     height: '96px',
     '&:hover': {
       boxShadow: '0px 1px 6px rgba(0, 0, 0, 0.25)',
-      background: opaqueBlack03,
+      background: grayBackground,
       transform: 'scale(1)',
     },
   },
   pager: {
-    color: opaqueBlack87,
+    color: textPrimary,
     fontSize: 'larger',
     fontWeight: 'bolder',
     textAlign: 'center',

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
-import { opaqueBlack87, black32, brandMain, opaqueBlack38, units, otherWhite } from '../../styles/js/shared.js';
+import { opaqueBlack87, opaqueBlack32, brandMain, opaqueBlack38, units, otherWhite } from '../../styles/js/shared.js';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -103,7 +103,7 @@ const AspectRatioComponent = ({
             onClick={onClickExpand}
             style={{
               color: otherWhite,
-              backgroundColor: black32,
+              backgroundColor: opaqueBlack32,
               position: 'absolute',
               right: '0',
               top: '0',

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
-import { opaqueBlack87, opaqueBlack32, brandMain, opaqueBlack38, units, otherWhite } from '../../styles/js/shared.js';
+import { textPrimary, grayBorderAccent, brandMain, textDisabled, units, otherWhite } from '../../styles/js/shared.js';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     height: 0,
     paddingBottom: '56.25%',
     position: 'relative',
-    backgroundColor: opaqueBlack38,
+    backgroundColor: textDisabled,
   },
   innerWrapper: {
     position: 'absolute',
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     width: '100%',
     height: '100%',
-    backgroundColor: props.contentWarning ? opaqueBlack87 : 'transparent',
+    backgroundColor: props.contentWarning ? textPrimary : 'transparent',
     zIndex: 100,
     color: otherWhite,
   }),
@@ -103,7 +103,7 @@ const AspectRatioComponent = ({
             onClick={onClickExpand}
             style={{
               color: otherWhite,
-              backgroundColor: opaqueBlack32,
+              backgroundColor: grayBorderAccent,
               position: 'absolute',
               right: '0',
               top: '0',

--- a/src/app/components/layout/BlankState.js
+++ b/src/app/components/layout/BlankState.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
-import { units, headline, opaqueBlack38 } from '../../styles/js/shared';
+import { units, headline, textDisabled } from '../../styles/js/shared';
 
 const StyledBlankState = styled.div`
   margin-top: ${units(5)};
   font: ${headline};
-  color: ${opaqueBlack38};
+  color: ${textDisabled};
   text-align: center;
 `;
 

--- a/src/app/components/layout/BlankState.js
+++ b/src/app/components/layout/BlankState.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
-import { units, headline, black38 } from '../../styles/js/shared';
+import { units, headline, opaqueBlack38 } from '../../styles/js/shared';
 
 const StyledBlankState = styled.div`
   margin-top: ${units(5)};
   font: ${headline};
-  color: ${black38};
+  color: ${opaqueBlack38};
   text-align: center;
 `;
 

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -15,14 +15,14 @@ import { stringHelper } from '../../customHelpers';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 import SearchKeywordContainer from '../search/SearchKeywordConfig/SearchKeywordContainer';
 import MediaItem from './Similarity/MediaItem';
-import { black32 } from '../../styles/js/shared';
+import { opaqueBlack32 } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   searchSettingsTitle: {
     fontWeight: 'bold',
   },
   searchSettingsBox: {
-    borderLeft: `1px solid ${black32}`,
+    borderLeft: `1px solid ${opaqueBlack32}`,
     marginLeft: theme.spacing(1),
     paddingLeft: theme.spacing(2),
     width: 300,

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -15,14 +15,14 @@ import { stringHelper } from '../../customHelpers';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 import SearchKeywordContainer from '../search/SearchKeywordConfig/SearchKeywordContainer';
 import MediaItem from './Similarity/MediaItem';
-import { opaqueBlack32 } from '../../styles/js/shared';
+import { grayBorderAccent } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   searchSettingsTitle: {
     fontWeight: 'bold',
   },
   searchSettingsBox: {
-    borderLeft: `1px solid ${opaqueBlack32}`,
+    borderLeft: `1px solid ${grayBorderAccent}`,
     marginLeft: theme.spacing(1),
     paddingLeft: theme.spacing(2),
     width: 300,

--- a/src/app/components/media/MediaExpanded.js
+++ b/src/app/components/media/MediaExpanded.js
@@ -27,11 +27,11 @@ import UserUtil from '../user/UserUtil';
 import { truncateLength } from '../../helpers';
 import CheckContext from '../../CheckContext';
 import { withPusher, pusherShape } from '../../pusher';
-import { units, opaqueBlack54 } from '../../styles/js/shared';
+import { units, textSecondary } from '../../styles/js/shared';
 
 const TypographyBlack54 = withStyles({
   root: {
-    color: opaqueBlack54,
+    color: textSecondary,
   },
 })(Typography);
 
@@ -248,7 +248,7 @@ class MediaExpandedComponent extends Component {
           <MediaExpandedSecondRow projectMedia={media} />
           { isImage ?
             <Box mb={2}>
-              <TypographyBlack54 variant="body2" color={opaqueBlack54}>
+              <TypographyBlack54 variant="body2" color={textSecondary}>
                 { media.extracted_text ?
                   <FormattedMessage id="mediaExpanded.extractedText" defaultMessage="Text extracted from image:" description="Label for text extracted from the image below" /> :
                   <FormattedMessage id="mediaExpanded.noExtractedText" defaultMessage="No text extracted from this image" description="Label when text extracted from an image is not available" />
@@ -258,7 +258,7 @@ class MediaExpandedComponent extends Component {
           }
           { isMedia ?
             <Box mb={2}>
-              <TypographyBlack54 variant="body2" color={opaqueBlack54}>
+              <TypographyBlack54 variant="body2" color={textSecondary}>
                 { media.transcription && media.transcription.data.last_response.job_status === 'COMPLETED' ?
                   <FormattedMessage id="mediaExpanded.transcriptionCompleted" defaultMessage="Audio transcribed from media:" description="Label for transcription from audio or video" /> : null }
                 { media.transcription && media.transcription.data.last_response.job_status === 'IN_PROGRESS' ?

--- a/src/app/components/media/MediaExpanded.js
+++ b/src/app/components/media/MediaExpanded.js
@@ -27,11 +27,11 @@ import UserUtil from '../user/UserUtil';
 import { truncateLength } from '../../helpers';
 import CheckContext from '../../CheckContext';
 import { withPusher, pusherShape } from '../../pusher';
-import { units, black54 } from '../../styles/js/shared';
+import { units, opaqueBlack54 } from '../../styles/js/shared';
 
 const TypographyBlack54 = withStyles({
   root: {
-    color: black54,
+    color: opaqueBlack54,
   },
 })(Typography);
 
@@ -248,7 +248,7 @@ class MediaExpandedComponent extends Component {
           <MediaExpandedSecondRow projectMedia={media} />
           { isImage ?
             <Box mb={2}>
-              <TypographyBlack54 variant="body2" color={black54}>
+              <TypographyBlack54 variant="body2" color={opaqueBlack54}>
                 { media.extracted_text ?
                   <FormattedMessage id="mediaExpanded.extractedText" defaultMessage="Text extracted from image:" description="Label for text extracted from the image below" /> :
                   <FormattedMessage id="mediaExpanded.noExtractedText" defaultMessage="No text extracted from this image" description="Label when text extracted from an image is not available" />
@@ -258,7 +258,7 @@ class MediaExpandedComponent extends Component {
           }
           { isMedia ?
             <Box mb={2}>
-              <TypographyBlack54 variant="body2" color={black54}>
+              <TypographyBlack54 variant="body2" color={opaqueBlack54}>
                 { media.transcription && media.transcription.data.last_response.job_status === 'COMPLETED' ?
                   <FormattedMessage id="mediaExpanded.transcriptionCompleted" defaultMessage="Audio transcribed from media:" description="Label for transcription from audio or video" /> : null }
                 { media.transcription && media.transcription.data.last_response.job_status === 'IN_PROGRESS' ?

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -14,8 +14,8 @@ import CheckContext from '../../CheckContext';
 import {
   subheading2,
   body1,
-  opaqueBlack87,
-  opaqueBlack54,
+  textPrimary,
+  textSecondary,
   units,
   brandBorder,
 } from '../../styles/js/shared';
@@ -30,12 +30,12 @@ const StyledAnnotationRow = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    color: ${opaqueBlack54};
+    color: ${textSecondary};
     font: ${body1};
   }
 
   h2 {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     flex: 1;
     font: ${subheading2};
     margin: 0;

--- a/src/app/components/media/MediaTasks.js
+++ b/src/app/components/media/MediaTasks.js
@@ -14,8 +14,8 @@ import CheckContext from '../../CheckContext';
 import {
   subheading2,
   body1,
-  black87,
-  black54,
+  opaqueBlack87,
+  opaqueBlack54,
   units,
   brandBorder,
 } from '../../styles/js/shared';
@@ -30,12 +30,12 @@ const StyledAnnotationRow = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    color: ${black54};
+    color: ${opaqueBlack54};
     font: ${body1};
   }
 
   h2 {
-    color: ${black87};
+    color: ${opaqueBlack87};
     flex: 1;
     font: ${subheading2};
     margin: 0;

--- a/src/app/components/media/MediasLoading.js
+++ b/src/app/components/media/MediasLoading.js
@@ -5,7 +5,7 @@ import {
   ContentColumn,
   FadeIn,
   Shimmer,
-  black05,
+  opaqueBlack05,
   borderWidthSmall,
   defaultBorderRadius,
   otherWhite,
@@ -29,7 +29,7 @@ const StyledLoadingInner = styled(ContentColumn)`
 
 const StyledLoadingCard = styled.div`
   background: ${otherWhite};
-  border: ${borderWidthSmall} solid ${black05};
+  border: ${borderWidthSmall} solid ${opaqueBlack05};
   border-radius: ${defaultBorderRadius};
   margin: ${gridUnit} 0;
   min-height: ${units(11)};

--- a/src/app/components/media/MediasLoading.js
+++ b/src/app/components/media/MediasLoading.js
@@ -5,7 +5,7 @@ import {
   ContentColumn,
   FadeIn,
   Shimmer,
-  opaqueBlack05,
+  grayDisabledBackground,
   borderWidthSmall,
   defaultBorderRadius,
   otherWhite,
@@ -29,7 +29,7 @@ const StyledLoadingInner = styled(ContentColumn)`
 
 const StyledLoadingCard = styled.div`
   background: ${otherWhite};
-  border: ${borderWidthSmall} solid ${opaqueBlack05};
+  border: ${borderWidthSmall} solid ${grayDisabledBackground};
   border-radius: ${defaultBorderRadius};
   margin: ${gridUnit} 0;
   min-height: ${units(11)};

--- a/src/app/components/media/NextPreviousLinks.js
+++ b/src/app/components/media/NextPreviousLinks.js
@@ -11,7 +11,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import NextIcon from '@material-ui/icons/KeyboardArrowRight';
 import PrevIcon from '@material-ui/icons/KeyboardArrowLeft';
 import NextOrPreviousButton from './NextOrPreviousButton';
-import { units, black54 } from '../../styles/js/shared';
+import { units, opaqueBlack54 } from '../../styles/js/shared';
 import { getPathnameAndSearch, pageSize } from '../../urlHelpers';
 
 const StyledPager = styled.div`
@@ -26,12 +26,12 @@ const StyledPager = styled.div`
   justify-content: flex-end;
   font-weight: bold;
   font-size: ${units(2)};
-  color: ${black54};
+  color: ${opaqueBlack54};
 
   button {
     background: transparent;
     border: 0;
-    color: ${black54};
+    color: ${opaqueBlack54};
     cursor: pointer;
     outline: 0;
   }

--- a/src/app/components/media/NextPreviousLinks.js
+++ b/src/app/components/media/NextPreviousLinks.js
@@ -11,7 +11,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import NextIcon from '@material-ui/icons/KeyboardArrowRight';
 import PrevIcon from '@material-ui/icons/KeyboardArrowLeft';
 import NextOrPreviousButton from './NextOrPreviousButton';
-import { units, opaqueBlack54 } from '../../styles/js/shared';
+import { units, textSecondary } from '../../styles/js/shared';
 import { getPathnameAndSearch, pageSize } from '../../urlHelpers';
 
 const StyledPager = styled.div`
@@ -26,12 +26,12 @@ const StyledPager = styled.div`
   justify-content: flex-end;
   font-weight: bold;
   font-size: ${units(2)};
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
 
   button {
     background: transparent;
     border: 0;
-    color: ${opaqueBlack54};
+    color: ${textSecondary};
     cursor: pointer;
     outline: 0;
   }

--- a/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
@@ -9,7 +9,7 @@ import WarningIcon from '@material-ui/icons/Warning';
 import ParsedText from '../../ParsedText';
 import ReportDesignerImagePreview from './ReportDesignerImagePreview';
 import { formatDate } from './reportDesignerHelpers';
-import { errorMain, opaqueBlack87 } from '../../../styles/js/shared';
+import { errorMain, textPrimary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     height: 500,
     top: 0,
     padding: '64px 40px 16px 40px',
-    backgroundColor: opaqueBlack87,
+    backgroundColor: textPrimary,
     zIndex: 100,
     position: 'absolute',
     display: 'flex',

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -11,7 +11,7 @@ import LayersIcon from '@material-ui/icons/Layers';
 import TimeBefore from '../../TimeBefore';
 import MediaTypeDisplayName from '../MediaTypeDisplayName';
 import { parseStringUnixTimestamp, truncateLength } from '../../../helpers';
-import { brandSecondary, brandBorder, brandMain, alertMain, black32 } from '../../../styles/js/shared';
+import { brandSecondary, brandBorder, brandMain, alertMain, opaqueBlack32 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -85,7 +85,7 @@ const useStyles = makeStyles(theme => ({
     color: alertMain,
   },
   reportUnpublished: {
-    color: black32,
+    color: opaqueBlack32,
   },
   by: {
     color: brandMain,

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -11,7 +11,7 @@ import LayersIcon from '@material-ui/icons/Layers';
 import TimeBefore from '../../TimeBefore';
 import MediaTypeDisplayName from '../MediaTypeDisplayName';
 import { parseStringUnixTimestamp, truncateLength } from '../../../helpers';
-import { brandSecondary, brandBorder, brandMain, alertMain, opaqueBlack32 } from '../../../styles/js/shared';
+import { brandSecondary, brandBorder, brandMain, alertMain, grayBorderAccent } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -85,7 +85,7 @@ const useStyles = makeStyles(theme => ({
     color: alertMain,
   },
   reportUnpublished: {
-    color: opaqueBlack32,
+    color: grayBorderAccent,
   },
   by: {
     color: brandMain,

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -42,7 +42,7 @@ import {
   validationMain,
   errorMain,
   brandBorder,
-  opaqueBlack54,
+  textSecondary,
   brandBackground,
 } from '../../../styles/js/shared';
 import BulkArchiveProjectMediaMutation from '../../../relay/mutations/BulkArchiveProjectMediaMutation';
@@ -105,7 +105,7 @@ const useStyles = makeStyles(theme => ({
   },
   suggestionsBackButton: {
     padding: 0,
-    color: opaqueBlack54,
+    color: textSecondary,
   },
   suggestionsNoMediaBox: {
     border: `1px solid ${brandBorder}`,

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -42,7 +42,7 @@ import {
   validationMain,
   errorMain,
   brandBorder,
-  black54,
+  opaqueBlack54,
   brandBackground,
 } from '../../../styles/js/shared';
 import BulkArchiveProjectMediaMutation from '../../../relay/mutations/BulkArchiveProjectMediaMutation';
@@ -105,7 +105,7 @@ const useStyles = makeStyles(theme => ({
   },
   suggestionsBackButton: {
     padding: 0,
-    color: black54,
+    color: opaqueBlack54,
   },
   suggestionsNoMediaBox: {
     border: `1px solid ${brandBorder}`,

--- a/src/app/components/project/Project.js
+++ b/src/app/components/project/Project.js
@@ -15,7 +15,7 @@ import Search from '../search/Search';
 import { safelyParseJSON } from '../../helpers';
 import NotFound from '../NotFound';
 import ProjectActions from '../drawer/Projects/ProjectActions';
-import { units, black32 } from '../../styles/js/shared';
+import { units, opaqueBlack32 } from '../../styles/js/shared';
 
 class ProjectComponent extends React.PureComponent {
   componentDidMount() {
@@ -95,7 +95,7 @@ class ProjectComponent extends React.PureComponent {
               { project.privacy > 0 ?
                 <div
                   style={{
-                    color: black32,
+                    color: opaqueBlack32,
                     display: 'flex',
                     alignItems: 'center',
                     fontSize: 14,

--- a/src/app/components/project/Project.js
+++ b/src/app/components/project/Project.js
@@ -15,7 +15,7 @@ import Search from '../search/Search';
 import { safelyParseJSON } from '../../helpers';
 import NotFound from '../NotFound';
 import ProjectActions from '../drawer/Projects/ProjectActions';
-import { units, opaqueBlack32 } from '../../styles/js/shared';
+import { units, grayBorderAccent } from '../../styles/js/shared';
 
 class ProjectComponent extends React.PureComponent {
   componentDidMount() {
@@ -95,7 +95,7 @@ class ProjectComponent extends React.PureComponent {
               { project.privacy > 0 ?
                 <div
                   style={{
-                    color: opaqueBlack32,
+                    color: grayBorderAccent,
                     display: 'flex',
                     alignItems: 'center',
                     fontSize: 14,

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -5,7 +5,7 @@ import { DatePicker } from '@material-ui/pickers';
 import InputBase from '@material-ui/core/InputBase';
 import { withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
-import { FlexRow, units, opaqueBlack07, brandMain } from '../../styles/js/shared';
+import { FlexRow, units, grayDisabledBackground, brandMain } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -20,7 +20,7 @@ const StyledCloseIcon = withStyles({
 
 const StyledInputBaseDate = withStyles(theme => ({
   root: {
-    backgroundColor: opaqueBlack07,
+    backgroundColor: grayDisabledBackground,
     padding: `0 ${theme.spacing(0.5)}px`,
     height: theme.spacing(4.5),
     fontSize: 14,
@@ -103,7 +103,7 @@ class AnnotationFilterDate extends React.Component {
     const { classes } = this.props;
 
     return (
-      <div style={{ background: opaqueBlack07 }}>
+      <div style={{ background: grayDisabledBackground }}>
         <FlexRow>
           <DatePicker
             onChange={this.handleChangeStartDate}

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -13,7 +13,7 @@ import { withStyles } from '@material-ui/core/styles';
 import DateRangeIcon from '@material-ui/icons/DateRange';
 import CloseIcon from '@material-ui/icons/Close';
 import RemoveableWrapper from './RemoveableWrapper';
-import { FlexRow, units, opaqueBlack07, brandMain } from '../../styles/js/shared';
+import { FlexRow, units, grayDisabledBackground, brandMain } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -28,7 +28,7 @@ const StyledCloseIcon = withStyles({
 
 const StyledInputBaseDate = withStyles(theme => ({
   root: {
-    backgroundColor: opaqueBlack07,
+    backgroundColor: grayDisabledBackground,
     padding: `0 ${theme.spacing(0.5)}px`,
     height: theme.spacing(4.5),
     fontSize: 14,
@@ -44,7 +44,7 @@ const StyledInputBaseDate = withStyles(theme => ({
 
 const StyledInputBaseDropdown = withStyles(theme => ({
   root: {
-    backgroundColor: opaqueBlack07,
+    backgroundColor: grayDisabledBackground,
     padding: `0 ${theme.spacing(0.5)}px`,
     height: theme.spacing(4.5),
     fontSize: 14,
@@ -91,7 +91,7 @@ const Styles = {
     paddingRight: '8px',
   },
   wrapper: {
-    backgroundColor: opaqueBlack07,
+    backgroundColor: grayDisabledBackground,
     borderRadius: '4px',
   },
 };

--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -14,7 +14,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { Clear as ClearIcon } from '@material-ui/icons';
 import { MediaPreview } from '../feed/MediaPreview';
 import {
-  opaqueBlack16,
+  grayBorderMain,
   borderWidthLarge,
   brandMain,
 } from '../../styles/js/shared';
@@ -25,7 +25,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: 14,
   },
   inputInactive: {
-    border: `${borderWidthLarge} solid ${opaqueBlack16}`,
+    border: `${borderWidthLarge} solid ${grayBorderMain}`,
   },
   inputActive: {
     border: `${borderWidthLarge} solid ${brandMain}`,

--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -14,7 +14,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { Clear as ClearIcon } from '@material-ui/icons';
 import { MediaPreview } from '../feed/MediaPreview';
 import {
-  black16,
+  opaqueBlack16,
   borderWidthLarge,
   brandMain,
 } from '../../styles/js/shared';
@@ -25,7 +25,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: 14,
   },
   inputInactive: {
-    border: `${borderWidthLarge} solid ${black16}`,
+    border: `${borderWidthLarge} solid ${opaqueBlack16}`,
   },
   inputActive: {
     border: `${borderWidthLarge} solid ${brandMain}`,

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -20,7 +20,7 @@ import ParsedText from '../ParsedText';
 import BulkActions from '../media/BulkActions';
 import MediasLoading from '../media/MediasLoading';
 import ProjectBlankState from '../project/ProjectBlankState';
-import { opaqueBlack87, opaqueBlack54, headline, units, Row, textSecondary } from '../../styles/js/shared';
+import { textPrimary, textSecondary, headline, units, Row, textSecondary } from '../../styles/js/shared';
 import SearchResultsTable from './SearchResultsTable';
 import SearchRoute from '../../relay/SearchRoute';
 import { pageSize } from '../../urlHelpers';
@@ -52,7 +52,7 @@ const StyledListHeader = styled.div`
 
 const StyledSearchResultsWrapper = styled.div`
   .search__results-heading {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     font-size: larger;
     font-weight: bolder;
     text-align: center;
@@ -63,7 +63,7 @@ const StyledSearchResultsWrapper = styled.div`
       padding: 0 ${units(1)};
       display: flex;
       cursor: pointer;
-      color: ${opaqueBlack87};
+      color: ${textPrimary};
 
       &:first-child {
         padding-left: 0;
@@ -71,7 +71,7 @@ const StyledSearchResultsWrapper = styled.div`
     }
 
     .search__button-disabled {
-      color: ${opaqueBlack54};
+      color: ${textSecondary};
       cursor: default;
     }
   }

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -20,7 +20,7 @@ import ParsedText from '../ParsedText';
 import BulkActions from '../media/BulkActions';
 import MediasLoading from '../media/MediasLoading';
 import ProjectBlankState from '../project/ProjectBlankState';
-import { textPrimary, textSecondary, headline, units, Row, textSecondary } from '../../styles/js/shared';
+import { textPrimary, textSecondary, headline, units, Row } from '../../styles/js/shared';
 import SearchResultsTable from './SearchResultsTable';
 import SearchRoute from '../../relay/SearchRoute';
 import { pageSize } from '../../urlHelpers';

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -20,7 +20,7 @@ import ParsedText from '../ParsedText';
 import BulkActions from '../media/BulkActions';
 import MediasLoading from '../media/MediasLoading';
 import ProjectBlankState from '../project/ProjectBlankState';
-import { black87, black54, headline, units, Row, textSecondary } from '../../styles/js/shared';
+import { opaqueBlack87, opaqueBlack54, headline, units, Row, textSecondary } from '../../styles/js/shared';
 import SearchResultsTable from './SearchResultsTable';
 import SearchRoute from '../../relay/SearchRoute';
 import { pageSize } from '../../urlHelpers';
@@ -52,7 +52,7 @@ const StyledListHeader = styled.div`
 
 const StyledSearchResultsWrapper = styled.div`
   .search__results-heading {
-    color: ${black87};
+    color: ${opaqueBlack87};
     font-size: larger;
     font-weight: bolder;
     text-align: center;
@@ -63,7 +63,7 @@ const StyledSearchResultsWrapper = styled.div`
       padding: 0 ${units(1)};
       display: flex;
       cursor: pointer;
-      color: ${black87};
+      color: ${opaqueBlack87};
 
       &:first-child {
         padding-left: 0;
@@ -71,7 +71,7 @@ const StyledSearchResultsWrapper = styled.div`
     }
 
     .search__button-disabled {
-      color: ${black54};
+      color: ${opaqueBlack54};
       cursor: default;
     }
   }

--- a/src/app/components/search/SearchResultsTable/FactCheckCell.js
+++ b/src/app/components/search/SearchResultsTable/FactCheckCell.js
@@ -5,7 +5,7 @@ import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   units,
-  black87,
+  opaqueBlack87,
   opaqueBlack54,
 } from '../../../styles/js/shared';
 
@@ -33,7 +33,7 @@ const useStyles = makeStyles({
     minWidth: 470,
   },
   title: {
-    color: black87,
+    color: opaqueBlack87,
     fontWeight: 'bold',
     overflow: 'hidden',
     display: '-webkit-box',

--- a/src/app/components/search/SearchResultsTable/FactCheckCell.js
+++ b/src/app/components/search/SearchResultsTable/FactCheckCell.js
@@ -5,8 +5,8 @@ import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   units,
-  opaqueBlack87,
-  opaqueBlack54,
+  textPrimary,
+  textSecondary,
 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
@@ -33,7 +33,7 @@ const useStyles = makeStyles({
     minWidth: 470,
   },
   title: {
-    color: opaqueBlack87,
+    color: textPrimary,
     fontWeight: 'bold',
     overflow: 'hidden',
     display: '-webkit-box',
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
   },
   description: {
     maxHeight: units(5),
-    color: opaqueBlack54,
+    color: textSecondary,
     overflow: 'hidden',
     display: '-webkit-box',
     '-webkit-box-orient': 'vertical',

--- a/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
+++ b/src/app/components/search/SearchResultsTable/SearchResultsTableRow.js
@@ -4,7 +4,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import { makeStyles } from '@material-ui/core/styles';
-import { opaqueBlack03 } from '../../../styles/js/shared';
+import { grayBackground } from '../../../styles/js/shared';
 
 const isFeedPage = /\/feed$/.test(window.location.pathname);
 
@@ -16,13 +16,13 @@ const swallowClick = (ev) => {
 const useStyles = makeStyles({
   root: ({ dbid, isRead }) => ({
     cursor: dbid ? 'pointer' : 'wait',
-    background: isRead || isFeedPage ? opaqueBlack03 : 'transparent',
+    background: isRead || isFeedPage ? grayBackground : 'transparent',
     textDecoration: 'none',
   }),
   hover: ({ isRead }) => ({
     '&$hover:hover': {
       boxShadow: '0px 1px 6px rgba(0, 0, 0, 0.25)',
-      background: isRead || isFeedPage ? opaqueBlack03 : 'transparent',
+      background: isRead || isFeedPage ? grayBackground : 'transparent',
       transform: 'scale(1)',
     },
   }),

--- a/src/app/components/search/SearchResultsTable/TitleCell.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.js
@@ -10,8 +10,8 @@ import {
   units,
   brandMain,
   alertMain,
-  opaqueBlack54,
-  opaqueBlack87,
+  textSecondary,
+  textPrimary,
 } from '../../../styles/js/shared';
 
 const isFeedPage = () => (/\/feed/.test(window.location.pathname));
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
     minHeight: units(10),
     height: units(10),
     marginRight: units(1),
-    backgroundColor: opaqueBlack87,
+    backgroundColor: textPrimary,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -63,7 +63,7 @@ const useStyles = makeStyles({
     minWidth: 470,
   },
   title: ({ isRead }) => ({
-    color: opaqueBlack87,
+    color: textPrimary,
     fontWeight: !isRead || isFeedPage() ? 'bold' : 'normal',
     overflow: 'hidden',
     display: '-webkit-box',
@@ -71,7 +71,7 @@ const useStyles = makeStyles({
   }),
   description: {
     maxHeight: units(5),
-    color: opaqueBlack54,
+    color: textSecondary,
     overflow: 'hidden',
     display: '-webkit-box',
     '-webkit-box-orient': 'vertical',

--- a/src/app/components/search/SearchResultsTable/TitleCell.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.js
@@ -8,7 +8,6 @@ import { Link } from 'react-router';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   units,
-  black87,
   brandMain,
   alertMain,
   opaqueBlack54,
@@ -64,7 +63,7 @@ const useStyles = makeStyles({
     minWidth: 470,
   },
   title: ({ isRead }) => ({
-    color: black87,
+    color: opaqueBlack87,
     fontWeight: !isRead || isFeedPage() ? 'bold' : 'normal',
     overflow: 'hidden',
     display: '-webkit-box',

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import CreateProjectMedia from '../media/CreateMedia';
 import ViewModeSwitcher from './ViewModeSwitcher';
 import Can from '../Can';
-import { otherWhite, opaqueBlack87, units, Row, FlexRow } from '../../styles/js/shared';
+import { otherWhite, textPrimary, units, Row, FlexRow } from '../../styles/js/shared';
 
 const StyledToolbar = styled.div`
   background-color: ${otherWhite};
@@ -15,7 +15,7 @@ const StyledToolbar = styled.div`
   margin: 0;
 
   .toolbar__title {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     margin: ${units(2)};
   }
 `;

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import CreateProjectMedia from '../media/CreateMedia';
 import ViewModeSwitcher from './ViewModeSwitcher';
 import Can from '../Can';
-import { otherWhite, black87, units, Row, FlexRow } from '../../styles/js/shared';
+import { otherWhite, opaqueBlack87, units, Row, FlexRow } from '../../styles/js/shared';
 
 const StyledToolbar = styled.div`
   background-color: ${otherWhite};
@@ -15,7 +15,7 @@ const StyledToolbar = styled.div`
   margin: 0;
 
   .toolbar__title {
-    color: ${black87};
+    color: ${opaqueBlack87};
     margin: ${units(2)};
   }
 `;

--- a/src/app/components/source/SourcePicture.js
+++ b/src/app/components/source/SourcePicture.js
@@ -10,7 +10,7 @@ import {
   avatarSizeSmall,
   avatarSizeExtraSmall,
   defaultBorderRadius,
-  black05,
+  opaqueBlack05,
 } from '../../styles/js/shared';
 
 // Sources are square. If the image is not square,
@@ -27,7 +27,7 @@ const StyledImage = styled.div`
   background-size: ${props => props.type === 'source' ? 'contain' : 'cover'};
   background-image: url('${props => props.avatarUrl}');
   background-color: white;
-  ${props => props.type === 'source' ? `border: 1px solid ${black05};` : null}
+  ${props => props.type === 'source' ? `border: 1px solid ${opaqueBlack05};` : null}
 
   ${props => (() => {
     if (props.size === 'large') {

--- a/src/app/components/source/SourcePicture.js
+++ b/src/app/components/source/SourcePicture.js
@@ -10,7 +10,7 @@ import {
   avatarSizeSmall,
   avatarSizeExtraSmall,
   defaultBorderRadius,
-  opaqueBlack05,
+  grayDisabledBackground,
 } from '../../styles/js/shared';
 
 // Sources are square. If the image is not square,
@@ -27,7 +27,7 @@ const StyledImage = styled.div`
   background-size: ${props => props.type === 'source' ? 'contain' : 'cover'};
   background-image: url('${props => props.avatarUrl}');
   background-color: white;
-  ${props => props.type === 'source' ? `border: 1px solid ${opaqueBlack05};` : null}
+  ${props => props.type === 'source' ? `border: 1px solid ${grayDisabledBackground};` : null}
 
   ${props => (() => {
     if (props.size === 'large') {

--- a/src/app/components/source/UserSecurity.js
+++ b/src/app/components/source/UserSecurity.js
@@ -22,7 +22,7 @@ import globalStrings from '../../globalStrings';
 import {
   ContentColumn,
   units,
-  opaqueBlack10,
+  grayBorderMain,
 } from '../../styles/js/shared';
 
 const messages = defineMessages({
@@ -223,7 +223,7 @@ class UserSecurity extends Component {
       lineHeight: units(3),
       fontWeight: 'bold',
       fontSize: units(1.5),
-      backgroundColor: opaqueBlack10,
+      backgroundColor: grayBorderMain,
       margin: '5px',
       textAlign: 'center',
     };

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -23,7 +23,6 @@ import DeleteDynamicMutation from '../../relay/mutations/DeleteDynamicMutation';
 import {
   units,
   grayBorderMain,
-  grayBorderMain,
   brandMain,
 } from '../../styles/js/shared';
 import CheckArchivedFlags from '../../CheckArchivedFlags';

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -22,7 +22,7 @@ import DeleteAnnotationMutation from '../../relay/mutations/DeleteAnnotationMuta
 import DeleteDynamicMutation from '../../relay/mutations/DeleteDynamicMutation';
 import {
   units,
-  black16,
+  opaqueBlack16,
   grayBorderMain,
   brandMain,
 } from '../../styles/js/shared';
@@ -65,7 +65,7 @@ const StyledWordBreakDiv = styled.div`
 
 const StyledTaskResponses = styled.div`
   .task__resolved {
-    border-bottom: 1px solid ${black16};
+    border-bottom: 1px solid ${opaqueBlack16};
     padding-bottom: ${units(1)};
     margin-bottom: ${units(1)};
   }

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -22,7 +22,7 @@ import DeleteAnnotationMutation from '../../relay/mutations/DeleteAnnotationMuta
 import DeleteDynamicMutation from '../../relay/mutations/DeleteDynamicMutation';
 import {
   units,
-  opaqueBlack16,
+  grayBorderMain,
   grayBorderMain,
   brandMain,
 } from '../../styles/js/shared';
@@ -65,7 +65,7 @@ const StyledWordBreakDiv = styled.div`
 
 const StyledTaskResponses = styled.div`
   .task__resolved {
-    border-bottom: 1px solid ${opaqueBlack16};
+    border-bottom: 1px solid ${grayBorderMain};
     padding-bottom: ${units(1)};
     margin-bottom: ${units(1)};
   }

--- a/src/app/components/team/Rules/RuleBody.js
+++ b/src/app/components/team/Rules/RuleBody.js
@@ -7,7 +7,7 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
-import { brandMain, opaqueBlack23 } from '../../../styles/js/shared';
+import { brandMain, textPlaceholder } from '../../../styles/js/shared';
 import RuleOperatorWrapper from './RuleOperatorWrapper';
 import RuleField from './RuleField';
 
@@ -35,7 +35,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(2),
   },
   box: {
-    border: `2px solid ${opaqueBlack23}`,
+    border: `2px solid ${textPlaceholder}`,
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(1),
     borderRadius: 4,

--- a/src/app/components/team/Rules/RuleOperatorButton.js
+++ b/src/app/components/team/Rules/RuleOperatorButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
-import { opaqueBlack54 } from '../../../styles/js/shared';
+import { textSecondary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -17,7 +17,7 @@ const useStyles = makeStyles(() => ({
   enabled: {
   },
   disabled: {
-    color: opaqueBlack54,
+    color: textSecondary,
   },
 }));
 

--- a/src/app/components/team/Rules/RuleOperatorButton.js
+++ b/src/app/components/team/Rules/RuleOperatorButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
-import { black54 } from '../../../styles/js/shared';
+import { opaqueBlack54 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -17,7 +17,7 @@ const useStyles = makeStyles(() => ({
   enabled: {
   },
   disabled: {
-    color: black54,
+    color: opaqueBlack54,
   },
 }));
 

--- a/src/app/components/team/Rules/RuleOperatorWrapper.js
+++ b/src/app/components/team/Rules/RuleOperatorWrapper.js
@@ -9,12 +9,12 @@ import Tooltip from '@material-ui/core/Tooltip';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import ClearIcon from '@material-ui/icons/Clear';
 import { makeStyles } from '@material-ui/core/styles';
-import { opaqueBlack54 } from '../../../styles/js/shared';
+import { textSecondary } from '../../../styles/js/shared';
 import RuleOperatorButton from './RuleOperatorButton';
 
 const useStyles = makeStyles(() => ({
   separator: {
-    color: opaqueBlack54,
+    color: textSecondary,
   },
   button: {
     padding: 0,
@@ -94,7 +94,7 @@ RuleOperatorWrapper.defaultProps = {
   allowRemove: false,
   operator: 'and',
   operators: ['and', 'or'],
-  deleteIconColor: opaqueBlack54,
+  deleteIconColor: textSecondary,
   onSetOperator: null,
 };
 

--- a/src/app/components/team/Rules/RuleOperatorWrapper.js
+++ b/src/app/components/team/Rules/RuleOperatorWrapper.js
@@ -9,12 +9,12 @@ import Tooltip from '@material-ui/core/Tooltip';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import ClearIcon from '@material-ui/icons/Clear';
 import { makeStyles } from '@material-ui/core/styles';
-import { black54 } from '../../../styles/js/shared';
+import { opaqueBlack54 } from '../../../styles/js/shared';
 import RuleOperatorButton from './RuleOperatorButton';
 
 const useStyles = makeStyles(() => ({
   separator: {
-    color: black54,
+    color: opaqueBlack54,
   },
   button: {
     padding: 0,
@@ -94,7 +94,7 @@ RuleOperatorWrapper.defaultProps = {
   allowRemove: false,
   operator: 'and',
   operators: ['and', 'or'],
-  deleteIconColor: black54,
+  deleteIconColor: opaqueBlack54,
   onSetOperator: null,
 };
 

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -11,19 +11,19 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { opaqueBlack05, opaqueBlack87, errorMain, validationMain } from '../../../styles/js/shared';
+import { grayDisabledBackground, textPrimary, errorMain, validationMain } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 
 const useStyles = makeStyles(theme => ({
   smoochBotIntegrationButton: {
     margin: theme.spacing(1),
-    background: opaqueBlack05,
+    background: grayDisabledBackground,
     flex: '1 1 0px',
     minWidth: 250,
     justifyContent: 'space-between',
     '&:hover': {
-      background: opaqueBlack05,
+      background: grayDisabledBackground,
     },
   },
   smoochBotIntegrationButtonIcon: {
@@ -50,8 +50,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: validationMain,
   },
   smoochBotIntegrationButtonDisconnected: {
-    color: opaqueBlack87,
-    borderColor: opaqueBlack87,
+    color: textPrimary,
+    borderColor: textPrimary,
   },
   smoochBotIntegrationButtonWarning: {
     color: errorMain,

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -11,19 +11,19 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { black05, black87, errorMain, validationMain } from '../../../styles/js/shared';
+import { opaqueBlack05, opaqueBlack87, errorMain, validationMain } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 
 const useStyles = makeStyles(theme => ({
   smoochBotIntegrationButton: {
     margin: theme.spacing(1),
-    background: black05,
+    background: opaqueBlack05,
     flex: '1 1 0px',
     minWidth: 250,
     justifyContent: 'space-between',
     '&:hover': {
-      background: black05,
+      background: opaqueBlack05,
     },
   },
   smoochBotIntegrationButtonIcon: {
@@ -50,8 +50,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: validationMain,
   },
   smoochBotIntegrationButtonDisconnected: {
-    color: black87,
-    borderColor: black87,
+    color: opaqueBlack87,
+    borderColor: opaqueBlack87,
   },
   smoochBotIntegrationButtonWarning: {
     color: errorMain,

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -16,12 +16,12 @@ import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 import AddIcon from '@material-ui/icons/Add';
 import SmoochBotMainMenuOption from './SmoochBotMainMenuOption';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { opaqueBlack23, opaqueBlack54 } from '../../../styles/js/shared';
+import { textPlaceholder, textSecondary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {
     background: '#F6F6F6',
-    border: `1px solid ${opaqueBlack23}`,
+    border: `1px solid ${textPlaceholder}`,
     borderRadius: theme.spacing(2),
   },
   textField: {
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(0.25),
   },
   lock: {
-    color: opaqueBlack54,
+    color: textSecondary,
   },
   noDescription: {
     fontStyle: 'italic',

--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
@@ -20,7 +20,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { getTimeZones } from '@vvo/tzdb';
 import SmoochBotPreviewFeed from './SmoochBotPreviewFeed';
 import { placeholders } from './localizables';
-import { opaqueBlack38, opaqueBlack23 } from '../../../styles/js/shared';
+import { textDisabled, textPlaceholder } from '../../../styles/js/shared';
 import ParsedText from '../../ParsedText';
 import WarningAlert from '../../cds/alerts-and-prompts/WarningAlert';
 import SuccessAlert from '../../cds/alerts-and-prompts/SuccessAlert';
@@ -74,7 +74,7 @@ const useStyles = makeStyles(theme => ({
     color: 'black',
   },
   bullet: {
-    color: opaqueBlack38,
+    color: textDisabled,
     fontSize: theme.spacing(2),
     marginRight: theme.spacing(1),
     height: theme.spacing(7),
@@ -82,12 +82,12 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
   },
   bulletRss: {
-    color: opaqueBlack38,
+    color: textDisabled,
     fontSize: theme.spacing(2),
     marginRight: theme.spacing(1),
   },
   textField: {
-    border: `1px solid ${opaqueBlack23}`,
+    border: `1px solid ${textPlaceholder}`,
     borderRadius: theme.spacing(0.5),
   },
   bulletPoints: {

--- a/src/app/components/team/SmoochBot/SmoochBotSidebar.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSidebar.js
@@ -6,7 +6,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
 import Divider from '@material-ui/core/Divider';
 import { labels, labelsV2 } from './localizables';
-import { brandMain, opaqueBlack54 } from '../../../styles/js/shared';
+import { brandMain, textSecondary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   selected: {
@@ -14,8 +14,8 @@ const useStyles = makeStyles(theme => ({
     color: brandMain,
   },
   notSelected: {
-    borderColor: opaqueBlack54,
-    color: opaqueBlack54,
+    borderColor: textSecondary,
+    color: textSecondary,
   },
   root: {
     borderRadius: 4,

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import CommentIcon from '@material-ui/icons/Comment';
-import { opaqueBlack32 } from '../../../styles/js/shared';
+import { grayBorderAccent } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   statusMessageText: {
@@ -11,7 +11,7 @@ const useStyles = makeStyles(() => ({
     opacity: 0.7,
   },
   statusMessageIcon: {
-    color: opaqueBlack32,
+    color: grayBorderAccent,
   },
 }));
 

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import CommentIcon from '@material-ui/icons/Comment';
-import { black32 } from '../../../styles/js/shared';
+import { opaqueBlack32 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   statusMessageText: {
@@ -11,7 +11,7 @@ const useStyles = makeStyles(() => ({
     opacity: 0.7,
   },
   statusMessageIcon: {
-    color: black32,
+    color: opaqueBlack32,
   },
 }));
 

--- a/src/app/components/team/SwitchTeamsComponent.js
+++ b/src/app/components/team/SwitchTeamsComponent.js
@@ -20,8 +20,8 @@ import CreateTeamDialog from './CreateTeamDialog';
 import {
   defaultBorderRadius,
   otherWhite,
-  black05,
-  black87,
+  opaqueBlack05,
+  opaqueBlack87,
 } from '../../styles/js/shared';
 import UpdateUserMutation from '../../relay/mutations/UpdateUserMutation';
 import DeleteTeamUserMutation from '../../relay/mutations/DeleteTeamUserMutation';
@@ -97,7 +97,7 @@ class SwitchTeamsComponent extends Component {
     const pendingTeams = [];
 
     const teamAvatarStyle = {
-      border: `1px solid ${black05}`,
+      border: `1px solid ${opaqueBlack05}`,
       borderRadius: `${defaultBorderRadius}`,
       backgroundColor: otherWhite,
     };
@@ -152,7 +152,7 @@ class SwitchTeamsComponent extends Component {
                 </ListItemAvatar>
                 <ListItemText
                   primary={team.name}
-                  style={{ color: black87 }}
+                  style={{ color: opaqueBlack87 }}
                   secondary={
                     <FormattedMessage
                       id="switchTeams.member"

--- a/src/app/components/team/SwitchTeamsComponent.js
+++ b/src/app/components/team/SwitchTeamsComponent.js
@@ -20,8 +20,8 @@ import CreateTeamDialog from './CreateTeamDialog';
 import {
   defaultBorderRadius,
   otherWhite,
-  opaqueBlack05,
-  opaqueBlack87,
+  grayDisabledBackground,
+  textPrimary,
 } from '../../styles/js/shared';
 import UpdateUserMutation from '../../relay/mutations/UpdateUserMutation';
 import DeleteTeamUserMutation from '../../relay/mutations/DeleteTeamUserMutation';
@@ -97,7 +97,7 @@ class SwitchTeamsComponent extends Component {
     const pendingTeams = [];
 
     const teamAvatarStyle = {
-      border: `1px solid ${opaqueBlack05}`,
+      border: `1px solid ${grayDisabledBackground}`,
       borderRadius: `${defaultBorderRadius}`,
       backgroundColor: otherWhite,
     };
@@ -152,7 +152,7 @@ class SwitchTeamsComponent extends Component {
                 </ListItemAvatar>
                 <ListItemText
                   primary={team.name}
-                  style={{ color: opaqueBlack87 }}
+                  style={{ color: textPrimary }}
                   secondary={
                     <FormattedMessage
                       id="switchTeams.member"

--- a/src/app/components/team/TeamAvatar.js
+++ b/src/app/components/team/TeamAvatar.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {
   avatarSize,
   backgroundCover,
-  black05,
+  opaqueBlack05,
   borderWidthSmall,
   defaultBorderRadius,
   grayBorderMain,
@@ -11,7 +11,7 @@ import {
 } from '../../styles/js/shared';
 
 const StyledAvatarDiv = styled.div`
-  border: ${borderWidthSmall} solid ${black05};
+  border: ${borderWidthSmall} solid ${opaqueBlack05};
   border-radius: ${defaultBorderRadius};
   flex: 0 0 auto;
   ${backgroundCover}

--- a/src/app/components/team/TeamAvatar.js
+++ b/src/app/components/team/TeamAvatar.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {
   avatarSize,
   backgroundCover,
-  opaqueBlack05,
+  grayDisabledBackground,
   borderWidthSmall,
   defaultBorderRadius,
   grayBorderMain,
@@ -11,7 +11,7 @@ import {
 } from '../../styles/js/shared';
 
 const StyledAvatarDiv = styled.div`
-  border: ${borderWidthSmall} solid ${opaqueBlack05};
+  border: ${borderWidthSmall} solid ${grayDisabledBackground};
   border-radius: ${defaultBorderRadius};
   flex: 0 0 auto;
   ${backgroundCover}

--- a/src/app/components/team/TeamBot.js
+++ b/src/app/components/team/TeamBot.js
@@ -3,7 +3,7 @@ import Box from '@material-ui/core/Box';
 import styled from 'styled-components';
 import FetchBot from './FetchBot';
 import KeepBot from './KeepBot';
-import { units, black32 } from '../../styles/js/shared';
+import { units, opaqueBlack32 } from '../../styles/js/shared';
 
 const StyledSchemaForm = styled.div`
   div {
@@ -28,7 +28,7 @@ const StyledSchemaForm = styled.div`
   fieldset fieldset {
     padding: ${units(1)};
     margin-top: ${units(1)};
-    border: 1px solid ${black32};
+    border: 1px solid ${opaqueBlack32};
   }
 
   fieldset fieldset button {
@@ -36,7 +36,7 @@ const StyledSchemaForm = styled.div`
     width: 32px !important;
     background: #fff !important;
     border-radius: 5px !important;
-    color: ${black32} !important;
+    color: ${opaqueBlack32} !important;
   }
   
   #bot-fetch fieldset div {

--- a/src/app/components/team/TeamBot.js
+++ b/src/app/components/team/TeamBot.js
@@ -3,7 +3,7 @@ import Box from '@material-ui/core/Box';
 import styled from 'styled-components';
 import FetchBot from './FetchBot';
 import KeepBot from './KeepBot';
-import { units, opaqueBlack32 } from '../../styles/js/shared';
+import { units, grayBorderAccent } from '../../styles/js/shared';
 
 const StyledSchemaForm = styled.div`
   div {
@@ -28,7 +28,7 @@ const StyledSchemaForm = styled.div`
   fieldset fieldset {
     padding: ${units(1)};
     margin-top: ${units(1)};
-    border: 1px solid ${opaqueBlack32};
+    border: 1px solid ${grayBorderAccent};
   }
 
   fieldset fieldset button {
@@ -36,7 +36,7 @@ const StyledSchemaForm = styled.div`
     width: 32px !important;
     background: #fff !important;
     border-radius: 5px !important;
-    color: ${opaqueBlack32} !important;
+    color: ${grayBorderAccent} !important;
   }
   
   #bot-fetch fieldset div {

--- a/src/app/components/team/TeamLists/TeamListsColumn.js
+++ b/src/app/components/team/TeamLists/TeamListsColumn.js
@@ -5,7 +5,7 @@ import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import TeamListsItem from './TeamListsItem';
-import { opaqueBlack54 } from '../../../styles/js/shared';
+import { textSecondary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   column: {
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     border: '1px solid transparent', // To match column of teamListComponent.js
   },
   placeholder: {
-    color: opaqueBlack54,
+    color: textSecondary,
     textAlign: 'center',
   },
   columnTitle: {

--- a/src/app/components/team/TeamLists/TeamListsColumn.js
+++ b/src/app/components/team/TeamLists/TeamListsColumn.js
@@ -5,7 +5,7 @@ import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import TeamListsItem from './TeamListsItem';
-import { black54 } from '../../../styles/js/shared';
+import { opaqueBlack54 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   column: {
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     border: '1px solid transparent', // To match column of teamListComponent.js
   },
   placeholder: {
-    color: black54,
+    color: opaqueBlack54,
     textAlign: 'center',
   },
   columnTitle: {

--- a/src/app/components/team/TeamLists/TeamListsComponent.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.js
@@ -12,7 +12,7 @@ import CardContent from '@material-ui/core/CardContent';
 import TeamListsColumn from './TeamListsColumn';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmDialog from '../../layout/ConfirmDialog';
-import { ContentColumn, black16 } from '../../../styles/js/shared';
+import { ContentColumn, opaqueBlack16 } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const useStyles = makeStyles(theme => ({
@@ -203,7 +203,7 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
                 style={{
                   background: '#F6F6F6',
                   borderRadius: '5px',
-                  border: `1px solid ${black16}`,
+                  border: `1px solid ${opaqueBlack16}`,
                   padding: '.3rem 1rem .5rem 0',
                 }}
               />

--- a/src/app/components/team/TeamLists/TeamListsComponent.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.js
@@ -12,7 +12,7 @@ import CardContent from '@material-ui/core/CardContent';
 import TeamListsColumn from './TeamListsColumn';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmDialog from '../../layout/ConfirmDialog';
-import { ContentColumn, opaqueBlack16 } from '../../../styles/js/shared';
+import { ContentColumn, grayBorderMain } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const useStyles = makeStyles(theme => ({
@@ -203,7 +203,7 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
                 style={{
                   background: '#F6F6F6',
                   borderRadius: '5px',
-                  border: `1px solid ${opaqueBlack16}`,
+                  border: `1px solid ${grayBorderMain}`,
                   padding: '.3rem 1rem .5rem 0',
                 }}
               />

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -7,11 +7,11 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Reorder from '../../layout/Reorder';
-import { black16 } from '../../../styles/js/shared';
+import { opaqueBlack16 } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {
-    border: `2px solid ${black16}`,
+    border: `2px solid ${opaqueBlack16}`,
     borderRadius: '5px',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -7,11 +7,11 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Reorder from '../../layout/Reorder';
-import { opaqueBlack16 } from '../../../styles/js/shared';
+import { grayBorderMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {
-    border: `2px solid ${opaqueBlack16}`,
+    border: `2px solid ${grayBorderMain}`,
     borderRadius: '5px',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),

--- a/src/app/components/user/UserMenu.js
+++ b/src/app/components/user/UserMenu.js
@@ -8,7 +8,7 @@ import UserMenuItems from '../UserMenuItems';
 import UserAvatar from '../UserAvatar';
 import {
   Text,
-  opaqueBlack54,
+  textSecondary,
   units,
   body1,
 } from '../../styles/js/shared';
@@ -52,7 +52,7 @@ export default class UserMenu extends React.Component {
                     {user ? user.name : null}
                   </span>
                   {role ? (
-                    <span className="user-menu__role" style={{ color: opaqueBlack54, marginLeft: units(1) }}>
+                    <span className="user-menu__role" style={{ color: textSecondary, marginLeft: units(1) }}>
                       <LocalizedRole role={role} />
                     </span>
                   ) : null}

--- a/src/app/components/user/UserMenu.js
+++ b/src/app/components/user/UserMenu.js
@@ -8,7 +8,7 @@ import UserMenuItems from '../UserMenuItems';
 import UserAvatar from '../UserAvatar';
 import {
   Text,
-  black54,
+  opaqueBlack54,
   units,
   body1,
 } from '../../styles/js/shared';
@@ -52,7 +52,7 @@ export default class UserMenu extends React.Component {
                     {user ? user.name : null}
                   </span>
                   {role ? (
-                    <span className="user-menu__role" style={{ color: black54, marginLeft: units(1) }}>
+                    <span className="user-menu__role" style={{ color: opaqueBlack54, marginLeft: units(1) }}>
                       <LocalizedRole role={role} />
                     </span>
                   ) : null}

--- a/src/app/components/user/UserTooltip.js
+++ b/src/app/components/user/UserTooltip.js
@@ -12,8 +12,8 @@ import ParsedText from '../ParsedText';
 import SocialIcon from '../SocialIcon';
 import { truncateLength } from '../../helpers';
 import {
-  opaqueBlack38,
-  opaqueBlack54,
+  textDisabled,
+  textSecondary,
   body2,
   caption,
   units,
@@ -28,7 +28,7 @@ const StyledMdLaunch = styled.div`
   svg {
     min-width: 20px !important;
     min-height: 20px !important;
-    color: ${opaqueBlack38};
+    color: ${textDisabled};
   }
 `;
 
@@ -56,7 +56,7 @@ const StyledSmallColumnTooltip = styled.div`
 `;
 
 const StyledUserRole = styled.span`
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   font: ${caption};
   margin: ${units(1)};
 `;

--- a/src/app/components/user/UserTooltip.js
+++ b/src/app/components/user/UserTooltip.js
@@ -12,8 +12,8 @@ import ParsedText from '../ParsedText';
 import SocialIcon from '../SocialIcon';
 import { truncateLength } from '../../helpers';
 import {
-  black38,
-  black54,
+  opaqueBlack38,
+  opaqueBlack54,
   body2,
   caption,
   units,
@@ -28,7 +28,7 @@ const StyledMdLaunch = styled.div`
   svg {
     min-width: 20px !important;
     min-height: 20px !important;
-    color: ${black38};
+    color: ${opaqueBlack38};
   }
 `;
 
@@ -56,7 +56,7 @@ const StyledSmallColumnTooltip = styled.div`
 `;
 
 const StyledUserRole = styled.span`
-  color: ${black54};
+  color: ${opaqueBlack54};
   font: ${caption};
   margin: ${units(1)};
 `;

--- a/src/app/styles/js/HeaderCard.js
+++ b/src/app/styles/js/HeaderCard.js
@@ -4,8 +4,8 @@ import {
   mediaQuery,
   units,
   headline,
-  opaqueBlack38,
-  opaqueBlack54,
+  textDisabled,
+  textSecondary,
   caption,
   subheading1,
   Row,
@@ -38,13 +38,13 @@ export const StyledName = styled.h1`
 `;
 
 export const StyledDescription = styled.div`
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   font: ${subheading1};
   margin-bottom: ${units(1)};
 `;
 
 export const StyledHelper = styled.div`
-  color: ${opaqueBlack38};
+  color: ${textDisabled};
   font: ${caption};
   margin-bottom: ${units(2)};
   ${mediaQuery.handheld`
@@ -53,7 +53,7 @@ export const StyledHelper = styled.div`
 `;
 
 export const StyledContactInfo = styled.div`
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   display: flex;
   flex-flow: wrap row;
   font: ${caption};

--- a/src/app/styles/js/HeaderCard.js
+++ b/src/app/styles/js/HeaderCard.js
@@ -4,8 +4,8 @@ import {
   mediaQuery,
   units,
   headline,
-  black38,
-  black54,
+  opaqueBlack38,
+  opaqueBlack54,
   caption,
   subheading1,
   Row,
@@ -38,13 +38,13 @@ export const StyledName = styled.h1`
 `;
 
 export const StyledDescription = styled.div`
-  color: ${black54};
+  color: ${opaqueBlack54};
   font: ${subheading1};
   margin-bottom: ${units(1)};
 `;
 
 export const StyledHelper = styled.div`
-  color: ${black38};
+  color: ${opaqueBlack38};
   font: ${caption};
   margin-bottom: ${units(2)};
   ${mediaQuery.handheld`
@@ -53,7 +53,7 @@ export const StyledHelper = styled.div`
 `;
 
 export const StyledContactInfo = styled.div`
-  color: ${black54};
+  color: ${opaqueBlack54};
   display: flex;
   flex-flow: wrap row;
   font: ${caption};

--- a/src/app/styles/js/global.js
+++ b/src/app/styles/js/global.js
@@ -1,7 +1,7 @@
 import {
   otherWhite,
   body1,
-  black87,
+  opaqueBlack87,
   title1,
   subheading1,
   textLink,
@@ -33,12 +33,12 @@ export const typography = `
   }
 
   h1 {
-    color: ${black87};
+    color: ${opaqueBlack87};
     font: ${title1};
   }
 
   h2 {
-    color: ${black87};
+    color: ${opaqueBlack87};
     font: ${subheading1};
   }
 

--- a/src/app/styles/js/global.js
+++ b/src/app/styles/js/global.js
@@ -1,7 +1,6 @@
 import {
   otherWhite,
   body1,
-  opaqueBlack87,
   title1,
   subheading1,
   textLink,
@@ -33,12 +32,12 @@ export const typography = `
   }
 
   h1 {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     font: ${title1};
   }
 
   h2 {
-    color: ${opaqueBlack87};
+    color: ${textPrimary};
     font: ${subheading1};
   }
 

--- a/src/app/styles/js/global.js
+++ b/src/app/styles/js/global.js
@@ -32,8 +32,7 @@ export const typography = `
     font: ${body1};
   }
 
-  h1,
-  .main-title {
+  h1 {
     color: ${black87};
     font: ${title1};
   }

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -6,7 +6,7 @@ import Card from '@material-ui/core/Card';
 // Check Design System Colors
 export const brandMain = '#567bff';
 export const brandSecondary = '#3b5cd0';
-export const brandLight = '#cfdfff';
+export const brandLight = '#e7efff';
 export const brandAccent = '#293e86';// eslint-disable-line import/no-unused-modules
 export const brandBorder = '#d0d6ec';// eslint-disable-line import/no-unused-modules
 export const brandBackground = '#f1f5f6';
@@ -47,7 +47,6 @@ export const black38 = 'rgba(0, 0, 0, .38)';
 export const black32 = 'rgba(0, 0, 0, .32)';
 export const black16 = 'rgba(0, 0, 0, .16)';
 export const black05 = 'rgba(0, 0, 0, .05)';
-export const black02 = 'rgba(0, 0, 0, .02)'; // eslint-disable-line import/no-unused-modules
 
 // Material blacks, translated to opaque versions
 //
@@ -58,9 +57,9 @@ export const opaqueBlack23 = '#c4c4c4';
 export const opaqueBlack16 = '#d6d6d6';
 export const opaqueBlack10 = '#e5e5e5';
 export const opaqueBlack07 = '#eeeeee';
-export const opaqueBlack05 = '#f2f2f2'; // eslint-disable-line import/no-unused-modules
+export const opaqueBlack05 = '#f2f2f2';
 export const opaqueBlack03 = '#f8f8f8';
-export const opaqueBlack02 = '#fafafa'; // eslint-disable-line import/no-unused-modules
+export const opaqueBlack02 = '#fafafa';
 
 // Social network colors
 //

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -33,23 +33,9 @@ export const errorLight = '#ffeeed';// eslint-disable-line import/no-unused-modu
 export const grayBackground = '#f7f7f7';// eslint-disable-line import/no-unused-modules
 export const grayDisabledBackground = '#efefef';// eslint-disable-line import/no-unused-modules
 export const grayBorderMain = '#e4e4e4';
-export const grayBorderAccent = '#b4b4b4';// eslint-disable-line import/no-unused-modules
+export const grayBorderAccent = '#b4b4b4';
 
 export const otherWhite = '#fff';
-
-// Material blacks, translated to opaque versions
-//
-export const opaqueBlack87 = '#212121';
-export const opaqueBlack54 = '#757575';
-export const opaqueBlack38 = '#9e9e9e';
-export const opaqueBlack23 = '#c4c4c4';
-export const opaqueBlack16 = '#d6d6d6';
-export const opaqueBlack10 = '#e5e5e5';
-export const opaqueBlack07 = '#eeeeee';
-export const opaqueBlack05 = '#f2f2f2';
-export const opaqueBlack03 = '#f8f8f8';
-export const opaqueBlack02 = '#fafafa';
-export const opaqueBlack32 = '#ADADAD';
 
 // Social network colors
 //
@@ -321,7 +307,7 @@ const shimmerKeyframes = keyframes`
 export const Shimmer = styled.div`
   animation: ${shimmerKeyframes} 1s ease-out infinite;
   animation-fill-mode: forwards;
-  background: linear-gradient(90deg, ${opaqueBlack05}, ${opaqueBlack05}, ${opaqueBlack02}, ${opaqueBlack02}, ${otherWhite}, ${opaqueBlack02}, ${opaqueBlack05}, ${opaqueBlack05});
+  background: linear-gradient(90deg, ${grayDisabledBackground}, ${grayDisabledBackground}, ${grayBackground}, ${grayBackground}, ${otherWhite}, ${grayBackground}, ${grayDisabledBackground}, ${grayDisabledBackground});
   background-size: 400%;
 `;
 
@@ -330,7 +316,7 @@ const pulseKeyframes = keyframes`
     background-color: ${otherWhite};
   }
   50% {
-    background-color: ${opaqueBlack02};
+    background-color: ${grayBackground};
   }
   100% {
     background-color: ${otherWhite};
@@ -372,7 +358,7 @@ export const Text = styled.div`
 export const HeaderTitle = styled.h3`
   ${ellipsisStyles}
   font: ${subheading2};
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   max-width: 45vw;
   ${mediaQuery.tablet`
      max-width: 27vw;
@@ -386,7 +372,7 @@ export const HeaderTitle = styled.h3`
 export const StyledSubHeader = styled.h2`
   font: ${title1};
   font-weight: 600;
-  color: ${opaqueBlack54};
+  color: ${textSecondary};
   text-align: center;
   margin-top: ${units(2)};
 `;
@@ -479,7 +465,7 @@ export const AlignOpposite = styled.div`
 export const StyledIconButton = styled(IconButton)`
   font-size: 20px !important;
   svg {
-    color: ${opaqueBlack38} !important;
+    color: ${textDisabled} !important;
     margin: 0!important;
   }
 `;

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -37,17 +37,6 @@ export const grayBorderAccent = '#b4b4b4';// eslint-disable-line import/no-unuse
 
 export const otherWhite = '#fff';
 
-// Material blacks
-// TODO make these opaque!
-// TODO change their names!
-// TODO https://material.io/design/color/the-color-system.html
-export const black87 = 'rgba(0, 0, 0, .87)';
-export const black54 = 'rgba(0, 0, 0, .54)';
-export const black38 = 'rgba(0, 0, 0, .38)';
-export const black32 = 'rgba(0, 0, 0, .32)';
-export const black16 = 'rgba(0, 0, 0, .16)';
-export const black05 = 'rgba(0, 0, 0, .05)';
-
 // Material blacks, translated to opaque versions
 //
 export const opaqueBlack87 = '#212121';
@@ -60,6 +49,7 @@ export const opaqueBlack07 = '#eeeeee';
 export const opaqueBlack05 = '#f2f2f2';
 export const opaqueBlack03 = '#f8f8f8';
 export const opaqueBlack02 = '#fafafa';
+export const opaqueBlack32 = '#ADADAD';
 
 // Social network colors
 //
@@ -382,7 +372,7 @@ export const Text = styled.div`
 export const HeaderTitle = styled.h3`
   ${ellipsisStyles}
   font: ${subheading2};
-  color: ${black54};
+  color: ${opaqueBlack54};
   max-width: 45vw;
   ${mediaQuery.tablet`
      max-width: 27vw;
@@ -396,7 +386,7 @@ export const HeaderTitle = styled.h3`
 export const StyledSubHeader = styled.h2`
   font: ${title1};
   font-weight: 600;
-  color: ${black54};
+  color: ${opaqueBlack54};
   text-align: center;
   margin-top: ${units(2)};
 `;
@@ -489,7 +479,7 @@ export const AlignOpposite = styled.div`
 export const StyledIconButton = styled(IconButton)`
   font-size: 20px !important;
   svg {
-    color: ${black38} !important;
+    color: ${opaqueBlack38} !important;
     margin: 0!important;
   }
 `;


### PR DESCRIPTION
## Description

This is a followup on work started for [CV2-2801](https://meedan.atlassian.net/browse/CV2-2801), first seen in [PR 1348](https://github.com/meedan/check-web/pull/1348)

References: [CV2-2801](https://meedan.atlassian.net/browse/CV2-2801), [1348](https://github.com/meedan/check-web/pull/1348)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Since I was just replacing colors. What I did was:
1. replace the opacity colors with the opaque versions
2. then found a replacement for each opaque color with a color already in our design system.
3. Check the grid below that I used to work from. The color on the left is the "original" and the right is the replacement from the design system:

<img width="364" alt="Screenshot 2023-02-24 at 2 28 06 PM" src="https://user-images.githubusercontent.com/418001/221273339-fd285ca7-a87d-44d3-8d73-84910a4ad7c2.png">


## Things to pay attention to during code review

Shouldn't been too much to look out for since the replacements are similar shades of black.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-2801]: https://meedan.atlassian.net/browse/CV2-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CV2-2801]: https://meedan.atlassian.net/browse/CV2-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ