### PR TITLE
Hardcoded, hardcore colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15008,7 +15008,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15008,7 +15008,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -9,7 +9,7 @@ import reactStringReplace from 'react-string-replace';
 import Message from './Message';
 import { withClientSessionId } from '../ClientSessionId';
 import { safelyParseJSON, createFriendlyErrorMessage } from '../helpers';
-import { brandMain, otherWhite, textSecondary } from '../styles/js/shared';
+import { brandMain, textSecondary, otherWhite } from '../styles/js/shared';
 
 /**
  * A global message, already translated for the user.
@@ -71,11 +71,11 @@ const useSnackBarStyles = makeStyles({
     backgroundColor: `${brandMain} !important`,
   },
   icon: {
-    color: 'white !important',
+    color: `${otherWhite} !important`,
     marginTop: '8px !important',
     paddingTop: '0px !important',
     '&:hover': {
-      color: 'white !important',
+      color: `${otherWhite} !important`,
     },
   },
   root: {

--- a/src/app/components/Login.js
+++ b/src/app/components/Login.js
@@ -21,6 +21,7 @@ import {
   StyledSubHeader,
   StyledCard,
   brandMain,
+  grayBorderMain,
 } from '../styles/js/shared';
 
 const styles = {
@@ -40,7 +41,7 @@ const styles = {
     margin: `${units(2)} auto`,
   },
   googleButton: {
-    border: '2px solid #D5D5D5',
+    border: `2px solid ${grayBorderMain}`,
   },
   orDivider: {
     padding: `${units(3)} 0`,

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -694,7 +694,7 @@ class Annotation extends Component {
                     style={{
                       background: `transparent url('${botResponse.image_url}') top left no-repeat`,
                       backgroundSize: 'cover',
-                      border: '1px solid #ccc',
+                      border: `1px solid ${grayBorderMain}`,
                       width: 80,
                       height: 80,
                       cursor: 'pointer',

--- a/src/app/components/annotations/TiplineRequest.js
+++ b/src/app/components/annotations/TiplineRequest.js
@@ -23,6 +23,7 @@ import {
   telegramBlue,
   viberPurple,
   lineGreen,
+  otherWhite,
 } from '../../styles/js/shared';
 
 const messages = defineMessages({
@@ -40,7 +41,7 @@ const SmoochIcon = ({ name }) => {
       <WhatsAppIcon
         style={{
           backgroundColor: whatsappGreen,
-          color: '#FFF',
+          color: otherWhite,
           borderRadius: 4,
           padding: 2,
         }}

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -5,6 +5,7 @@ import {
   Box,
   Typography,
 } from '@material-ui/core';
+import { otherWhite, textPrimary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {
@@ -49,8 +50,8 @@ const Alert = ({
 Alert.defaultProps = {
   icon: null,
   content: null,
-  primaryColor: 'white',
-  secondaryColor: 'black',
+  primaryColor: otherWhite,
+  secondaryColor: textPrimary,
 };
 
 Alert.propTypes = {

--- a/src/app/components/cds/media-cards/MediaCardCondensed.js
+++ b/src/app/components/cds/media-cards/MediaCardCondensed.js
@@ -7,15 +7,15 @@ import {
 import ExternalLink from '../../ExternalLink';
 import ParsedText from '../../ParsedText';
 import BulletSeparator from '../../layout/BulletSeparator';
-import { brandBorder } from '../../../styles/js/shared';
+import { brandBorder, grayBorderAccent, otherWhite, textPrimary } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     border: `1px solid ${brandBorder}`,
     borderRadius: 8,
-    color: 'black',
-    backgroundColor: 'white',
+    color: textPrimary,
+    backgroundColor: otherWhite,
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
     padding: theme.spacing(1),
@@ -69,9 +69,9 @@ const useStyles = makeStyles(theme => ({
     maxWidth: '33vw', // 1/3 of the viewport width
   },
   placeholder: {
-    border: '1px solid rgba(0, 0, 0, 0.23)',
+    border: `1px solid ${grayBorderAccent}`,
     borderRadius: theme.spacing(1),
-    color: 'black',
+    color: textPrimary,
     padding: theme.spacing(2),
     display: 'flex',
     flexDirection: 'column',

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -30,7 +30,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import ProjectsListItem from './ProjectsListItem';
 import NewProject from './NewProject';
 import Can from '../../Can';
-import { brandLight } from '../../../styles/js/shared';
+import { brandLight, otherWhite } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const useStyles = makeStyles(theme => ({
@@ -62,7 +62,7 @@ const useStyles = makeStyles(theme => ({
     right: 0,
     top: 0,
     bottom: 0,
-    background: 'white',
+    background: otherWhite,
     opacity: 0.7,
     zIndex: 1,
   },

--- a/src/app/components/feed/FeedItemComponent.js
+++ b/src/app/components/feed/FeedItemComponent.js
@@ -42,6 +42,7 @@ import {
   textSecondary,
   textDisabled,
   Column,
+  otherWhite,
 } from '../../styles/js/shared';
 import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
 import { withSetFlashMessage } from '../FlashMessage';
@@ -52,14 +53,14 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: brandBackground,
   },
   claimsColumn: {
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
     borderRight: `1px solid ${brandBorder}`,
     width: 360,
     minWidth: 360,
     maxWidth: 360,
   },
   middleColumn: {
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
     borderRight: `1px solid ${brandBorder}`,
   },
   mediasColumn: {
@@ -135,7 +136,7 @@ const useStyles = makeStyles(theme => ({
   },
   selected: {
     backgroundColor: brandSecondary,
-    border: '1px solid #ced3e2',
+    border: `1px solid ${brandBorder}`,
   },
   detailTitle: {
     overflow: 'hidden',
@@ -164,9 +165,9 @@ const useStyles = makeStyles(theme => ({
   },
   box: {
     textAlign: 'center',
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
     padding: theme.spacing(2),
-    border: '1px solid #ced3e2',
+    border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(1),
     whiteSpace: 'nowrap',
   },

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -28,7 +28,7 @@ import ErrorBoundary from '../error/ErrorBoundary';
 import MediasLoading from '../media/MediasLoading';
 import SearchKeyword from '../search/SearchKeyword';
 import ProjectBlankState from '../project/ProjectBlankState';
-import { grayBackground, textPrimary } from '../../styles/js/shared';
+import { grayBackground, textPrimary, otherWhite, alertMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles({
   root: {
@@ -51,8 +51,8 @@ const useStyles = makeStyles({
   noFactCheck: {
     fontSize: 12,
     fontWeight: 400,
-    color: 'white',
-    background: '#E78A00',
+    color: otherWhite,
+    background: alertMain,
     display: 'inline-block',
     borderRadius: '50px',
     padding: '3px 10px',

--- a/src/app/components/feed/MediaCard.js
+++ b/src/app/components/feed/MediaCard.js
@@ -6,14 +6,14 @@ import MediaPreview from './MediaPreview';
 import ExternalLink from '../ExternalLink';
 import ParsedText from '../ParsedText';
 import BulletSeparator from '../layout/BulletSeparator';
-import { brandBorder } from '../../styles/js/shared';
+import { brandBorder, otherWhite } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     border: `1px solid ${brandBorder}`,
     borderRadius: 8,
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
     padding: theme.spacing(2),

--- a/src/app/components/feed/MediaCardCondensed.js
+++ b/src/app/components/feed/MediaCardCondensed.js
@@ -9,7 +9,7 @@ import FeedRequestedMediaDialog from './FeedRequestedMediaDialog';
 import ExternalLink from '../ExternalLink';
 import ParsedText from '../ParsedText';
 import BulletSeparator from '../layout/BulletSeparator';
-import { brandBorder } from '../../styles/js/shared';
+import { brandBorder, textPrimary, otherWhite } from '../../styles/js/shared';
 
 // Modelled after src/app/components/media/Similarity/MediaItem.js
 
@@ -19,8 +19,8 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     border: `1px solid ${brandBorder}`,
     borderRadius: 8,
-    color: 'black',
-    backgroundColor: 'white',
+    color: textPrimary,
+    backgroundColor: otherWhite,
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
     padding: theme.spacing(1),

--- a/src/app/components/feed/RequestCards.js
+++ b/src/app/components/feed/RequestCards.js
@@ -11,7 +11,7 @@ import RequestSubscription from './RequestSubscription';
 import MediasLoading from '../media/MediasLoading';
 import ErrorBoundary from '../error/ErrorBoundary';
 import BulletSeparator from '../layout/BulletSeparator';
-import { whatsappGreen } from '../../styles/js/shared';
+import { whatsappGreen, alertMain, otherWhite } from '../../styles/js/shared';
 
 const useStyles = makeStyles({
   requestsHeader: {
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
   },
   subscriptions: {
-    color: '#E78A00',
+    color: alertMain,
   },
 });
 
@@ -36,7 +36,7 @@ const RequestCards = ({ request, mediaDbid }) => {
     <WhatsAppIcon
       style={{
         backgroundColor: whatsappGreen,
-        color: '#FFF',
+        color: otherWhite,
         borderRadius: 4,
         padding: 2,
       }}

--- a/src/app/components/feed/RequestSubscription.js
+++ b/src/app/components/feed/RequestSubscription.js
@@ -5,14 +5,15 @@ import Box from '@material-ui/core/Box';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import CheckIcon from '@material-ui/icons/Check';
 import { FormattedDate } from 'react-intl';
+import { validationMain, alertMain } from '../../styles/js/shared';
 
 const useStyles = makeStyles({
   bellIcon: {
-    color: '#E78A00',
+    color: alertMain,
     display: 'inline-block',
   },
   checkIcon: {
-    color: '#4CAF50',
+    color: validationMain,
     fontWeight: 700,
     fontSize: 12,
   },

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -59,8 +59,8 @@ const useStyles = makeStyles(theme => ({
     bottom: 0,
     color: otherWhite,
     minWidth: theme.spacing(22),
-    backgroundColor: props.contentWarning ? 'black' : brandMain,
-    border: '2px solid white',
+    backgroundColor: props.contentWarning ? textPrimary : brandMain,
+    border: `2px solid ${otherWhite}`,
     '& :hover': {
       backgroundColor: 'unset',
     },

--- a/src/app/components/layout/ColorPicker.js
+++ b/src/app/components/layout/ColorPicker.js
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { makeStyles } from '@material-ui/core/styles';
+import { brandBorder, otherWhite } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   statusButton: props => ({
     borderRadius: theme.spacing(0.5),
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
-    color: 'white',
+    color: otherWhite,
     backgroundColor: props.backgroundColor,
   }),
   statusButtonIcon: {

--- a/src/app/components/layout/ColorPicker.js
+++ b/src/app/components/layout/ColorPicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { makeStyles } from '@material-ui/core/styles';
-import { brandBorder, otherWhite } from '../../styles/js/shared';
+import { otherWhite } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   statusButton: props => ({

--- a/src/app/components/media/ChangeMediaSource.js
+++ b/src/app/components/media/ChangeMediaSource.js
@@ -7,6 +7,7 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import { can } from '../Can';
+import { brandMain } from '../../styles/js/shared';
 
 function ChangeMediaSource({
   team,
@@ -44,7 +45,7 @@ function ChangeMediaSource({
   if (can(projectMediaPermissions, 'create Source')) {
     createNew = (
       <Button
-        style={{ color: 'blue' }}
+        style={{ color: brandMain }}
         onClick={() => { createNewClick(input); }}
         id="media-source__create-button"
       >

--- a/src/app/components/media/CreateMediaInput.test.js
+++ b/src/app/components/media/CreateMediaInput.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
 import CreateMediaInput from './CreateMediaInput';
 import UploadFile from '../UploadFile';
+import { brandMain } from '../../styles/js/shared';
 
 describe('<CreateMediaInput />', () => {
   const team = {
@@ -16,8 +17,8 @@ describe('<CreateMediaInput />', () => {
           id: 'undetermined',
           label: 'Unstarted',
           style: {
-            backgroundColor: '#518FFF',
-            color: '#518FFF',
+            backgroundColor: brandMain,
+            color: brandMain,
           },
         },
       ],

--- a/src/app/components/media/CreateMediaSource.js
+++ b/src/app/components/media/CreateMediaSource.js
@@ -28,6 +28,7 @@ import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
 import {
   Row,
   StyledIconButton,
+  brandMain,
 } from '../../styles/js/shared';
 import {
   StyledTwoColumns,
@@ -50,7 +51,7 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'row-reverse',
   },
   linkedText: {
-    color: 'blue',
+    color: brandMain,
     textDecoration: 'underline',
   },
   sourceCardHeader: {

--- a/src/app/components/media/MediaActionsBar.test.js
+++ b/src/app/components/media/MediaActionsBar.test.js
@@ -3,6 +3,7 @@ import { shallowWithIntl } from '../../../../test/unit/helpers/intl-test';
 import MediaStatus from './MediaStatus';
 import { MediaActionsBarComponent } from './MediaActionsBar';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
+import { brandMain } from '../../styles/js/shared';
 
 describe('<MediaActionsBarComponent />', () => {
   const team = {
@@ -17,8 +18,8 @@ describe('<MediaActionsBarComponent />', () => {
           id: 'undetermined',
           label: 'Unstarted',
           style: {
-            backgroundColor: '#518FFF',
-            color: '#518FFF',
+            backgroundColor: brandMain,
+            color: brandMain,
           },
         },
       ],
@@ -40,8 +41,8 @@ describe('<MediaActionsBarComponent />', () => {
           id: 'undetermined',
           label: 'Unstarted',
           style: {
-            backgroundColor: '#518FFF',
-            color: '#518FFF',
+            backgroundColor: brandMain,
+            color: brandMain,
           },
         },
       ],

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -16,6 +16,7 @@ import CheckContext from '../../CheckContext';
 import { getStatus, getErrorMessage, bemClass } from '../../helpers';
 import { stringHelper } from '../../customHelpers';
 import { withSetFlashMessage } from '../FlashMessage';
+import { otherWhite } from '../../styles/js/shared';
 
 const StyledMediaStatus = styled.div`
   display: flex;
@@ -100,7 +101,7 @@ class MediaStatusCommon extends Component {
       <StyledMediaStatus className="media-status">
         <Button
           className={`media-status__label media-status__current ${MediaStatusCommon.currentStatusToClass(media.last_status || this.props.currentStatus)}`}
-          style={{ backgroundColor: currentStatus.style.color, color: 'white', minHeight: 41 }}
+          style={{ backgroundColor: currentStatus.style.color, color: otherWhite, minHeight: 41 }}
           variant="contained"
           disableElevation
           onClick={e => this.setState({ anchorEl: e.currentTarget })}

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.test.js
@@ -3,6 +3,7 @@ import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import ReportDesignerComponent from './ReportDesignerComponent';
 import ReportDesignerTopBar from './ReportDesignerTopBar';
 import CheckArchivedFlags from '../../../CheckArchivedFlags';
+import { brandMain } from '../../../styles/js/shared';
 
 describe('<ReportDesignerComponent />', () => {
   const props = {
@@ -21,8 +22,8 @@ describe('<ReportDesignerComponent />', () => {
               id: 'undetermined',
               label: 'Unstarted',
               style: {
-                backgroundColor: '#518FFF',
-                color: '#518FFF',
+                backgroundColor: brandMain,
+                color: brandMain,
               },
               locales: {
                 en: {

--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -18,6 +18,7 @@ import LanguagePickerSelect from '../../layout/LanguagePickerSelect';
 import { formatDate } from './reportDesignerHelpers';
 import LimitedTextFieldWithCounter from '../../layout/LimitedTextFieldWithCounter';
 import { safelyParseJSON } from '../../../helpers';
+import { otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -30,7 +31,7 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     right: 0,
     bottom: 0,
-    background: 'white',
+    background: otherWhite,
     opacity: 0.5,
     cursor: 'not-allowed',
     zIndex: 2,

--- a/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
@@ -8,7 +8,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import { brandBorder} from '../../../styles/js/shared';
+import { brandBorder } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   expansionPanelDetails: {

--- a/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
@@ -8,6 +8,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import { brandBorder} from '../../../styles/js/shared';
 
 const useStyles = makeStyles(() => ({
   expansionPanelDetails: {
@@ -15,7 +16,7 @@ const useStyles = makeStyles(() => ({
   },
   reportMessage: {
     boxShadow: 'none',
-    border: '1px solid #DFE4F4',
+    border: `1px solid ${brandBorder}`,
     borderRadius: '5px',
   },
 }));

--- a/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
@@ -9,21 +9,21 @@ import WarningIcon from '@material-ui/icons/Warning';
 import ParsedText from '../../ParsedText';
 import ReportDesignerImagePreview from './ReportDesignerImagePreview';
 import { formatDate } from './reportDesignerHelpers';
-import { errorMain, textPrimary } from '../../../styles/js/shared';
+import { errorMain, textPrimary, brandBorder, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     margin: '0 auto',
   },
   messagePreview: {
-    border: '2px solid #DFE4F4',
+    border: `2px solid ${brandBorder}`,
     borderRadius: '5px',
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
     padding: theme.spacing(2),
     marginBottom: theme.spacing(2),
     marginTop: theme.spacing(2),
     width: 502,
-    color: 'black',
+    color: textPrimary,
     lineHeight: '1.5em',
   },
   visualCardPreview: {
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'space-between',
-    color: 'white',
+    color: otherWhite,
     textAlign: 'center',
   },
   icon: {

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
@@ -15,18 +15,18 @@ import IconPause from '@material-ui/icons/Pause';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import ReportDesignerConfirmableButton from './ReportDesignerConfirmableButton';
 import MediaStatus from '../MediaStatus';
-import { validationMain, alertMain, brandSecondary, brandMain } from '../../../styles/js/shared';
+import { validationMain, alertMain, brandSecondary, brandMain, otherWhite } from '../../../styles/js/shared';
 import { getStatus } from '../../../helpers';
 import { languageLabel } from '../../../LanguageRegistry';
 
 const useStyles = makeStyles(theme => ({
   publish: {
     background: validationMain,
-    color: 'white',
+    color: otherWhite,
   },
   pause: {
     background: alertMain,
-    color: 'white',
+    color: otherWhite,
   },
   confirmation: {
     marginBottom: theme.spacing(2),

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.test.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import ReportDesignerTopBar from './ReportDesignerTopBar';
+import { brandMain } from '../../../styles/js/shared';
 
 describe('<ReportDesignerTopBar />', () => {
   const team = {
@@ -15,8 +16,8 @@ describe('<ReportDesignerTopBar />', () => {
           id: 'undetermined',
           label: 'Unstarted',
           style: {
-            backgroundColor: '#518FFF',
-            color: '#518FFF',
+            backgroundColor: brandMain,
+            color: brandMain,
           },
         },
       ],

--- a/src/app/components/media/Similarity/MediaItem.js
+++ b/src/app/components/media/Similarity/MediaItem.js
@@ -11,13 +11,13 @@ import LayersIcon from '@material-ui/icons/Layers';
 import TimeBefore from '../../TimeBefore';
 import MediaTypeDisplayName from '../MediaTypeDisplayName';
 import { parseStringUnixTimestamp, truncateLength } from '../../../helpers';
-import { brandSecondary, brandBorder, brandMain, alertMain, grayBorderAccent } from '../../../styles/js/shared';
+import { textPrimary, brandSecondary, brandBorder, brandMain, alertMain, grayBorderAccent, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   root: {
     border: `1px solid ${brandBorder}`,
     borderRadius: 8,
-    color: 'black',
+    color: textPrimary,
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
     justifyContent: 'space-between',
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
     width: 'calc(100% - 50px)', // Make space for the menu
   },
   notSelected: {
-    background: 'white',
+    background: otherWhite,
   },
   selected: {
     background: brandSecondary,
@@ -36,16 +36,16 @@ const useStyles = makeStyles(theme => ({
   title: {
     fontSize: 14,
     lineHeight: '1.5em',
-    color: 'black',
+    color: textPrimary,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     textDecoration: 'none',
     '&:hover': {
-      color: 'black',
+      color: textPrimary,
     },
     '&:visited': {
-      color: 'black',
+      color: textPrimary,
     },
   },
   image: {
@@ -73,7 +73,7 @@ const useStyles = makeStyles(theme => ({
     overflow: 'hidden',
   },
   description: {
-    color: 'black',
+    color: textPrimary,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -44,6 +44,8 @@ import {
   brandBorder,
   textSecondary,
   brandBackground,
+  otherWhite,
+  textPrimary,
 } from '../../../styles/js/shared';
 import BulkArchiveProjectMediaMutation from '../../../relay/mutations/BulkArchiveProjectMediaMutation';
 
@@ -90,15 +92,15 @@ const useStyles = makeStyles(theme => ({
   media: {
     border: `1px solid ${brandBorder}`,
     borderRadius: 8,
-    color: 'black',
-    backgroundColor: 'white',
+    color: textPrimary,
+    backgroundColor: otherWhite,
   },
   noMedia: {
-    color: 'black',
+    color: textPrimary,
     textAlign: 'center',
     fontWeight: 'bold',
     fontSize: 14,
-    backgroundColor: 'white',
+    backgroundColor: otherWhite,
   },
   spaced: {
     padding: theme.spacing(1),
@@ -120,8 +122,8 @@ const useStyles = makeStyles(theme => ({
   card: {
     border: `1px solid ${brandBorder}`,
     borderRadius: theme.spacing(2),
-    color: 'black',
-    backgroundColor: 'white',
+    color: textPrimary,
+    backgroundColor: otherWhite,
     margin: theme.spacing(2, 1, 1, 1),
     padding: theme.spacing(2),
     display: 'flex',

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -5,7 +5,7 @@ import { DatePicker } from '@material-ui/pickers';
 import InputBase from '@material-ui/core/InputBase';
 import { withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
-import { FlexRow, units, grayDisabledBackground, brandMain } from '../../styles/js/shared';
+import { FlexRow, units, grayDisabledBackground, brandMain, otherWhite} from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -31,7 +31,7 @@ const StyledInputBaseDate = withStyles(theme => ({
 const Styles = {
   dateRangeFilterSelected: {
     backgroundColor: brandMain,
-    color: 'white',
+    color: otherWhite,
     height: 24,
     margin: '6px 3px',
     borderRadius: 2,

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -5,7 +5,7 @@ import { DatePicker } from '@material-ui/pickers';
 import InputBase from '@material-ui/core/InputBase';
 import { withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
-import { FlexRow, units, grayDisabledBackground, brandMain, otherWhite} from '../../styles/js/shared';
+import { FlexRow, units, grayDisabledBackground, brandMain, otherWhite } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -13,7 +13,7 @@ import { withStyles } from '@material-ui/core/styles';
 import DateRangeIcon from '@material-ui/icons/DateRange';
 import CloseIcon from '@material-ui/icons/Close';
 import RemoveableWrapper from './RemoveableWrapper';
-import { FlexRow, units, grayDisabledBackground, brandMain } from '../../styles/js/shared';
+import { FlexRow, units, grayDisabledBackground, brandMain, otherWhite } from '../../styles/js/shared';
 import globalStrings from '../../globalStrings';
 
 const StyledCloseIcon = withStyles({
@@ -50,12 +50,12 @@ const StyledInputBaseDropdown = withStyles(theme => ({
     fontSize: 14,
     borderRadius: '4px',
     '& .MuiSelect-icon': {
-      color: 'white',
+      color: otherWhite,
     },
   },
   input: {
     backgroundColor: brandMain,
-    color: 'white',
+    color: otherWhite,
     paddingLeft: theme.spacing(1),
     '&:focus': {
       backgroundColor: brandMain,
@@ -74,7 +74,7 @@ const Styles = {
   },
   dateRangeFilterSelected: {
     backgroundColor: brandMain,
-    color: 'white',
+    color: otherWhite,
     height: 'auto',
     borderRadius: 4,
     paddingLeft: '8px',

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -11,13 +11,13 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { MultiSelector } from '@meedan/check-ui';
 import RemoveableWrapper from './RemoveableWrapper';
 import SelectButton from './SelectButton';
-import { brandMain, errorMain } from '../../styles/js/shared';
+import { textPrimary, brandMain, brandAccent, otherWhite, errorMain } from '../../styles/js/shared';
 
 const NoHoverButton = withStyles({
   root: {
     borderRadius: 0,
-    borderLeft: '2px solid white',
-    borderRight: '2px solid white',
+    borderLeft: `2px solid ${otherWhite}`,
+    borderRight: `2px solid ${otherWhite}`,
     height: '36px',
     minWidth: 0,
     margin: 0,
@@ -26,7 +26,7 @@ const NoHoverButton = withStyles({
     },
   },
   disabled: {
-    color: 'black !important',
+    color: `${textPrimary} !important`,
   },
 })(Button);
 
@@ -51,7 +51,7 @@ const useTagStyles = makeStyles({
     height: '24px',
     margin: '2px',
     lineHeight: '22px',
-    color: 'white',
+    color: otherWhite,
     backgroundColor: brandMain,
     borderRadius: '4px',
     boxSizing: 'content-box',
@@ -59,8 +59,8 @@ const useTagStyles = makeStyles({
     outline: 0,
     overflow: 'hidden',
     '& :focus': {
-      borderColor: '#40a9ff',
-      backgroundColor: '#e6f7ff',
+      borderColor: brandAccent,
+      backgroundColor: brandAccent,
     },
     '& span': {
       overflow: 'hidden',
@@ -110,7 +110,7 @@ const usePlusButtonStyles = makeStyles({
   root: {
     height: '36px',
     paddingLeft: '4px',
-    borderLeft: '2px solid white',
+    borderLeft: '2px solid otherWhite',
     alignItems: 'center',
     display: 'flex',
     cursor: 'pointer',

--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -17,6 +17,7 @@ import {
   grayBorderMain,
   borderWidthLarge,
   brandMain,
+  otherWhite,
 } from '../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
@@ -55,7 +56,7 @@ const useStyles = makeStyles(theme => ({
     marginLeft: theme.spacing(2),
   },
   closeButton: {
-    color: 'white',
+    color: otherWhite,
     zIndex: 1000,
     position: 'absolute',
     right: theme.spacing(1),

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -27,7 +27,7 @@ import MultiSelectFilter from '../MultiSelectFilter';
 import SaveList from '../SaveList';
 import { can } from '../../Can';
 import { languageLabel } from '../../../LanguageRegistry';
-import { Row, brandMain } from '../../../styles/js/shared';
+import { Row, brandMain, textPrimary } from '../../../styles/js/shared';
 import SearchFieldSource from './SearchFieldSource';
 import SearchFieldTag from './SearchFieldTag';
 import SearchFieldChannel from './SearchFieldChannel';
@@ -298,7 +298,7 @@ const SearchFields = ({
   const OperatorToggle = () => {
     let operatorProps = { style: { minWidth: 0, color: brandMain }, onClick: handleOperatorClick };
     if (page === 'feed') {
-      operatorProps = { style: { minWidth: 0, color: 'black' }, disabled: true };
+      operatorProps = { style: { minWidth: 0, color: textPrimary }, disabled: true };
     }
     return (
       <Button {...operatorProps}>

--- a/src/app/components/search/SearchResultsTable/MetadataCell.js
+++ b/src/app/components/search/SearchResultsTable/MetadataCell.js
@@ -4,14 +4,15 @@ import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import ValueListCell from './ValueListCell';
 import { truncateLength } from '../../../helpers';
+import { textDisabled, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
   number: {
     textAlign: 'right',
   },
   urlChip: {
-    backgroundColor: '#979797',
-    color: 'white',
+    backgroundColor: textDisabled,
+    color: otherWhite,
     marginTop: '4px',
   },
   link: {

--- a/src/app/components/search/SearchResultsTable/TitleCell.js
+++ b/src/app/components/search/SearchResultsTable/TitleCell.js
@@ -12,6 +12,7 @@ import {
   alertMain,
   textSecondary,
   textPrimary,
+  otherWhite,
 } from '../../../styles/js/shared';
 
 const isFeedPage = () => (/\/feed/.test(window.location.pathname));
@@ -46,7 +47,7 @@ const useStyles = makeStyles({
   },
   icon: {
     fontSize: '40px',
-    color: 'white',
+    color: otherWhite,
   },
   textBox: {
     // This is a <div>, not a <th> with vertical-align center, because we need

--- a/src/app/components/search/SearchResultsTable/ValueListCell.js
+++ b/src/app/components/search/SearchResultsTable/ValueListCell.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
-import { brandMain, alertMain } from '../../../styles/js/shared';
+import { brandMain, alertMain, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles({
   tableCell: {
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
   },
   chip: {
-    color: 'white',
+    color: otherWhite,
     fontSize: 12,
   },
   noFactCheck: {

--- a/src/app/components/search/SelectButton.js
+++ b/src/app/components/search/SelectButton.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import { brandMain, grayBorderMain, textDisabled } from '../../styles/js/shared';
+import { grayBorderMain, textDisabled } from '../../styles/js/shared';
 
 const StyledButton = withStyles({
   root: {

--- a/src/app/components/search/SelectButton.js
+++ b/src/app/components/search/SelectButton.js
@@ -4,15 +4,16 @@ import { FormattedMessage } from 'react-intl';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import { brandMain, grayBorderMain, textDisabled } from '../../styles/js/shared';
 
 const StyledButton = withStyles({
   root: {
-    backgroundColor: '#ddd',
+    backgroundColor: grayBorderMain,
     padding: '0 8px',
     fontWeight: 'normal',
   },
   text: {
-    color: '#777',
+    color: textDisabled,
   },
 })(Button);
 

--- a/src/app/components/source/SourceInfo.js
+++ b/src/app/components/source/SourceInfo.js
@@ -36,6 +36,7 @@ import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
 import {
   Row,
   StyledIconButton,
+  textLink,
 } from '../../styles/js/shared';
 import {
   StyledTwoColumns,
@@ -52,7 +53,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(2),
   },
   linkedText: {
-    color: 'blue',
+    color: textLink,
     textDecoration: 'underline',
   },
   sourceInfoRight: {

--- a/src/app/components/source/SourcePicture.js
+++ b/src/app/components/source/SourcePicture.js
@@ -11,6 +11,7 @@ import {
   avatarSizeExtraSmall,
   defaultBorderRadius,
   grayDisabledBackground,
+  otherWhite,
 } from '../../styles/js/shared';
 
 // Sources are square. If the image is not square,
@@ -26,7 +27,7 @@ const StyledImage = styled.div`
   background-position: center;
   background-size: ${props => props.type === 'source' ? 'contain' : 'cover'};
   background-image: url('${props => props.avatarUrl}');
-  background-color: white;
+  background-color: ${otherWhite};
   ${props => props.type === 'source' ? `border: 1px solid ${grayDisabledBackground};` : null}
 
   ${props => (() => {

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -34,7 +34,7 @@ import EditTaskAlert from './EditTaskAlert';
 import EditTaskOptions from './EditTaskOptions';
 import Message from '../Message';
 import NumberIcon from '../../icons/NumberIcon';
-import { units } from '../../styles/js/shared';
+import { units, errorMain } from '../../styles/js/shared';
 
 const timezones = getTimeZones({ includeUtc: true }).map((option) => {
   const offset = option.currentTimeOffsetInMinutes / 60;
@@ -56,7 +56,7 @@ const styles = {
     marginTop: units(2),
   },
   error: {
-    color: '#ff0000',
+    color: errorMain,
   },
 };
 

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -24,6 +24,7 @@ import {
   units,
   grayBorderMain,
   brandMain,
+  textDisabled,
 } from '../../styles/js/shared';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 
@@ -74,7 +75,7 @@ const StyledAnnotatorInformation = styled.span`
   display: inline-block;
   p {
     font-size: 9px;
-    color: #979797;
+    color: ${textDisabled};
   }
 `;
 

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -13,7 +13,7 @@ import moment from 'moment';
 import Task from './Task';
 import NavigateAwayDialog from '../NavigateAwayDialog';
 import BlankState from '../layout/BlankState';
-import { units } from '../../styles/js/shared';
+import { units, validationMain, otherWhite, textDisabled } from '../../styles/js/shared';
 import { withSetFlashMessage } from '../FlashMessage';
 
 const StyledMetadataContainer = styled.div`
@@ -33,7 +33,7 @@ const StyledFormControls = styled.div`
   position: sticky;
   top: 0px;
   z-index: 1001;
-  background-color: white;
+  background-color: ${otherWhite};
   box-shadow: 0 0 8px 4px rgba(170, 170, 170, 0.25);
   clip-path: polygon(0% 0%, 100% 0%, 100.94% 107.30%, 0% 120%);
 `;
@@ -42,7 +42,7 @@ const StyledAnnotatorInformation = styled.span`
   display: inline-block;
   p {
     font-size: 9px;
-    color: #979797;
+    color: ${textDisabled};
   }
 `;
 
@@ -285,7 +285,7 @@ const Tasks = ({
                   />
                 }
               />
-              <Button className="form-save" variant="contained" onClick={handleSaveAnnotations} style={{ backgroundColor: '#1BB157', color: 'white' }}>
+              <Button className="form-save" variant="contained" onClick={handleSaveAnnotations} style={{ backgroundColor: validationMain, color: otherWhite }}>
                 <FormattedMessage id="metadata.form.save" defaultMessage="Save" description="This is a label on a button at the top of a form. The label indicates that if the user presses this button, the user will save the changes they have been making in the form." />
               </Button>
               <Button className="form-cancel" onClick={handleCancelAnnotations}>

--- a/src/app/components/team/SlackConfig/SlackConfigDialogComponent.js
+++ b/src/app/components/team/SlackConfig/SlackConfigDialogComponent.js
@@ -26,6 +26,7 @@ import FolderOpenIcon from '@material-ui/icons/FolderOpen';
 import MultiSelectFilter from '../../search/MultiSelectFilter';
 import { safelyParseJSON } from '../../../helpers';
 import { withSetFlashMessage } from '../../FlashMessage';
+import { grayBackground, textDisabled } from '../../../styles/js/shared';
 
 const messages = defineMessages({
   defaultLabel: {
@@ -40,10 +41,10 @@ const useStyles = makeStyles(theme => ({
     minWidth: 800,
   },
   header: {
-    backgroundColor: '#F6F6F6',
+    backgroundColor: grayBackground,
   },
   icon: {
-    color: '#979797',
+    color: textDisabled,
   },
   box: {
     padding: theme.spacing(2),

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -11,7 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { grayDisabledBackground, textPrimary, errorMain, validationMain } from '../../../styles/js/shared';
+import { grayDisabledBackground, textPrimary, errorMain, validationMain, otherWhite } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 
@@ -27,7 +27,7 @@ const useStyles = makeStyles(theme => ({
     },
   },
   smoochBotIntegrationButtonIcon: {
-    color: 'white',
+    color: otherWhite,
     padding: theme.spacing(0.5),
     display: 'flex',
     borderRadius: theme.spacing(1),
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
     minWidth: 80,
   },
   smoochBotIntegrationButtonConnected: {
-    color: 'white',
+    color: otherWhite,
     backgroundColor: validationMain,
   },
   smoochBotIntegrationButtonDisconnected: {

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -16,16 +16,16 @@ import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 import AddIcon from '@material-ui/icons/Add';
 import SmoochBotMainMenuOption from './SmoochBotMainMenuOption';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
-import { textPlaceholder, textSecondary } from '../../../styles/js/shared';
+import { textPlaceholder, textSecondary, grayBackground, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {
-    background: '#F6F6F6',
+    background: grayBackground,
     border: `1px solid ${textPlaceholder}`,
     borderRadius: theme.spacing(2),
   },
   textField: {
-    background: 'white',
+    background: otherWhite,
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
   },

--- a/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotNewsletterEditor.js
@@ -20,7 +20,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { getTimeZones } from '@vvo/tzdb';
 import SmoochBotPreviewFeed from './SmoochBotPreviewFeed';
 import { placeholders } from './localizables';
-import { textDisabled, textPlaceholder } from '../../../styles/js/shared';
+import { textDisabled, textPlaceholder, grayBackground, textPrimary, errorMain } from '../../../styles/js/shared';
 import ParsedText from '../../ParsedText';
 import WarningAlert from '../../cds/alerts-and-prompts/WarningAlert';
 import SuccessAlert from '../../cds/alerts-and-prompts/SuccessAlert';
@@ -57,7 +57,7 @@ const useStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
   },
   icon: {
-    color: '#979797',
+    color: textDisabled,
   },
   load: {
     height: theme.spacing(4),
@@ -70,8 +70,8 @@ const useStyles = makeStyles(theme => ({
     gap: '8px',
   },
   none: {
-    background: '#F6F6F6',
-    color: 'black',
+    background: grayBackground,
+    color: textPrimary,
   },
   bullet: {
     color: textDisabled,
@@ -321,7 +321,7 @@ const SmoochBotNewsletterEditor = ({
         <Typography paragraph>
           <FormattedMessage id="smoochBotNewsletterEditor.secondStep2" defaultMessage="If the content is not changed between two scheduled sendouts, the newsletter will not be sent." description="Explanation about tipline newsletter delivery, in tipline newsletter settings page" />
         </Typography>
-        <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: 'red' } : {}}>
+        <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: errorMain } : {}}>
           <FormattedMessage
             id="smoochBotNewsletterEditor.charsCounter"
             defaultMessage="{count}/{max} characters available"

--- a/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
@@ -155,7 +155,7 @@ const SmoochBotResourceEditor = ({
               />
             </strong>
           </Typography>
-          <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: errorMain} : {}}>
+          <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: errorMain } : {}}>
             <FormattedMessage
               id="smoochBotResourceEditor.charsCounter"
               defaultMessage="{count}/{max} characters available"

--- a/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
+++ b/src/app/components/team/SmoochBot/SmoochBotResourceEditor.js
@@ -15,6 +15,7 @@ import Switch from '@material-ui/core/Switch';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import SmoochBotPreviewFeed from './SmoochBotPreviewFeed';
 import ParsedText from '../../ParsedText';
+import { textDisabled, errorMain } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   spaced: {
@@ -37,7 +38,7 @@ const useStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
   },
   icon: {
-    color: '#979797',
+    color: textDisabled,
   },
   load: {
     height: theme.spacing(4),
@@ -154,7 +155,7 @@ const SmoochBotResourceEditor = ({
               />
             </strong>
           </Typography>
-          <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: 'red' } : {}}>
+          <Typography variant="caption" paragraph style={charactersCount > maxCharacters ? { color: errorMain} : {}}>
             <FormattedMessage
               id="smoochBotResourceEditor.charsCounter"
               defaultMessage="{count}/{max} characters available"

--- a/src/app/components/team/Statuses/EditStatusDialog.js
+++ b/src/app/components/team/Statuses/EditStatusDialog.js
@@ -16,6 +16,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import { FormattedGlobalMessage } from '../../MappedMessage';
 import ColorPicker from '../../layout/ColorPicker';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
+import { textPrimary } from '../../../styles/js/shared';
 
 const maxLength = 35;
 
@@ -41,7 +42,7 @@ const EditStatusDialog = ({
   const classes = useStyles();
   const [statusLabel, setStatusLabel] = React.useState(status ? status.label : '');
   const [statusDescription, setStatusDescription] = React.useState(status ? status.locales[defaultLanguage].description : '');
-  const [statusColor, setStatusColor] = React.useState(status ? status.style.color : '#000000');
+  const [statusColor, setStatusColor] = React.useState(status ? status.style.color : textPrimary);
   const [statusMessage, setStatusMessage] = React.useState(status ? status.locales[defaultLanguage].message : '');
   const [statusMessageEnabled, setStatusMessageEnabled] = React.useState(status ? Boolean(status.should_send_message) : false);
   const [showSaveConfirmDialog, setShowSaveConfirmDialog] = React.useState(false);

--- a/src/app/components/team/TeamLists/TeamListsComponent.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.js
@@ -12,13 +12,13 @@ import CardContent from '@material-ui/core/CardContent';
 import TeamListsColumn from './TeamListsColumn';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmDialog from '../../layout/ConfirmDialog';
-import { ContentColumn, grayBorderMain } from '../../../styles/js/shared';
+import { ContentColumn, grayBorderMain, grayBackground } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const useStyles = makeStyles(theme => ({
   link: {
     textDecoration: 'underline',
-    background: '#F6F6F6',
+    background: grayBackground,
     padding: theme.spacing(1),
     margin: theme.spacing(1),
     minHeight: theme.spacing(10),
@@ -201,7 +201,7 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
                 onMoveUp={handleMoveUp}
                 onMoveDown={handleMoveDown}
                 style={{
-                  background: '#F6F6F6',
+                  background: grayBackground,
                   borderRadius: '5px',
                   border: `1px solid ${grayBorderMain}`,
                   padding: '.3rem 1rem .5rem 0',

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Reorder from '../../layout/Reorder';
-import { grayBorderMain } from '../../../styles/js/shared';
+import { grayBorderMain, otherWhite } from '../../../styles/js/shared';
 
 const useStyles = makeStyles(theme => ({
   box: {

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
     Minheight: theme.spacing(10),
-    background: 'white',
+    background: otherWhite,
   },
   label: {
     fontSize: 14,

--- a/src/app/components/team/TeamMembersComponent.js
+++ b/src/app/components/team/TeamMembersComponent.js
@@ -22,12 +22,12 @@ import SettingsHeader from './SettingsHeader';
 import TeamMemberActions from './TeamMemberActions';
 import { can } from '../Can';
 import TimeBefore from '../TimeBefore';
-import { ContentColumn } from '../../styles/js/shared';
+import { ContentColumn, textPrimary } from '../../styles/js/shared';
 import { StyledTwoColumns, StyledBigColumn, StyledSmallColumn } from '../../styles/js/HeaderCard';
 
 const useStyles = makeStyles(theme => ({
   pending: {
-    border: '1px solid black',
+    border: `1px solid ${textPrimary}`,
     padding: theme.spacing(0.5),
     marginTop: theme.spacing(0.5),
     borderRadius: '5px',

--- a/src/app/components/team/TeamTags/TeamTagsComponent.js
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.js
@@ -20,7 +20,7 @@ import SaveTag from './SaveTag';
 import TeamTagsActions from './TeamTagsActions';
 import TimeBefore from '../../TimeBefore';
 import SettingsHeader from '../SettingsHeader';
-import { ContentColumn } from '../../../styles/js/shared';
+import { ContentColumn, otherWhite } from '../../../styles/js/shared';
 import Can from '../../Can';
 
 const useStyles = makeStyles(theme => ({
@@ -32,7 +32,7 @@ const useStyles = makeStyles(theme => ({
     borderBottom: 0,
   },
   teamTagsSearchField: {
-    background: 'white',
+    background: otherWhite,
     margin: `0 ${theme.spacing(27)}px`,
   },
   teamTagsNewTagButton: {

--- a/src/app/components/team/TeamTaskCard.js
+++ b/src/app/components/team/TeamTaskCard.js
@@ -15,7 +15,7 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import TeamTaskCardForm from './TeamTaskCardForm';
 import globalStrings from '../../globalStrings';
-
+import { grayBackground } from '../../styles/js/shared';
 
 const TeamTaskCard = ({
   about,
@@ -47,8 +47,8 @@ const TeamTaskCard = ({
     <Box
       my={2}
       mr={2}
-      bgcolor="#f6f6f6"
-      border="2px solid #ced3e2"
+      bgcolor={grayBackground}
+      border="2px solid {brandBorder}"
       borderRadius="10px"
       minHeight="100px"
       width="100%"

--- a/src/app/components/user/UserConnectedAccount.js
+++ b/src/app/components/user/UserConnectedAccount.js
@@ -12,7 +12,7 @@ import ConfirmDialog from '../layout/ConfirmDialog';
 import UserDisconnectLoginAccountMutation from '../../relay/mutations/UserDisconnectLoginAccountMutation';
 import { login } from '../../redux/actions';
 import SocialIcon from '../SocialIcon';
-import { FlexRow } from '../../styles/js/shared';
+import { FlexRow, brandMain } from '../../styles/js/shared';
 
 class UserConnectedAccount extends Component {
   static renderLabel(userAction) {
@@ -70,7 +70,7 @@ class UserConnectedAccount extends Component {
   render() {
     const { provider } = this.props;
     const buttonStyle = {
-      color: 'rgb(46, 119, 252)',
+      color: brandMain,
     };
     const confirmDialog = {
       title: <FormattedMessage

--- a/src/app/styles/js/shared.js
+++ b/src/app/styles/js/shared.js
@@ -7,16 +7,16 @@ import Card from '@material-ui/core/Card';
 export const brandMain = '#567bff';
 export const brandSecondary = '#3b5cd0';
 export const brandLight = '#e7efff';
-export const brandAccent = '#293e86';// eslint-disable-line import/no-unused-modules
-export const brandBorder = '#d0d6ec';// eslint-disable-line import/no-unused-modules
+export const brandAccent = '#293e86';
+export const brandBorder = '#d0d6ec';
 export const brandBackground = '#f1f5f6';
 export const brandHoverAccent = '#f2f8ff';// eslint-disable-line import/no-unused-modules
 
 export const textPrimary = '#1f1f1f';
 export const textSecondary = '#656565';
-export const textPlaceholder = '#b6b6b6';// eslint-disable-line import/no-unused-modules
-export const textDisabled = '#999';// eslint-disable-line import/no-unused-modules
-export const textLink = '#3b5cd0';// eslint-disable-line import/no-unused-modules
+export const textPlaceholder = '#b6b6b6';
+export const textDisabled = '#999';
+export const textLink = '#3b5cd0';
 
 export const validationMain = '#4caf50';
 export const validationSecondary = '#237c27';
@@ -30,8 +30,8 @@ export const errorMain = '#f44336';
 export const errorSecondary = '#c9291d';// eslint-disable-line import/no-unused-modules
 export const errorLight = '#ffeeed';// eslint-disable-line import/no-unused-modules
 
-export const grayBackground = '#f7f7f7';// eslint-disable-line import/no-unused-modules
-export const grayDisabledBackground = '#efefef';// eslint-disable-line import/no-unused-modules
+export const grayBackground = '#f7f7f7';
+export const grayDisabledBackground = '#efefef';
 export const grayBorderMain = '#e4e4e4';
 export const grayBorderAccent = '#b4b4b4';
 


### PR DESCRIPTION
## Description

This PR continues the work of ensuring the colors used in the app are the ones from the design system.
- change hardcoded colors to vars
- renable `eslint-disable-line import/no-unused-modules` colors in sharedjs that are now used

References: [CV2-2801](https://meedan.atlassian.net/browse/CV2-2801)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

should be just straight color replacements, no functional changes

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-2801]: https://meedan.atlassian.net/browse/CV2-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ