### PR TITLE
Removing deprecated "Refresh" option from top-right actions menu on item page

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaActionsMenuButton.json
+++ b/localization/react-intl/src/app/components/media/MediaActionsMenuButton.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "mediaActions.refresh",
-    "defaultMessage": "Refresh"
-  },
-  {
     "id": "mediaActions.assignOrUnassign",
     "defaultMessage": "Assign to…"
   },

--- a/src/app/components/media/MediaActionsMenuButton.js
+++ b/src/app/components/media/MediaActionsMenuButton.js
@@ -24,7 +24,6 @@ class MediaActionsMenuButton extends React.PureComponent {
         url: PropTypes.string,
       }).isRequired,
     }).isRequired,
-    handleRefresh: PropTypes.func.isRequired,
     handleSendToTrash: PropTypes.func.isRequired,
     handleSendToSpam: PropTypes.func.isRequired,
     handleAssign: PropTypes.func.isRequired,
@@ -54,7 +53,6 @@ class MediaActionsMenuButton extends React.PureComponent {
     const {
       projectMedia,
       isParent,
-      handleRefresh,
       handleSendToTrash,
       handleSendToSpam,
       handleAssign,
@@ -64,24 +62,6 @@ class MediaActionsMenuButton extends React.PureComponent {
     const menuItems = [];
 
     if (isParent) {
-      if (can(projectMedia.permissions, 'update ProjectMedia') && projectMedia.archived === CheckArchivedFlags.NONE) {
-        if (projectMedia.media.url) {
-          menuItems.push((
-            <MenuItem
-              key="mediaActions.refresh"
-              className="media-actions__refresh"
-              id="media-actions__refresh"
-              onClick={e => this.handleActionAndClose(e, handleRefresh)}
-            >
-              <ListItemText
-                primary={
-                  <FormattedMessage id="mediaActions.refresh" defaultMessage="Refresh" />
-                }
-              />
-            </MenuItem>));
-        }
-      }
-
       if (can(projectMedia.permissions, 'update Status') && projectMedia.archived === CheckArchivedFlags.NONE) {
         menuItems.push((
           <MenuItem


### PR DESCRIPTION
## Description

It's now on the media card, so we don't need it in the top-right menu.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

There should be no "Refresh" option in the top-right actions menu on the item page for a link.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

