### PR TITLE
A couple of fixes for the "manage media" modal.

### DIFF
--- a/localization/react-intl/src/app/components/media/AutoCompleteMediaItem.json
+++ b/localization/react-intl/src/app/components/media/AutoCompleteMediaItem.json
@@ -33,9 +33,5 @@
     "id": "autoCompleteMediaItem.requestsCount",
     "description": "Header of requests list. Example: 26 requests",
     "defaultMessage": "{requestsCount, plural, one {# request} other {# requests}}"
-  },
-  {
-    "id": "autoCompleteMediaItem.searchSettings",
-    "defaultMessage": "Search settings"
   }
 ]

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -3,10 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
+import { Link } from 'react-router';
 import Box from '@material-ui/core/Box';
 import Tooltip from '@material-ui/core/Tooltip';
 import Checkbox from '@material-ui/core/Checkbox';
-import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import TextField from '@material-ui/core/TextField';
 import SettingsIcon from '@material-ui/icons/Settings';
@@ -34,6 +34,13 @@ const useStyles = makeStyles(theme => ({
   },
   selectedItem: {
     background: grayBackground,
+  },
+  link: {
+    textDecoration: 'none',
+    display: 'contents',
+  },
+  settingsButton: {
+    padding: 2,
   },
 }));
 
@@ -162,6 +169,7 @@ const AutoCompleteMediaItem = (props, context) => {
                     linked_items_count
                     report_status
                     is_confirmed_similar_to_another_item
+                    full_url
                     media {
                       type
                       url
@@ -279,7 +287,7 @@ const AutoCompleteMediaItem = (props, context) => {
   return (
     <Box display="flex" alignItems="center" className="autocomplete-media-item">
       <Box flexGrow="1" width={1}>
-        <Box display="flex" alignItems="center" flexGrow="1">
+        <Box display="flex" alignItems="flex-start" flexGrow="1">
           <TextField
             id="autocomplete-media-item"
             name="autocomplete-media-item"
@@ -303,6 +311,7 @@ const AutoCompleteMediaItem = (props, context) => {
           />
           { props.showFilters ?
             <IconButton
+              className={classes.settingsButton}
               onClick={handleSettingsButton}
             >
               <SettingsIcon />
@@ -342,55 +351,51 @@ const AutoCompleteMediaItem = (props, context) => {
                         </span>
                       </Tooltip> : null
                     }
-                    <SmallMediaCard
-                      customTitle={projectMedia.title}
-                      details={[
-                        (
+                    <Link to={projectMedia.full_url} className={classes.link}>
+                      <SmallMediaCard
+                        customTitle={projectMedia.title}
+                        details={[
+                          (
+                            <FormattedMessage
+                              id="autoCompleteMediaItem.lastSubmitted"
+                              defaultMessage="Last submitted {date}"
+                              description="Shows the last time a media was submitted"
+                              values={{
+                                date: props.intl.formatDate(+projectMedia.last_seen * 1000, { year: 'numeric', month: 'short', day: '2-digit' }),
+                              }}
+                            />
+                          ),
                           <FormattedMessage
-                            id="autoCompleteMediaItem.lastSubmitted"
-                            defaultMessage="Last submitted {date}"
-                            description="Shows the last time a media was submitted"
-                            values={{
-                              date: props.intl.formatDate(+projectMedia.last_seen * 1000, { year: 'numeric', month: 'short', day: '2-digit' }),
-                            }}
-                          />
-                        ),
-                        <FormattedMessage
-                          id="autoCompleteMediaItem.requestsCount"
-                          defaultMessage="{requestsCount, plural, one {# request} other {# requests}}"
-                          description="Header of requests list. Example: 26 requests"
-                          values={{ requestsCount: projectMedia.requests_count }}
-                        />,
-                      ]}
-                      media={projectMedia.media}
-                      description={projectMedia.description}
-                      className={selectedDbid === projectMedia.dbid ? classes.selectedItem : null}
-                      onClick={() => {
-                        if (!props.multiple) {
-                          handleSelectOne(projectMedia.dbid);
-                        }
-                      }}
-                    />
+                            id="autoCompleteMediaItem.requestsCount"
+                            defaultMessage="{requestsCount, plural, one {# request} other {# requests}}"
+                            description="Header of requests list. Example: 26 requests"
+                            values={{ requestsCount: projectMedia.requests_count }}
+                          />,
+                        ]}
+                        media={projectMedia.media}
+                        description={projectMedia.description}
+                        className={selectedDbid === projectMedia.dbid ? classes.selectedItem : null}
+                        onClick={(e) => {
+                          if (!props.multiple) {
+                            handleSelectOne(projectMedia.dbid);
+                          }
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                      />
+                    </Link>
                   </Box>
                 ))}
               </Box> : null }
           </Box> : null }
       </Box>
       { showFilters ?
-        <Box className={classes.searchSettingsBox}>
-          <Typography variant="subtitle1" className={classes.searchSettingsTitle}>
-            <FormattedMessage
-              id="autoCompleteMediaItem.searchSettings"
-              defaultMessage="Search settings"
-            />
-          </Typography>
-          <SearchKeywordContainer
-            anchorEl={anchorEl}
-            query={query}
-            onDismiss={handleCloseFilters}
-            onSubmit={handleChangeFilters}
-          />
-        </Box> : null }
+        <SearchKeywordContainer
+          anchorEl={anchorEl}
+          query={query}
+          onDismiss={handleCloseFilters}
+          onSubmit={handleChangeFilters}
+        /> : null }
     </Box>
   );
 };


### PR DESCRIPTION
## Description

We call the "manage media" modal the modal that opens when, from the Manage Media drop-down on the item page, one of the import/export options is chosen. Fixes for that modal:

* Right-click on a card opens the context menu, so the item can be opened in a new tab
* Aligning the settings icon with the text field

Fixes both CV2-2915 and CV2-2916.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. Choose an option from the "manage media" drop-down in an item page. Verify that:

* Settings icon should be aligned with the text field
* It's possible to right-click a media card and open the item in a new tab

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

