### PR TITLE
Fixes to newsletter header upload error states

### DIFF
--- a/localization/react-intl/src/app/components/cds/inputs/Upload.json
+++ b/localization/react-intl/src/app/components/cds/inputs/Upload.json
@@ -16,7 +16,12 @@
   },
   {
     "id": "upload.dragMessage",
-    "description": "A label that appears when a user drags a file over a valid file drop area",
-    "defaultMessage": "Drag a video, image, PDF, or audio file here or"
+    "description": "A label that appears when a user drags a file over a valid file drop area. It ends with 'or' because it will be followed with a link that reads in English 'select a local file'.",
+    "defaultMessage": "Drag a file here or"
+  },
+  {
+    "id": "upload.selectFile",
+    "description": "Text for a link that when a user clicks it, it pulls up the file selector dialog for their local device operating system.",
+    "defaultMessage": "Select a local file"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Newsletter/NewsletterComponent.json
+++ b/localization/react-intl/src/app/components/team/Newsletter/NewsletterComponent.json
@@ -20,9 +20,14 @@
     "defaultMessage": "Scheduled date cannot be blank."
   },
   {
-    "id": "newsletterComponent.errorHeaderTye",
+    "id": "newsletterComponent.errorHeaderType",
     "description": "Error message displayed when a user submits a form with a blank header type field (this is chosen from a list).",
     "defaultMessage": "Header type must be supplied from the list."
+  },
+  {
+    "id": "newsletterComponent.errorHeaderFile",
+    "description": "Error message displayed when a user uploads a file of the wrong type. This is followed with a list of file types like 'png, jpg, jpeg, pdf'.",
+    "defaultMessage": "File must be of the following allowed types: {fileTypes}"
   },
   {
     "id": "newsletterComponent.error",

--- a/src/app/components/cds/inputs/DatePicker.module.css
+++ b/src/app/components/cds/inputs/DatePicker.module.css
@@ -16,7 +16,6 @@
   border-radius: 8px;
   color: var(--textPrimary);
   font: 400 14px var(--fontStackSans);
-  height: 100%;
   letter-spacing: .15px;
   line-height: 20px;
   padding: 10px;

--- a/src/app/components/cds/inputs/Time.module.css
+++ b/src/app/components/cds/inputs/Time.module.css
@@ -4,7 +4,6 @@
   border-radius: 8px;
   color: var(--textPrimary);
   font: 400 14px var(--fontStackSans);
-  height: 100%;
   letter-spacing: .15px;
   line-height: 20px;
   padding: 10px;

--- a/src/app/components/cds/inputs/Upload.js
+++ b/src/app/components/cds/inputs/Upload.js
@@ -9,6 +9,8 @@ import styles from './Upload.module.css';
 
 function Upload({
   fileName,
+  error,
+  helpContent,
   handleFileChange,
   setFile,
   setFileName,
@@ -33,7 +35,7 @@ function Upload({
 
   const handleClick = (e) => {
     // We use :scope to scope the query to just children of the parent element, in case there is more than one Upload component on the page
-    const inputElement = e.target.parentElement.querySelector(':scope .upload-input');
+    const inputElement = e.target.parentElement.parentElement.querySelector(':scope .upload-input');
     if (inputElement) {
       inputElement.click();
     }
@@ -88,9 +90,12 @@ function Upload({
           <input className={`upload-input ${styles.input}`} type="file" onChange={handleFileChange} />
         </form>
         <span className={`typography-button ${styles['drag-text']}`}>
-          <FormattedMessage id="upload.dragMessage" defaultMessage="Drag a video, image, PDF, or audio file here or" description="A label that appears when a user drags a file over a valid file drop area" />
+          <FormattedMessage id="upload.dragMessage" defaultMessage="Drag a file here or" description="A label that appears when a user drags a file over a valid file drop area. It ends with 'or' because it will be followed with a link that reads in English 'select a local file'." />
         </span>
-        &nbsp;<a className="typography-button" href="#!" onClick={handleClick}>Select a local file</a>.
+        &nbsp;
+        <a className="typography-button" href="#!" onClick={handleClick}>
+          <FormattedMessage id="upload.selectFile" defaultMessage="Select a local file" description="Text for a link that when a user clicks it, it pulls up the file selector dialog for their local device operating system." />
+        </a>.
       </div>
     );
   };
@@ -109,8 +114,8 @@ function Upload({
 
   const RenderError = () => (
     <div className={`${styles.error}`}>
-      <div><ErrorOutlineIcon className={styles['error-icon']} />&nbsp;{fileName}</div>
-      <div className="typography-caption">{ errorInternal }</div>
+      <div><ErrorOutlineIcon className={styles['error-icon']} />&nbsp;<span>{fileName}</span></div>
+      <div className="typography-caption">{ errorInternal || helpContent }</div>
     </div>
   );
 
@@ -122,7 +127,7 @@ function Upload({
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
     >
-      { errorInternal && <RenderError /> }
+      { (errorInternal || error) && <RenderError /> }
       { fileName ? <RenderFile /> : <RenderDropZone /> }
     </div>
   );

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -124,7 +124,9 @@ const NewsletterComponent = ({
         err[0]?.data.introduction ||
         err[0]?.data.rss_feed_url ||
         err[0]?.data.send_on ||
-        err[0]?.data.header_type
+        err[0]?.data.header_type ||
+        err[0]?.data.header_file ||
+        err[0]?.data.base
       )
     ) {
       const { data } = err[0];
@@ -167,11 +169,27 @@ const NewsletterComponent = ({
       if (data.header_type && data.header_type[0] === 'is not included in the list') {
         data.header_type = (
           <FormattedMessage
-            id="newsletterComponent.errorHeaderTye"
+            id="newsletterComponent.errorHeaderType"
             defaultMessage="Header type must be supplied from the list."
             description="Error message displayed when a user submits a form with a blank header type field (this is chosen from a list)."
           />
         );
+      }
+      if (data.header_file && data.header_file[0].includes('cannot be of type')) {
+        data.header_file = (
+          <FormattedMessage
+            id="newsletterComponent.errorHeaderFile"
+            defaultMessage="File must be of the following allowed types: {fileTypes}"
+            description="Error message displayed when a user uploads a file of the wrong type. This is followed with a list of file types like 'png, jpg, jpeg, pdf'."
+            values={{
+              fileTypes: data.header_file[0].split(':')[1],
+            }}
+          />
+        );
+      }
+      if (data.base && data.base[0].includes('Sorry, we don\'t support')) {
+        // FIXME: We are not going to internationalize this string for now, it's too unstructured and variable to make work
+        data.base = data.base[0]; // eslint-disable-line prefer-destructuring
       }
       setErrors(data);
     } else if (err.length && err[0]?.message) {
@@ -408,13 +426,12 @@ const NewsletterComponent = ({
             className="newsletter-component-header"
             key={`newsletter-header-${language}`}
             disabled={scheduled}
-            error={errors.header_type}
-            helpContent={errors.header_type}
+            parentErrors={errors}
             file={file}
             handleFileChange={handleFileChange}
             setFile={setFile}
             setFileName={setFileName}
-            availableHeaderTypes={team.available_newsletter_header_types || []}
+            availableHeaderTypes={['image', 'none'] || team.available_newsletter_header_types || []}
             headerType={headerType}
             fileName={fileName}
             overlayText={overlayText}

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -38,11 +38,11 @@ const NewsletterHeader = ({
   disabled,
   availableHeaderTypes,
   error,
-  helpContent,
   headerType,
   handleFileChange,
   file,
   fileName,
+  parentErrors,
   setFile,
   setFileName,
   overlayText,
@@ -56,8 +56,8 @@ const NewsletterHeader = ({
       value={headerType}
       onChange={(e) => { onUpdateField('headerType', e.target.value); }}
       disabled={disabled}
-      error={error}
-      helpContent={helpContent}
+      error={parentErrors.header_type || error}
+      helpContent={parentErrors.header_type}
     >
       <option />
       <option disabled={!availableHeaderTypes.includes('none')} value="none">{intl.formatMessage(messages.headerTypeNone)}</option>
@@ -71,6 +71,8 @@ const NewsletterHeader = ({
       <div className={styles.uploader}>
         <Upload
           type="image+video+audio"
+          error={parentErrors.header_file || parentErrors.base}
+          helpContent={parentErrors.header_file || parentErrors.base}
           disabled={disabled}
           handleFileChange={handleFileChange}
           fileName={fileName}


### PR DESCRIPTION
The upload component now displays two upload-related server-side errors: when a file is too big and when it is the wrong type.

For example:

![image](https://github.com/meedan/check-web/assets/266454/ab0ed774-6ed5-4d43-9524-524965dd8296)

This commit also fixes a minor display bug in some versions of Chrome - other versions unaffected by the change.

References: CV2-2873

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Verified fixed locally by dev.

## Things to pay attention to during code review

There is a `FIXME` in line 192 of `NewsletterComponent.js` where we are not localizing the string that the API returns when an uploaded file is too big. It was too variable for me to figure out how to turn into a localized string.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)