### PR TITLE
CV2-3002: Add OpenAI ada model to settings/similarity

### DIFF
--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -57,7 +57,8 @@ const SimilarityComponent = ({
   const [vectorModelToggle, setVectorModelToggle] = React.useState((
     alegre_settings.text_similarity_model === MEAN_TOKENS_MODEL ||
     alegre_settings.text_similarity_model === INDIAN_MODEL ||
-    alegre_settings.text_similarity_model === FILIPINO_MODEL
+    alegre_settings.text_similarity_model === FILIPINO_MODEL ||
+    alegre_settings.text_similarity_model === OPENAI_ADA_MODEL
   ));
 
   const handleSettingsChange = (key, value) => {

--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -29,6 +29,7 @@ const MEAN_TOKENS_MODEL = 'xlm-r-bert-base-nli-stsb-mean-tokens';
 const INDIAN_MODEL = 'indian-sbert';
 const ELASTICSEARCH_MODEL = 'elasticsearch';
 const FILIPINO_MODEL = 'paraphrase-filipino-mpnet-base-v2';
+const OPENAI_ADA_MODEL = 'openai-text-embedding-ada-002';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -308,6 +309,12 @@ const SimilarityComponent = ({
                           value={FILIPINO_MODEL}
                           control={<Radio />}
                           label="Filipino Paraphrase - Specialized in Filipino"
+                        />
+                        <FormControlLabel
+                          disabled={!vectorModelToggle || !settings.text_similarity_enabled}
+                          value={OPENAI_ADA_MODEL}
+                          control={<Radio />}
+                          label="OpenAI ada model - Experimental, pay-per-use model"
                         />
                       </RadioGroup>
                     </Box>


### PR DESCRIPTION
Adds the OpenAI ada model to the similarity settings page

## Description

The goal is to add a new vector model for text similarity to Alegre, Check-API, and Check-Web. All repos have a CV2-3002 branch.

References: CV2-3002

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Local tests

## Things to pay attention to during code review

Nothing particular. I don't know check-web well; so, please let me know if there is any additional place you think edits might be needed to enable a new vector model.

## Checklist

- [X] I have performed a self-review of my own code
- [n/a] I have commented my code in hard-to-understand areas, if any
- [n/a] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [n/a] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [n/a] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [n/a] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

