### PR TITLE
Refactor: remove `react-color`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,11 +1270,6 @@
         }
       }
     },
-    "@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -12133,11 +12128,6 @@
         }
       }
     },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
-    },
     "material-ui-popup-state": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-1.5.4.tgz",
@@ -13997,19 +13987,6 @@
         }
       }
     },
-    "react-color": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.1.tgz",
-      "integrity": "sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==",
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "react-copy-to-clipboard": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.3.tgz",
@@ -14305,14 +14282,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "read-pkg": {
@@ -16213,11 +16182,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tlds": {
       "version": "1.207.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "rc-tooltip": "^3.5.0",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",
-    "react-color": "^2.17.0",
     "react-copy-to-clipboard": "^5.0.0",
     "react-document-title": "^2.0.2",
     "react-dom": "^17.0.2",

--- a/src/app/components/layout/ColorPicker.js
+++ b/src/app/components/layout/ColorPicker.js
@@ -1,10 +1,9 @@
+/* eslint-disable jsx-a11y/label-has-for */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
-import Popover from '@material-ui/core/Popover';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { SketchPicker } from 'react-color';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
   statusButton: props => ({
@@ -17,31 +16,25 @@ const useStyles = makeStyles(theme => ({
   statusButtonIcon: {
     fontSize: 32,
   },
+  input: {
+    position: 'absolute',
+    opacity: 0,
+    width: '100%',
+    height: '100%',
+  },
 }));
 
 const ColorPicker = ({ color, onChange }) => {
   const classes = useStyles({ backgroundColor: color });
-  const [colorPickerAnchorEl, setColorPickerAnchorEl] = React.useState(null);
 
   return (
     <React.Fragment>
       <IconButton
         className={classes.statusButton}
-        onClick={e => setColorPickerAnchorEl(e.currentTarget)}
       >
         <ExpandMoreIcon className={classes.statusButtonIcon} />
+        <input className={classes.input} type="color" id="head" name="head" value={color} onChange={onChange} />
       </IconButton>
-      <Popover
-        open={Boolean(colorPickerAnchorEl)}
-        anchorEl={colorPickerAnchorEl}
-        onClose={() => setColorPickerAnchorEl(null)}
-      >
-        <SketchPicker
-          color={color}
-          onChangeComplete={onChange}
-          disableAlpha
-        />
-      </Popover>
     </React.Fragment>
   );
 };

--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -88,6 +88,10 @@ const ReportDesignerForm = (props) => {
     props.onUpdate(updates);
   };
 
+  const handleChangeColor = (event) => {
+    props.onUpdate('theme_color', event.target.value);
+  };
+
   const textFieldProps = {
     className: classes.textField,
     variant: 'outlined',
@@ -301,7 +305,7 @@ const ReportDesignerForm = (props) => {
               <Box display="flex">
                 <ColorPicker
                   color={data.theme_color}
-                  onChange={color => props.onUpdate('theme_color', color.hex)}
+                  onChange={handleChangeColor}
                 />
                 <div className={classes.spacer} />
                 <Box display="flex" flexWrap="wrap" flexGrow="1">

--- a/src/app/components/team/Statuses/EditStatusDialog.js
+++ b/src/app/components/team/Statuses/EditStatusDialog.js
@@ -74,6 +74,10 @@ const EditStatusDialog = ({
     }
   };
 
+  const handleChangeColor = (event) => {
+    setStatusColor(event.target.value);
+  };
+
   return (
     <Dialog
       open={open}
@@ -116,7 +120,7 @@ const EditStatusDialog = ({
           <Box p={1} />
           <ColorPicker
             color={statusColor}
-            onChange={color => setStatusColor(color.hex)}
+            onChange={handleChangeColor}
           />
         </Box>
         <TextField


### PR DESCRIPTION
This PR removes `react-color`, which is 130kb minified, and replaces it with `<input type="color">`, with no change to the end user experience.

References: CHECK-2815

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manual testing of the two places in code this is used.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

