### PR TITLE
CV2-3079: add lock_version for similarity settings

### DIFF
--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -22,6 +22,8 @@ import Can from '../../Can';
 import { withSetFlashMessage } from '../../FlashMessage';
 import GenericUnknownErrorMessage from '../../GenericUnknownErrorMessage';
 import { ContentColumn } from '../../../styles/js/shared';
+import { getErrorObjectsForRelayModernProblem } from '../../../helpers';
+import CheckError from '../../../CheckError';
 
 const MEAN_TOKENS_MODEL = 'xlm-r-bert-base-nli-stsb-mean-tokens';
 const INDIAN_MODEL = 'indian-sbert';
@@ -85,9 +87,11 @@ const SimilarityComponent = ({
 
   const [saving, setSaving] = React.useState(false);
 
-  const handleError = () => {
+  const handleError = (error) => {
     setSaving(false);
-    setFlashMessage((<GenericUnknownErrorMessage />), 'error');
+    const errors = getErrorObjectsForRelayModernProblem(error);
+    const message = errors && errors.length > 0 ? CheckError.getMessageFromCode(errors[0].code) : <GenericUnknownErrorMessage />;
+    setFlashMessage(message, 'error');
   };
 
   const handleSuccess = () => {
@@ -110,11 +114,13 @@ const SimilarityComponent = ({
           team_bot_installation {
             id
             json_settings
+            lock_version
             team {
               id
               alegre_bot: team_bot_installation(bot_identifier: "alegre") {
                 id
                 alegre_settings
+                lock_version
               }
             }
           }
@@ -128,6 +134,7 @@ const SimilarityComponent = ({
         input: {
           id: team.alegre_bot.id,
           json_settings: JSON.stringify(settings),
+          lock_version: team.alegre_bot.lock_version,
         },
       },
       onCompleted: handleSuccess,
@@ -503,6 +510,7 @@ export default createFragmentContainer(withSetFlashMessage(SimilarityComponent),
     permissions
     alegre_bot: team_bot_installation(bot_identifier: "alegre") {
       id
+      lock_version
       alegre_settings
     }
   }


### PR DESCRIPTION
## Description
This feature handle conflict on similarity settings and should handle this situation 

- User A opens the similarity settings for a workspace
- User B opens the same page
- User B changes setting X value
- User B save the changes
- User A changes setting Y value
=> Setting X value will be reverted, because User A had the old value loaded in their form
Same as CV2-2482 ticket

References: CV2-3079

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Open similarity settings page in two different tabs 
- Go to first tab and update settings then save
Result: settings updated
- Go to second tab and update settings
Result: should go an error because you load old values 

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

