### PR TITLE
bug fix: remove unnecessary typography from side navigation menu

### DIFF
--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -341,43 +341,41 @@ const ProjectsComponent = ({
         <ListItem onClick={handleToggleFoldersExpand} className={[classes.projectsComponentHeader, 'project-list__header'].join(' ')}>
           { foldersExpanded ? <ExpandLess className={classes.projectsComponentChevron} /> : <ExpandMore className={classes.projectsComponentChevron} /> }
           <ListItemText disableTypography>
-            <Typography variant="body1">
-              <Box display="flex" alignItems="center" justifyContent="space-between" fontWeight="bold">
-                <FormattedMessage id="projectsComponent.folders" defaultMessage="Folders" description="Label for a collapsable panel displayed on the left sidebar." />
-                <Can permissions={team.permissions} permission="create Project">
-                  <IconButton onClick={(e) => { setFolderMenuAnchor(e.currentTarget); e.stopPropagation(); }} className={[classes.projectsComponentButton, 'projects-list__add-folder-or-collection'].join(' ')}>
-                    <AddIcon />
-                  </IconButton>
-                </Can>
-                <Menu
-                  anchorEl={folderMenuAnchor}
-                  keepMounted
-                  open={Boolean(folderMenuAnchor)}
-                  onClose={() => { setFolderMenuAnchor(null); }}
+            <Box display="flex" alignItems="center" justifyContent="space-between" fontWeight="bold">
+              <FormattedMessage id="projectsComponent.folders" defaultMessage="Folders" description="Label for a collapsable panel displayed on the left sidebar." />
+              <Can permissions={team.permissions} permission="create Project">
+                <IconButton onClick={(e) => { setFolderMenuAnchor(e.currentTarget); e.stopPropagation(); }} className={[classes.projectsComponentButton, 'projects-list__add-folder-or-collection'].join(' ')}>
+                  <AddIcon />
+                </IconButton>
+              </Can>
+              <Menu
+                anchorEl={folderMenuAnchor}
+                keepMounted
+                open={Boolean(folderMenuAnchor)}
+                onClose={() => { setFolderMenuAnchor(null); }}
+              >
+                <MenuItem
+                  onClick={(e) => {
+                    setFolderMenuAnchor(null);
+                    setShowNewFolderDialog(true);
+                    e.stopPropagation();
+                  }}
+                  className="projects-list__add-folder"
                 >
-                  <MenuItem
-                    onClick={(e) => {
-                      setFolderMenuAnchor(null);
-                      setShowNewFolderDialog(true);
-                      e.stopPropagation();
-                    }}
-                    className="projects-list__add-folder"
-                  >
-                    <FormattedMessage id="projectsComponent.newFolderMenu" defaultMessage="New folder" description="Menu item for creating new folder" />
-                  </MenuItem>
-                  <MenuItem
-                    onClick={(e) => {
-                      setFolderMenuAnchor(null);
-                      setShowNewCollectionDialog(true);
-                      e.stopPropagation();
-                    }}
-                    className="projects-list__add-collection"
-                  >
-                    <FormattedMessage id="projectsComponent.newCollectionMenu" defaultMessage="New collection" description="Menu item for creating new collection" />
-                  </MenuItem>
-                </Menu>
-              </Box>
-            </Typography>
+                  <FormattedMessage id="projectsComponent.newFolderMenu" defaultMessage="New folder" description="Menu item for creating new folder" />
+                </MenuItem>
+                <MenuItem
+                  onClick={(e) => {
+                    setFolderMenuAnchor(null);
+                    setShowNewCollectionDialog(true);
+                    e.stopPropagation();
+                  }}
+                  className="projects-list__add-collection"
+                >
+                  <FormattedMessage id="projectsComponent.newCollectionMenu" defaultMessage="New collection" description="Menu item for creating new collection" />
+                </MenuItem>
+              </Menu>
+            </Box>
           </ListItemText>
         </ListItem>
 
@@ -470,16 +468,14 @@ const ProjectsComponent = ({
         <ListItem onClick={handleToggleListsExpand} className={[classes.projectsComponentHeader, 'project-list__header'].join(' ')}>
           { listsExpanded ? <ExpandLess className={classes.projectsComponentChevron} /> : <ExpandMore className={classes.projectsComponentChevron} /> }
           <ListItemText disableTypography>
-            <Typography variant="body1">
-              <Box display="flex" alignItems="center" justifyContent="space-between" fontWeight="bold">
-                <FormattedMessage id="projectsComponent.lists" defaultMessage="Filtered lists" description="List of items with some filters applied" />
-                <Can permissions={team.permissions} permission="create Project">
-                  <IconButton onClick={(e) => { setShowNewListDialog(true); e.stopPropagation(); }} className={classes.projectsComponentButton}>
-                    <AddIcon id="projects-list__add-filtered-list" />
-                  </IconButton>
-                </Can>
-              </Box>
-            </Typography>
+            <Box display="flex" alignItems="center" justifyContent="space-between" fontWeight="bold">
+              <FormattedMessage id="projectsComponent.lists" defaultMessage="Filtered lists" description="List of items with some filters applied" />
+              <Can permissions={team.permissions} permission="create Project">
+                <IconButton onClick={(e) => { setShowNewListDialog(true); e.stopPropagation(); }} className={classes.projectsComponentButton}>
+                  <AddIcon id="projects-list__add-filtered-list" />
+                </IconButton>
+              </Can>
+            </Box>
           </ListItemText>
         </ListItem>
 
@@ -509,9 +505,7 @@ const ProjectsComponent = ({
               { feedsExpanded ? <ExpandLess className={classes.projectsComponentChevron} /> : <ExpandMore className={classes.projectsComponentChevron} /> }
               <ListItemText disableTypography>
                 <Box display="flex" alignItems="center" justifyContent="space-between" fontWeight="bold">
-                  <Typography variant="body1">
-                    <FormattedMessage id="projectsComponent.sharedFeeds" defaultMessage="Shared feeds" description="Feeds of content shared across workspaces" />
-                  </Typography>
+                  <FormattedMessage id="projectsComponent.sharedFeeds" defaultMessage="Shared feeds" description="Feeds of content shared across workspaces" />
                 </Box>
               </ListItemText>
             </ListItem>

--- a/src/app/styles/css/index.css
+++ b/src/app/styles/css/index.css
@@ -43,8 +43,8 @@ input:-webkit-autofill {
 .check-icon {
   box-sizing: content-box;
   display: inline-block;
+  fill: currentcolor;
   flex-shrink: 0;
-  fill: currentColor;
   height: 1em;
   line-height: 1;
   overflow: visible;


### PR DESCRIPTION
## Description

There was a minor browser console error because of an invalid nesting tracked down to the side navigation menu specifically the section title "Folders", "Unfiltered lists", etc

This PR:
- removes unnecessary type settings
- tangentially fixes the "Shared feeds" title not matching the other section (it wasnt bold)

References: [CV2-2992](https://meedan.atlassian.net/browse/CV2-2992)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- manual tests
- verifying the error is gone from the console

## Things to pay attention to during code review

- no visual changes other than "Shared feeds" should now be correctly bold.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-2992]: https://meedan.atlassian.net/browse/CV2-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ