### PR TITLE
add function to escape HTML characters

### DIFF
--- a/src/app/components/media/ReportDesigner/ReportDesignerImagePreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerImagePreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import escapeHtml from 'escape-html';
+import { escapeHtml } from '../../../helpers';
 
 function overwriteDocumentHtml(contentDocument, html) {
   contentDocument.open();

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -355,6 +355,16 @@ function getMediaType(media) {
   return type;
 }
 
+/**
+ * Safely escape some HTML characters.
+ */
+function escapeHtml(url) {
+  return url.replace(/>/g, '&gt;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 export { // eslint-disable-line import/no-unused-modules
   bemClass,
   safelyParseJSON,
@@ -377,4 +387,5 @@ export { // eslint-disable-line import/no-unused-modules
   parseStringUnixTimestamp,
   botName,
   getMediaType,
+  escapeHtml,
 };


### PR DESCRIPTION
## Description

we were using the lib 'escape-html' to escape the characters but it was breaking the image URL and consequently, the image was not being rendered on the "Report" page. 
Replaced the 'escape-html' lib for a new function on the helper file to escape those characters instead of using the lib.

Reference: CV2-2796

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

