### PR TITLE
Reload the page when newsletter is created for the first time

### DIFF
--- a/src/app/components/cds/forms/LanguagePickerSelect.js
+++ b/src/app/components/cds/forms/LanguagePickerSelect.js
@@ -25,7 +25,8 @@ const LanguagePickerSelect = ({
   isDisabled,
 }) => {
   const [value, setValue] = React.useState(selectedLanguage);
-  languages.unshift('und');
+  const options = languages.slice();
+  options.unshift('und');
 
   // intl.formatMessage needed here because Autocomplete
   // performs toLowerCase on strings for comparison
@@ -53,7 +54,7 @@ const LanguagePickerSelect = ({
         disableClearable
         id="autocomplete-add-language"
         name="autocomplete-add-language"
-        options={languages}
+        options={options}
         openOnFocus
         getOptionLabel={getOptionLabel}
         getOptionDisabled={option => option === 'und'}

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -85,6 +85,7 @@ const NewsletterComponent = ({
     setArticleNum(number_of_articles || 0);
     setArticles([first_article || '', second_article || '', third_article || '']);
     setHeaderType(header_type || '');
+    setFileName((header_file_url && header_file_url.match(fileNameFromUrl) && header_file_url.match(fileNameFromUrl)[0]) || '');
     setContentType(content_type || 'static');
     setRssFeedUrl(rss_feed_url || '');
     setSendEvery(send_every || ['wednesday']);
@@ -235,28 +236,8 @@ const NewsletterComponent = ({
   const createMutation = graphql`
     mutation NewsletterComponentCreateMutation($input: CreateTiplineNewsletterInput!) {
       createTiplineNewsletter(input: $input) {
-        tipline_newsletter {
+        team {
           id
-          introduction
-          language
-          header_type
-          header_overlay_text
-          content_type
-          first_article
-          second_article
-          third_article
-          rss_feed_url
-          number_of_articles
-          send_every
-          send_on
-          timezone
-          time
-          enabled
-          last_delivery_error
-          last_scheduled_at
-          last_scheduled_by {
-            name
-          }
         }
       }
     }
@@ -333,6 +314,10 @@ const NewsletterComponent = ({
               handleError(err);
             } else {
               handleSuccess(response);
+              // FIXME: Find a better way to refresh the local store when a newsletter is created
+              if (!input.id) {
+                window.location.assign(`/${team.slug}/settings/newsletter`);
+              }
             }
           },
           onError: (err) => {
@@ -557,8 +542,9 @@ export { NewsletterComponent as NewsletterComponentTest };
 
 export default createFragmentContainer(withSetFlashMessage(NewsletterComponent), graphql`
   fragment NewsletterComponent_team on Team {
-    permissions
     id
+    slug
+    permissions
     defaultLanguage: get_language
     languages: get_languages
     available_newsletter_header_types

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -14,19 +14,18 @@ import SwitchComponent from '../../cds/inputs/SwitchComponent';
 import styles from './NewsletterComponent.module.css';
 import LanguagePickerSelect from '../../cds/forms/LanguagePickerSelect';
 import SettingsHeader from '../SettingsHeader';
-import { safelyParseJSON } from '../../../helpers';
 import { can } from '../../Can';
 import { withSetFlashMessage } from '../../FlashMessage';
 
 const NewsletterComponent = ({
   environment,
   team,
+  language,
+  languages,
+  onChangeLanguage,
   setFlashMessage,
 }) => {
   const newsletters = team.tipline_newsletters?.edges;
-  const { defaultLanguage } = team;
-  const languages = safelyParseJSON(team.languages);
-  const [language, setLanguage] = React.useState(defaultLanguage || languages[0] || 'en');
   const newsletter = newsletters.find(item => item.node.language === language)?.node || {};
   const [file, setFile] = React.useState(null);
   const [errors, setErrors] = React.useState({});
@@ -73,28 +72,10 @@ const NewsletterComponent = ({
   const [sendEvery, setSendEvery] = React.useState(send_every || ['wednesday']);
   const [sendOn, setSendOn] = React.useState(send_on || null);
   const [timezone, setTimezone] = React.useState(send_timezone || '');
-  const [time, setTime] = React.useState(send_time || '9:00');
+  const [time, setTime] = React.useState(send_time || '09:00');
   const [scheduled, setScheduled] = React.useState(enabled || false);
 
   const numberOfArticles = (contentType === 'rss' && articleNum === 0) ? 1 : articleNum;
-
-  // This triggers when language is selected, and rerenders all data fields with their defaults
-  React.useEffect(() => {
-    setOverlayText(header_overlay_text || '');
-    setIntroductionText(introduction || '');
-    setArticleNum(number_of_articles || 0);
-    setArticles([first_article || '', second_article || '', third_article || '']);
-    setHeaderType(header_type || '');
-    setFileName((header_file_url && header_file_url.match(fileNameFromUrl) && header_file_url.match(fileNameFromUrl)[0]) || '');
-    setContentType(content_type || 'static');
-    setRssFeedUrl(rss_feed_url || '');
-    setSendEvery(send_every || ['wednesday']);
-    setSendOn(send_on || '');
-    setTimezone(send_timezone || '');
-    setTime(send_time || '09:00');
-    setScheduled(enabled || false);
-    setErrors({});
-  }, [language]);
 
   // This triggers when a file is changed, rerenders the file name
   React.useEffect(() => {
@@ -112,7 +93,7 @@ const NewsletterComponent = ({
 
   const handleLanguageChange = (value) => {
     const { languageCode } = value;
-    setLanguage(languageCode);
+    onChangeLanguage(languageCode);
   };
 
   const handleError = (err) => {
@@ -514,8 +495,6 @@ const NewsletterComponent = ({
 
 NewsletterComponent.propTypes = {
   team: PropTypes.shape({
-    defaultLanguage: PropTypes.string.isRequired,
-    languages: PropTypes.string.isRequired,
     permissions: PropTypes.string.isRequired,
     tipline_newsletters: PropTypes.shape({
       edges: PropTypes.arrayOf(PropTypes.shape({
@@ -535,6 +514,9 @@ NewsletterComponent.propTypes = {
       ),
     }),
   }).isRequired,
+  language: PropTypes.string.isRequired,
+  languages: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onChangeLanguage: PropTypes.func.isRequired,
 };
 
 // eslint-disable-next-line import/no-unused-modules
@@ -545,8 +527,6 @@ export default createFragmentContainer(withSetFlashMessage(NewsletterComponent),
     id
     slug
     permissions
-    defaultLanguage: get_language
-    languages: get_languages
     available_newsletter_header_types
     tipline_newsletters(first: 1000) {
       edges {

--- a/src/app/components/team/Newsletter/index.js
+++ b/src/app/components/team/Newsletter/index.js
@@ -1,38 +1,49 @@
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
+import { safelyParseJSON } from '../../../helpers';
 import NewsletterComponent from './NewsletterComponent';
 import createEnvironment from '../../../relay/EnvironmentModern';
 
-const Newsletter = () => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query NewsletterQuery {
-        me {
-          token
-        }
-        team {
-          slug
-          ...NewsletterComponent_team
-        }
-      }
-    `}
-    variables={{}}
-    render={({ props }) => {
-      const environment = createEnvironment(props?.me?.token, props?.team?.slug);
+const Newsletter = () => {
+  const [language, setLanguage] = React.useState(null);
 
-      if (props) {
-        return (
-          <NewsletterComponent
-            team={props.team}
-            environment={environment}
-          />
-        );
-      }
-      return null;
-    }}
-  />
-);
+  return (
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query NewsletterQuery {
+          me {
+            token
+          }
+          team {
+            slug
+            get_language
+            get_languages
+            ...NewsletterComponent_team
+          }
+        }
+      `}
+      variables={{ language }}
+      render={({ props }) => {
+        const environment = createEnvironment(props?.me?.token, props?.team?.slug);
+
+        if (props && props.team) {
+          const languages = safelyParseJSON(props.team.get_languages);
+          return (
+            <NewsletterComponent
+              team={props.team}
+              environment={environment}
+              language={language || props.team.get_language || languages[0] || 'en'}
+              languages={languages}
+              onChangeLanguage={setLanguage}
+            />
+          );
+        }
+        return null;
+      }}
+    />
+  );
+};
 
 export default Newsletter;


### PR DESCRIPTION
## Description

When a newsletter is created for the first time, for now we're going to reload the page in order to force an update of the local store, otherwise the newsletter can't be updated. This is meant to be a temporary solution... we should use Relay's RANGE_ADD or something like that.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Create a newsletter and verify that the page is reload. After a reload, you should be able to update the created newsletter.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

