### PR TITLE
Refactoring language switcher component and using it in media modal

### DIFF
--- a/localization/react-intl/src/app/components/cds/forms/LanguagePickerSelect.json
+++ b/localization/react-intl/src/app/components/cds/forms/LanguagePickerSelect.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "LanguagePickerSelect.optionLabel",
+    "defaultMessage": "{languageName} ({languageCode})"
+  },
+  {
+    "id": "LanguagePickerSelect.unknownLanguage",
+    "defaultMessage": "Unknown language"
+  },
+  {
+    "id": "LanguagePickerSelect.selectLanguage",
+    "description": "Change language label",
+    "defaultMessage": "Select language"
+  }
+]

--- a/localization/react-intl/src/app/components/cds/forms/LanguagePickerSelect.test.json
+++ b/localization/react-intl/src/app/components/cds/forms/LanguagePickerSelect.test.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "LanguagePickerSelect.optionLabel",
+    "defaultMessage": "{languageName} ({languageCode})"
+  },
+  {
+    "id": "LanguagePickerSelect.unknownLanguage",
+    "defaultMessage": "Unknown language"
+  }
+]

--- a/localization/react-intl/src/app/components/media/MediaLanguageSwitcher.json
+++ b/localization/react-intl/src/app/components/media/MediaLanguageSwitcher.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "mediaLanguageSwitcher.error",
+    "description": "Error message displayed when it's not possible to change an item language",
+    "defaultMessage": "Could not change language, please try again"
+  },
+  {
+    "id": "mediaLanguageSwitcher.success",
+    "description": "Success message displayed when an item language is changed",
+    "defaultMessage": "Language updated"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14782,7 +14782,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/src/app/components/cds/forms/LanguagePickerSelect.js
+++ b/src/app/components/cds/forms/LanguagePickerSelect.js
@@ -1,12 +1,10 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import LanguageIcon from '@material-ui/icons/Language';
-import { safelyParseJSON } from '../../helpers';
-import LanguageRegistry, { languageLabel } from '../../LanguageRegistry';
+import LanguageRegistry, { languageLabel } from '../../../LanguageRegistry';
 
 const messages = defineMessages({
   optionLabel: {
@@ -21,13 +19,12 @@ const messages = defineMessages({
 
 const LanguagePickerSelect = ({
   intl,
-  isDisabled,
   selectedlanguage,
   onSubmit,
-  team,
+  languages,
+  isDisabled,
 }) => {
   const [value, setValue] = React.useState(selectedlanguage);
-  const languages = safelyParseJSON(team.get_languages) || [];
   languages.unshift('und');
 
   // intl.formatMessage needed here because Autocomplete
@@ -69,7 +66,7 @@ const LanguagePickerSelect = ({
               <TextField
                 {...params}
                 name="language-name"
-                label={placeholder}
+                label=""
                 placeholder={placeholder}
                 variant="outlined"
                 InputProps={{
@@ -91,18 +88,16 @@ const LanguagePickerSelect = ({
 };
 
 LanguagePickerSelect.defaultProps = {
+  languages: [],
   isDisabled: false,
 };
 
 LanguagePickerSelect.propTypes = {
   intl: intlShape.isRequired,
-  isDisabled: PropTypes.bool,
   selectedlanguage: PropTypes.string.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  team: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    get_languages: PropTypes.string.isRequired,
-  }).isRequired,
+  languages: PropTypes.arrayOf(PropTypes.string),
+  isDisabled: PropTypes.bool,
 };
 
 export default injectIntl(LanguagePickerSelect);

--- a/src/app/components/cds/forms/LanguagePickerSelect.test.js
+++ b/src/app/components/cds/forms/LanguagePickerSelect.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { defineMessages } from 'react-intl';
 import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import LanguagePickerSelect from './LanguagePickerSelect';
 

--- a/src/app/components/cds/forms/LanguagePickerSelect.test.js
+++ b/src/app/components/cds/forms/LanguagePickerSelect.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import LanguagePickerSelect from './LanguagePickerSelect';
+
+describe('<LanguagePickerSelect />', () => {
+  const props = {
+    selectedlanguage: 'en',
+    onSubmit: jest.fn(),
+    languages: ['en', 'fr'],
+    isDisabled: false,
+  };
+
+  it('renders without crashing', () => {
+    mountWithIntl(<LanguagePickerSelect {...props} />);
+  });
+});

--- a/src/app/components/media/MediaCardLargeActions.js
+++ b/src/app/components/media/MediaCardLargeActions.js
@@ -15,7 +15,7 @@ import RefreshButton from './RefreshButton';
 import OcrButton from './OcrButton';
 import TranscriptionButton from './TranscriptionButton';
 import ExternalLink from '../ExternalLink';
-import LanguagePickerSelect from '../layout/LanguagePickerSelect';
+import MediaLanguageSwitcher from './MediaLanguageSwitcher';
 import { brandBorder } from '../../styles/js/shared';
 
 const ExtraMediaActions = ({
@@ -90,11 +90,6 @@ const ExtraMediaActions = ({
   );
 };
 
-const handleLanguageSelect = (value) => {
-  // TODO implement language mutation
-  console.log('value', value); // eslint-disable-line
-};
-
 class MediaExpandedActions extends React.Component {
   reverseImageSearchGoogle() {
     const imagePath = this.props.projectMedia.picture;
@@ -133,12 +128,7 @@ class MediaExpandedActions extends React.Component {
                   defaultMessage="More"
                 />
               </Button> : null }
-            { inModal ?
-              <LanguagePickerSelect
-                selectedlanguage={projectMedia.language}
-                onSubmit={handleLanguageSelect}
-                team={projectMedia.team}
-              /> : null }
+            { inModal ? <MediaLanguageSwitcher projectMedia={projectMedia} /> : null }
           </div>
           <Box display="flex">
             { media.type === 'Link' ?
@@ -168,7 +158,7 @@ MediaExpandedActions.propTypes = {
 export default createFragmentContainer(MediaExpandedActions, graphql`
   fragment MediaCardLargeActions_projectMedia on ProjectMedia {
     id
-    language
+    language_code
     team {
       get_languages
     }
@@ -178,6 +168,9 @@ export default createFragmentContainer(MediaExpandedActions, graphql`
     }
     extracted_text: annotation(annotation_type: "extracted_text") {
       data
+    }
+    language: annotation(annotation_type: "language") {
+      id
     }
     url
     media {

--- a/src/app/components/media/MediaCardLargeFooter.js
+++ b/src/app/components/media/MediaCardLargeFooter.js
@@ -61,27 +61,28 @@ const MediaCardLargeFooter = ({
         </Box> : null }
       { projectMedia.type === 'Link' ?
         <Box my={2}>
-          { /* 1st MediaLargeFooterContent, exclusive for Link, aways displays URL above MediaCardLargeActions */}
-          <MediaCardLargeFooterContent
-            title={
-              <FormattedMessage
-                id="mediaCardLarge.publishedOn"
-                defaultMessage="Published on {date}"
-                description="Publication date and time of a web article"
-                values={{
-                  date: (
-                    <FormattedDate
-                      value={data.published_at}
-                      year="numeric"
-                      month="short"
-                      day="numeric"
-                    />
-                  ),
-                }}
-              />
-            }
-            body={<ExternalLink url={data.url} />}
-          />
+          { /* 1st MediaLargeFooterContent, exclusive for Link, always displays URL above MediaCardLargeActions */}
+          { data.published_at ?
+            <MediaCardLargeFooterContent
+              title={
+                <FormattedMessage
+                  id="mediaCardLarge.publishedOn"
+                  defaultMessage="Published on {date}"
+                  description="Publication date and time of a web article"
+                  values={{
+                    date: (
+                      <FormattedDate
+                        value={data.published_at}
+                        year="numeric"
+                        month="short"
+                        day="numeric"
+                      />
+                    ),
+                  }}
+                />
+              }
+              body={<ExternalLink url={data.url} />}
+            /> : null }
         </Box> : null }
       <MediaCardLargeActions
         inModal={inModal}

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -8,7 +8,7 @@ import Button from '@material-ui/core/Button';
 import IconReport from '@material-ui/icons/PlaylistAddCheck';
 import Typography from '@material-ui/core/Typography';
 import TimeBefore from '../TimeBefore';
-import LanguagePickerSelect from '../layout/LanguagePickerSelect';
+import LanguagePickerSelect from '../cds/forms/LanguagePickerSelect';
 import { parseStringUnixTimestamp, truncateLength, safelyParseJSON } from '../../helpers';
 import { can } from '../Can';
 import MediaFactCheckField from './MediaFactCheckField';
@@ -248,7 +248,7 @@ const MediaFactCheck = ({ projectMedia }) => {
             isDisabled={(!hasPermission || isDisabled)}
             selectedlanguage={language}
             onSubmit={handleLanguageSubmit}
-            team={team}
+            languages={JSON.parse(team.get_languages || '[]')}
           />
         </Box> : null
       }

--- a/src/app/components/media/MediaLanguageSwitcher.js
+++ b/src/app/components/media/MediaLanguageSwitcher.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { commitMutation, graphql } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import LanguagePickerSelect from '../cds/forms/LanguagePickerSelect';
+import { withSetFlashMessage } from '../FlashMessage';
+
+const MediaLanguageSwitcher = ({ projectMedia, setFlashMessage }) => {
+  const [saving, setSaving] = React.useState(false);
+
+  const handleError = () => {
+    setSaving(false);
+    setFlashMessage((
+      <FormattedMessage
+        id="mediaLanguageSwitcher.error"
+        defaultMessage="Could not change language, please try again"
+        description="Error message displayed when it's not possible to change an item language"
+      />
+    ), 'error');
+  };
+
+  const handleSuccess = () => {
+    setSaving(false);
+    setFlashMessage((
+      <FormattedMessage
+        id="mediaLanguageSwitcher.success"
+        defaultMessage="Language updated"
+        description="Success message displayed when an item language is changed"
+      />
+    ), 'success');
+  };
+
+  const handleUpdate = (value) => {
+    const { languageCode } = value;
+    setSaving(true);
+    commitMutation(Relay.Store, {
+      mutation: graphql`
+        mutation MediaLanguageSwitcherUpdateDynamicAnnotationLanguageMutation($input: UpdateDynamicAnnotationLanguageInput!) {
+          updateDynamicAnnotationLanguage(input: $input) {
+            project_media {
+              id
+              language_code
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          id: projectMedia.language?.id,
+          set_fields: JSON.stringify({ language: languageCode }),
+        },
+      },
+      onCompleted: (response, err) => {
+        if (err) {
+          handleError();
+        } else {
+          handleSuccess();
+        }
+      },
+      onError: () => {
+        handleError();
+      },
+    });
+  };
+
+  return (
+    <LanguagePickerSelect
+      selectedlanguage={projectMedia.language_code || 'und'}
+      onSubmit={handleUpdate}
+      languages={JSON.parse(projectMedia.team?.get_languages || '[]')}
+      isDisabled={saving}
+    />
+  );
+};
+
+MediaLanguageSwitcher.propTypes = {
+  projectMedia: PropTypes.shape({
+    language_code: PropTypes.string.isRequired,
+    language: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+    team: PropTypes.shape({
+      get_languages: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default withSetFlashMessage(MediaLanguageSwitcher);

--- a/src/app/components/media/ReportDesigner/ReportDesignerForm.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerForm.js
@@ -14,7 +14,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import ReportDesignerFormSection from './ReportDesignerFormSection';
 import ColorPicker from '../../layout/ColorPicker';
 import UploadFile from '../../UploadFile';
-import LanguagePickerSelect from '../../layout/LanguagePickerSelect';
+import LanguagePickerSelect from '../../cds/forms/LanguagePickerSelect';
 import { formatDate } from './reportDesignerHelpers';
 import LimitedTextFieldWithCounter from '../../layout/LimitedTextFieldWithCounter';
 import { safelyParseJSON } from '../../../helpers';
@@ -108,8 +108,8 @@ const ReportDesignerForm = (props) => {
           <Box my={3} >
             <LanguagePickerSelect
               selectedlanguage={currentLanguage}
+              languages={JSON.parse(team.get_languages || '[]')}
               onSubmit={handleLanguageSubmit}
-              team={team}
             />
           </Box> : null
         }


### PR DESCRIPTION
## Description

* Refactored `<LanguagePickerSelect />` to be more self-contained and implemented it as a design system component
* Implemented a new component `<MediaLanguageSwitcher />` that uses `<LanguagePickerSelect />` and handles all the logic for updating the language for an item

Reference: CV2-2555.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I added a unit test for the refactored component under `cds/`. But in order to test manually, try to see and update language for the following contexts:

* Fact-check language
* Media language in modal
* Report language

## Things to pay attention to during code review

Design system implementation for the language drop-down.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

