### PR TITLE
Do not allow negative numbers on numeric filters

### DIFF
--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -344,13 +344,15 @@ const DateRangeFilter = ({
   };
 
   const handleChangeRelativeQuantity = (e) => {
-    const valueRelativeQuantity = e.target.value;
-    setRelativeQuantity(valueRelativeQuantity);
-    onChange(buildValueRelative(
-      getValueType(),
-      valueRelativeQuantity,
-      relativeRange,
-    ));
+    if (e.target.value >= 0) {
+      const valueRelativeQuantity = e.target.value;
+      setRelativeQuantity(valueRelativeQuantity);
+      onChange(buildValueRelative(
+        getValueType(),
+        valueRelativeQuantity,
+        relativeRange,
+      ));
+    }
   };
 
   const handleClearDate = (event, field) => {

--- a/src/app/components/search/NumericRangeFilter.js
+++ b/src/app/components/search/NumericRangeFilter.js
@@ -63,19 +63,21 @@ const NumericRangeFilter = ({
   const filterKeysMapping = { linked_items_count: 'linkedItems', suggestions_count: 'suggestedItems', demand: 'tiplineRequests' };
 
   const handleFieldChange = (key, keyValue) => {
-    const range = { min: minNumber, max: maxNumber };
-    if (key === 'min') {
-      setMinNumber(keyValue);
-      range.min = keyValue;
-    } else if (key === 'max') {
-      setMaxNumber(keyValue);
-      range.max = keyValue;
-    }
-    if (range.max !== '' && parseInt(range.min, 10) > parseInt(range.max, 10)) {
-      setShowErrorMsg(true);
-    } else {
-      setShowErrorMsg(false);
-      onChange(filterKey, range);
+    if (keyValue >= 0) {
+      const range = { min: minNumber, max: maxNumber };
+      if (key === 'min') {
+        setMinNumber(keyValue);
+        range.min = keyValue;
+      } else if (key === 'max') {
+        setMaxNumber(keyValue);
+        range.max = keyValue;
+      }
+      if (range.max !== '' && parseInt(range.min, 10) > parseInt(range.max, 10)) {
+        setShowErrorMsg(true);
+      } else {
+        setShowErrorMsg(false);
+        onChange(filterKey, range);
+      }
     }
   };
 


### PR DESCRIPTION
## Description
Prevent inputs from allowing negative numbers on numeric filters

Reference: CV2-2942

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

