### PR TITLE
CV2-2885: add text length to similarity settings page

### DIFF
--- a/localization/react-intl/src/app/components/team/Similarity/SimilarityComponent.json
+++ b/localization/react-intl/src/app/components/team/Similarity/SimilarityComponent.json
@@ -42,6 +42,7 @@
   },
   {
     "id": "similarityComponent.textLength",
+    "description": "A label on a text input where the user specifies the minimum number of words needed to match before a text content match is considered confirmed",
     "defaultMessage": "Minimum words required for a confirmed match"
   },
   {

--- a/localization/react-intl/src/app/components/team/Similarity/SimilarityComponent.json
+++ b/localization/react-intl/src/app/components/team/Similarity/SimilarityComponent.json
@@ -41,6 +41,10 @@
     "defaultMessage": "Only send fact-checks in the same language as the conversation language"
   },
   {
+    "id": "similarityComponent.textLength",
+    "defaultMessage": "Minimum words required for a confirmed match"
+  },
+  {
     "id": "similarityComponent.minimumDuration",
     "defaultMessage": "Minimum duration in seconds"
   },

--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -279,6 +279,7 @@ const SimilarityComponent = ({
                       <FormattedMessage
                         id="similarityComponent.textLength"
                         defaultMessage="Minimum words required for a confirmed match"
+                        description="A label on a text input where the user specifies the minimum number of words needed to match before a text content match is considered confirmed"
                       />
                     </Typography>
                     <TextField

--- a/src/app/components/team/Similarity/SimilarityComponent.js
+++ b/src/app/components/team/Similarity/SimilarityComponent.js
@@ -274,6 +274,23 @@ const SimilarityComponent = ({
                     label="Elasticsearch suggestion threshold"
                     error={(settings.text_elasticsearch_suggestion_threshold > settings.text_elasticsearch_matching_threshold)}
                   />
+                  <Box ml={7}>
+                    <Typography component="span" style={{ fontWeight: 'bold' }} className={classes.transactionMargin}>
+                      <FormattedMessage
+                        id="similarityComponent.textLength"
+                        defaultMessage="Minimum words required for a confirmed match"
+                      />
+                    </Typography>
+                    <TextField
+                      classes={{ root: classes.root }}
+                      variant="outlined"
+                      size="small"
+                      value={settings.text_length_matching_threshold}
+                      onChange={(e) => { handleSettingsChange('text_length_matching_threshold', e.target.value); }}
+                      type="number"
+                      disabled={!settings.text_similarity_enabled}
+                    />
+                  </Box>
                 </Box>
                 <Box mb={4}>
                   <Box ml={6}>


### PR DESCRIPTION
## Description

Add ‘text_length_matching_threshold’ to /settings/similarity page so user can change this settings using UI


References: CV2-2885

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Go to similarity settings page
- you will find a settings `Minimum words required for a confirmed match` to change the settings value

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

