### PR TITLE
fix header color on report page. Fixes #CV2-2856

### DIFF
--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
@@ -19,7 +19,7 @@ import {
 } from './reportDesignerHelpers';
 import { getStatus, getStatusStyle, safelyParseJSON } from '../../../helpers';
 import { stringHelper } from '../../../customHelpers';
-import { brandMain, brandBackground } from '../../../styles/js/shared';
+import { brandMain, grayBackground, brandBorder } from '../../../styles/js/shared';
 import CreateReportDesignMutation from '../../../relay/mutations/CreateReportDesignMutation';
 import UpdateReportDesignMutation from '../../../relay/mutations/UpdateReportDesignMutation';
 import CheckArchivedFlags from '../../../CheckArchivedFlags';
@@ -30,10 +30,10 @@ const useStyles = makeStyles(theme => ({
     height: 'calc(100vh - 60px)',
     overflow: 'auto',
     padding: theme.spacing(2),
-    backgroundColor: brandBackground,
+    backgroundColor: grayBackground,
   },
   preview: {
-    borderRight: '1px solid #DFE4F4',
+    borderRight: `1px solid ${brandBorder}`,
   },
   editor: {
     padding: '16px 32px',

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
@@ -15,7 +15,7 @@ import IconPause from '@material-ui/icons/Pause';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import ReportDesignerConfirmableButton from './ReportDesignerConfirmableButton';
 import MediaStatus from '../MediaStatus';
-import { validationMain, alertMain, brandSecondary, brandMain, otherWhite } from '../../../styles/js/shared';
+import { validationMain, alertMain, brandBackground, brandMain, brandBorder, otherWhite } from '../../../styles/js/shared';
 import { getStatus } from '../../../helpers';
 import { languageLabel } from '../../../LanguageRegistry';
 
@@ -32,7 +32,8 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(2),
   },
   reportHeader: {
-    backgroundColor: brandSecondary,
+    backgroundColor: brandBackground,
+    borderBottom: `1px solid ${brandBorder}`,
   },
   cell: {
     marginRight: theme.spacing(2),


### PR DESCRIPTION
## Description

- The header on the report page didn't get correctly converted to the right design system color. this fixes that issue
- Also changes a hardcoded color I randomly saw doing this work

References: [CV2-2856](https://meedan.atlassian.net/browse/CV2-2856)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manual visual testing

## Things to pay attention to during code review

### BEFORE
<img width="1884" alt="Screenshot 2023-03-09 at 3 52 06 PM" src="https://user-images.githubusercontent.com/418001/224155377-9d7a31a1-77fc-4bae-b2cd-556461584693.png">

### AFTER

<img width="1885" alt="Screenshot 2023-03-09 at 3 51 03 PM" src="https://user-images.githubusercontent.com/418001/224155407-549994f2-09be-4897-96eb-38af007222af.png">


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-2856]: https://meedan.atlassian.net/browse/CV2-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ