### PR TITLE
fix errors seen in console for typography not listed in shared.js

### DIFF
--- a/src/app/components/media/MediaAnalysis.js
+++ b/src/app/components/media/MediaAnalysis.js
@@ -38,7 +38,7 @@ const MediaAnalysis = ({ projectMedia }) => {
         <Divider />
       </Box>
       <Box mt={2} mb={3}>
-        <Typography variant="body" component="div" paragraph>
+        <Typography variant="body1" component="div" paragraph>
           <strong>
             <FormattedMessage id="mediaAnalysis.analysis" defaultMessage="Analysis" description="Title of the media analysis bar" />
           </strong>

--- a/src/app/components/media/MediaClaim.js
+++ b/src/app/components/media/MediaClaim.js
@@ -123,7 +123,7 @@ const MediaClaim = ({ projectMedia }) => {
   return (
     <Box id="media__claim">
       <Box id="media__claim-title" display="flex" alignItems="center" mb={2} justifyContent="space-between">
-        <Typography className={classes.title} variant="body" component="div">
+        <Typography className={classes.title} variant="body1" component="div">
           <strong>
             <FormattedMessage id="mediaClaim.claim" defaultMessage="Claim" description="Title of the media claim section." />
           </strong>

--- a/src/app/components/media/MediaCreatedBy.js
+++ b/src/app/components/media/MediaCreatedBy.js
@@ -47,7 +47,7 @@ const MediaCreatedBy = ({ projectMedia, intl }) => {
   const formattedChannelName = Object.keys(messages).includes(channelNameKey) ? intl.formatMessage(messages[channelNameKey]) : creatorName;
 
   return (
-    <Typography className={classes.createdBy} variant="body" component="div">
+    <Typography className={classes.createdBy} variant="body1" component="div">
       <FormattedMessage
         id="mediaCreatedBy.createdBy"
         defaultMessage="Item created by {name}"

--- a/src/app/components/media/Similarity/MediaSuggestionReview.js
+++ b/src/app/components/media/Similarity/MediaSuggestionReview.js
@@ -252,7 +252,7 @@ const MediaSuggestionReview = ({ projectMedia, setFlashMessage }) => {
           <Typography className={classes.title} variant="h5" component="h1">
             <FormattedMessage id="mediaSuggestionReview.matchTitle" defaultMessage="Matched claim" description="Title of a box that lets the user open a claim that this has been matched with." />
           </Typography>
-          <Typography className={classes.prompt} variant="body" component="p">
+          <Typography className={classes.prompt} variant="body1" component="p">
             <FormattedMessage
               id="mediaSuggestionReview.matchDescription"
               defaultMessage="This media has been matched to the claim and fact-check below."
@@ -289,7 +289,7 @@ const MediaSuggestionReview = ({ projectMedia, setFlashMessage }) => {
         <Typography className={classes.title} variant="h5" component="h1">
           <FormattedMessage id="mediaSuggestionReview.title" defaultMessage="Suggested Claim and Fact-check" description="Title of a box that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)." />
         </Typography>
-        <Typography className={classes.prompt} variant="body" component="p">
+        <Typography className={classes.prompt} variant="body1" component="p">
           <FormattedMessage id="mediaSuggestionReview.prompt" defaultMessage="Is the Claim or Fact-check below a good match for this media?" description="Text that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)." />
         </Typography>
         <Grid container direction="row" justifyContent="center" alignItems="flex-end">

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -330,7 +330,7 @@ const MediaSuggestionsComponent = ({
               />
             </Typography>
             <div className={classes.break} />
-            <Typography variant="body">
+            <Typography variant="body1">
               <FormattedMessage
                 id="mediaSuggestionsComponent.flashBulkReject"
                 defaultMessage='Added to the list "{folder}"'
@@ -688,7 +688,7 @@ const MediaSuggestionsComponent = ({
                     <PreviousIcon />
                   </IconButton>
                 </Tooltip>
-                <Typography variant="body" className={classes.title}>
+                <Typography variant="body1" className={classes.title}>
                   <FormattedMessage
                     id="mediaSuggestionsComponent.title"
                     defaultMessage="{start} to {end} of {total, plural, one {{total} suggestion} other {{total} suggestions}}"


### PR DESCRIPTION
## Description

While looking through some errors in the browser console I noticed there were some regarding an invalid typography variable being set as `body` but this is not listed in the typography definition in shared.js. I figured this was a missed holdover from a previous change. I have set them to `body1` to remove the console error.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Checked the browser console for presence of the error.
### Example BEFORE, error present:
<img width="849" alt="Screenshot 2023-03-02 at 1 44 17 PM" src="https://user-images.githubusercontent.com/418001/222522567-9ee28de6-7636-414b-9930-f6e5673fba77.png">


## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

