### PR TITLE
Adding icon for imported report in small media card

### DIFF
--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
@@ -35,6 +35,11 @@
     "defaultMessage": "Export media to another fact-check"
   },
   {
+    "id": "mediaSimilarityBarAdd.addToImportedReport",
+    "description": "Menu option for adding the current media to an imported fact-check",
+    "defaultMessage": "Add media to an imported fact-check"
+  },
+  {
     "id": "mediaSimilarityBarAdd.addAsSimilar",
     "description": "Button label to commit action of exporting media",
     "defaultMessage": "Export all media"

--- a/src/app/components/media/MediaTypeDisplayIcon.js
+++ b/src/app/components/media/MediaTypeDisplayIcon.js
@@ -10,6 +10,7 @@ import {
   Instagram,
   Twitter,
   YouTube,
+  PlaylistAddCheck,
 } from '@material-ui/icons';
 
 export default function MediaTypeDisplayIcon({ mediaType }) {
@@ -34,7 +35,7 @@ export default function MediaTypeDisplayIcon({ mediaType }) {
   case 'Youtube':
     return <YouTube {...props} />;
   case 'Blank':
-    return null;
+    return <PlaylistAddCheck {...props} />;
   case '-':
   default:
     return null;

--- a/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarAdd.js
@@ -6,6 +6,7 @@ import { Store } from 'react-relay/classic';
 import Tooltip from '@material-ui/core/Tooltip';
 import { browserHistory } from 'react-router';
 import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -13,7 +14,9 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import PublishIcon from '@material-ui/icons/Publish';
 import GetAppIcon from '@material-ui/icons/GetApp';
+import IconReport from '@material-ui/icons/PlaylistAddCheck';
 import { makeStyles } from '@material-ui/core/styles';
+import BlankMediaButton from '../BlankMediaButton';
 import CreateRelatedMediaDialog from '../CreateRelatedMediaDialog';
 import { withSetFlashMessage } from '../../FlashMessage';
 
@@ -29,6 +32,7 @@ const MediaSimilarityBarAdd = ({
   setFlashMessage,
   canBeAddedToSimilar,
   similarCanBeAddedToIt,
+  canBeAddedToImported,
 }) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -255,6 +259,33 @@ const MediaSimilarityBarAdd = ({
             </MenuItem>
           </span>
         </Tooltip>
+        <Divider />
+        <BlankMediaButton
+          reverse
+          projectMediaId={projectMediaId}
+          ButtonComponent={({ onClick }) => (
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null);
+                onClick();
+              }}
+              disabled={!canBeAddedToImported}
+            >
+              <ListItemIcon>
+                <IconReport />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <FormattedMessage
+                    id="mediaSimilarityBarAdd.addToImportedReport"
+                    defaultMessage="Add media to an imported fact-check"
+                    description="Menu option for adding the current media to an imported fact-check"
+                  />
+                }
+              />
+            </MenuItem>
+          )}
+        />
       </Menu>
       <CreateRelatedMediaDialog
         title={label}
@@ -291,6 +322,7 @@ const MediaSimilarityBarAdd = ({
 MediaSimilarityBarAdd.defaultProps = {
   canBeAddedToSimilar: true,
   similarCanBeAddedToIt: true,
+  canBeAddedToImported: false,
 };
 
 MediaSimilarityBarAdd.propTypes = {
@@ -298,6 +330,7 @@ MediaSimilarityBarAdd.propTypes = {
   projectMediaDbid: PropTypes.number.isRequired,
   canBeAddedToSimilar: PropTypes.bool,
   similarCanBeAddedToIt: PropTypes.bool,
+  canBeAddedToImported: PropTypes.bool,
 };
 
 export default withSetFlashMessage(MediaSimilarityBarAdd);


### PR DESCRIPTION
## Description

Adding icon for imported report in small media card.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Try to add media to imported report. The small media card should show an icon.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

