### PR TITLE
Display similarity errors from server

### DIFF
--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
@@ -10,11 +10,6 @@
     "defaultMessage": "Export all media to another item"
   },
   {
-    "id": "mediaSimilarityBarAdd.defaultErrorMessage",
-    "description": "Warning displayed if an error occurred when adding a similar item",
-    "defaultMessage": "Could not add similar item"
-  },
-  {
     "id": "mediaSimilarityBarAdd.savedSuccessfully",
     "description": "Banner displayed when similar item is added successfully",
     "defaultMessage": "Similar item added successfully"

--- a/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
@@ -75,16 +75,10 @@ const MediaSimilarityBarAdd = ({
     setAnchorEl(null);
   };
 
-  const handleError = () => {
+  // Accepts a JS Error object
+  const handleError = (error) => {
     setSubmitting(false);
-    // FIXME: Get error message from backend
-    setFlashMessage((
-      <FormattedMessage
-        id="mediaSimilarityBarAdd.defaultErrorMessage"
-        defaultMessage="Could not add similar item"
-        description="Warning displayed if an error occurred when adding a similar item"
-      />
-    ), 'error');
+    setFlashMessage(error.message, 'error');
   };
 
   const handleSuccess = (response) => {
@@ -172,15 +166,17 @@ const MediaSimilarityBarAdd = ({
           rangeBehavior: 'prepend',
         }],
       }],
-      onCompleted: (response, error) => {
-        if (error) {
-          handleError();
+      onCompleted: (response, errors) => {
+        if (errors?.length > 0) {
+          for (error of errors) {
+            handleError(error);
+          }
         } else {
           handleSuccess(response);
         }
       },
-      onError: () => {
-        handleError();
+      onError: (error) => {
+        handleError(error);
       },
     });
   };

--- a/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
@@ -168,8 +168,8 @@ const MediaSimilarityBarAdd = ({
       }],
       onCompleted: (response, errors) => {
         if (errors?.length > 0) {
-          for (error of errors) {
-            handleError(error);
+          for (let i = 0; i < errors.length; i += 1) {
+            handleError(errors[i]);
           }
         } else {
           handleSuccess(response);


### PR DESCRIPTION
## Description

We had a `FIXME` in the code that we needed to display server errors instead of a generic one when similarity API calls fail. This PR addresses the issue.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

