### PR TITLE
Make default newsletter timezone the local browser timezone

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -71,7 +71,7 @@ const NewsletterComponent = ({
   const [contentType, setContentType] = React.useState(content_type || 'static');
   const [sendEvery, setSendEvery] = React.useState(send_every || ['wednesday']);
   const [sendOn, setSendOn] = React.useState(send_on || null);
-  const [timezone, setTimezone] = React.useState(send_timezone || '');
+  const [timezone, setTimezone] = React.useState(send_timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
   const [time, setTime] = React.useState(send_time || '09:00');
   const [scheduled, setScheduled] = React.useState(enabled || false);
 

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -171,7 +171,8 @@ const NewsletterScheduler = ({
           <Time value={time} onChange={(e) => { onUpdate('time', e.target.value); }} disabled={scheduled} required />
           <Select
             className={styles.select}
-            value={timezone}
+            // We check for both code ('Europe/London') and value ('Europe/London (GMT+1:00)') because default values in the browser will only guarantee the first, but if it's saved, the timezone is returned from the API with the offset appended. Doing it this way means we don't have to recalculate the offset in the parent NewsletterComponent)
+            value={timezones.find(item => item.code === timezone || item.value === timezone)?.value}
             onChange={(e) => { onUpdate('timezone', e.target.value); }}
             error={parentErrors.timezone}
             helpContent={parentErrors.timezone && parentErrors.timezone}


### PR DESCRIPTION
When figuring out what value to display in the `NewsletterScheduler` we check for both `code` ('Europe/London') and `value` ('Europe/London (GMT+1:00)'). If the timezone comes from the browser's default timezone then it will match `code` and if it comes from the API it will match `value`. Doing it this way means we don't have to recalculate the offset in the parent `NewsletterComponent` or make changes to how we save the timezone in the API.

@caiosba Does this seem fine? The other solution is to store `code` (like `Europe/London`) on the server instead of `value`. I do think we might run into issues where sometimes `Europe/London` is GMT+1 and sometimes it is GMT+0. I am not 100% sure of this but if we save `Europe/London` would we run into issues when we schedule a newsletter for `Europe/London (GMT+1:00)` and then daylight savings rolls back? Would we get an `undefined` when trying to match the timezone? If so we should be storing just the `code` without offset on the server, I think.