### PR TITLE
Fixing a warning that was displayed when deploying to QA: "start value has mixed support, consider using flex-start instead"

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.module.css
+++ b/src/app/components/team/Newsletter/NewsletterComponent.module.css
@@ -17,9 +17,9 @@
 .newsletter {
   background: var(--otherWhite);
   border-color: var(--grayBorderMain);
-  border-radius: 16px 16px 0;
+  border-radius: 16px;
   border-style: solid;
-  border-width: 2px 2px 0;
+  border-width: 2px;
   padding: 16px;
 }
 
@@ -134,7 +134,7 @@
   }
 
   .newsletter-scheduler-time {
-    align-items: start;
+    align-items: flex-start;
     display: flex;
     gap: 8px;
     padding: 8px;


### PR DESCRIPTION
## Description

Fixing a warning that was displayed when deploying to QA: "start value has mixed support, consider using flex-start instead".

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I will test on QA, because that error is not displayed when building locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

