### PR TITLE
Truncate description in two lines instead of one if there is no URL

### DIFF
--- a/src/app/components/cds/media-cards/MediaCardCondensed.js
+++ b/src/app/components/cds/media-cards/MediaCardCondensed.js
@@ -56,12 +56,20 @@ const useStyles = makeStyles(theme => ({
     maxWidth: '33vw', // 1/3 of the viewport width
   },
   description: {
-    maxHeight: '20px',
     lineHeight: '143%',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     maxWidth: '33vw', // 1/3 of the viewport width
+  },
+  oneLineDescription: {
+    maxHeight: '20px',
+  },
+  twoLinesDescription: { // Just works on Webkit
+    display: '-webkit-box',
+    '-webkit-line-clamp': 2,
+    '-webkit-box-orient': 'vertical',
+    whiteSpace: 'pre-line',
   },
   placeholder: {
     border: `1px solid ${grayBorderAccent}`,
@@ -139,7 +147,7 @@ const MediaCardCondensed = ({
             details={details}
             compact
           />
-          <div className={classes.description}>
+          <div className={[classes.description, (externalUrl ? classes.oneLineDescription : classes.twoLinesDescription)].join(' ')}>
             <ParsedText text={description || media.metadata?.description || media.quote} />
           </div>
           { externalUrl ? <div className={classes.url}><ExternalLink url={externalUrl} maxUrlLength={60} /></div> : null }


### PR DESCRIPTION
## Description

In the small media card, display the description in two lines if there is no URL to be rendered.

Reference: CV2-2613.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing tests.

## Things to pay attention to during code review

This should conform to the design system.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

