### PR TITLE
Some fixes for the link management and newsletter interfaces.

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamDetails.json
+++ b/localization/react-intl/src/app/components/team/TeamDetails.json
@@ -72,6 +72,6 @@
   {
     "id": "teamDetails.warnContent",
     "description": "Text displayed in a warning box on team details page when link shortening is on",
-    "defaultMessage": "Links processed in the Check platform will be rewritten to match this example: https://chck.media/x1y2z3w4?utm_source=utm_code. The unique code in each link will redirect your users to the original final destination."
+    "defaultMessage": "Links processed in the Check platform will be rewritten to match this example: https://chck.media/x1y2z3w4. The unique code in each link will redirect your users to the original final destination."
   }
 ]

--- a/src/app/components/layout/inputs/LimitedTextArea.js
+++ b/src/app/components/layout/inputs/LimitedTextArea.js
@@ -11,13 +11,13 @@ const LimitedTextArea = ({
   helpContent,
   ...textFieldProps
 }) => {
-  const [error, setError] = React.useState(false);
+  const [localError, setLocalError] = React.useState(false);
 
   React.useEffect(() => {
     if ((value?.length || 0) > maxChars) {
-      setError(true);
+      setLocalError(true);
     } else {
-      setError(false);
+      setLocalError(false);
     }
   });
 
@@ -41,8 +41,8 @@ const LimitedTextArea = ({
       )}
       onChange={onChange || handleChange}
       value={value}
-      error={error}
       {...textFieldProps}
+      error={localError || textFieldProps.error}
     />
   );
 };
@@ -50,6 +50,7 @@ const LimitedTextArea = ({
 LimitedTextArea.defaultProps = {
   value: '',
   helpContent: null,
+  textFieldProps: {},
 };
 
 LimitedTextArea.propTypes = {
@@ -57,6 +58,7 @@ LimitedTextArea.propTypes = {
   value: PropTypes.string,
   setValue: PropTypes.func.isRequired,
   helpContent: PropTypes.element,
+  textFieldProps: PropTypes.object,
 };
 
 export default LimitedTextArea;

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -64,7 +64,7 @@ const NewsletterComponent = ({
   const [introductionText, setIntroductionText] = React.useState(introduction || '');
   const [articleNum, setArticleNum] = React.useState(number_of_articles || 0);
   const [articles, setArticles] = React.useState([first_article || '', second_article || '', third_article || '']);
-  const [headerType, setHeaderType] = React.useState(header_type || '');
+  const [headerType, setHeaderType] = React.useState(header_type || 'link_preview');
   const fileNameFromUrl = new RegExp(/[^/\\&?]+\.\w{3,4}(?=([?&].*$|$))/);
   const [fileName, setFileName] = React.useState((header_file_url && header_file_url.match(fileNameFromUrl) && header_file_url.match(fileNameFromUrl)[0]) || '');
   const [rssFeedUrl, setRssFeedUrl] = React.useState(rss_feed_url || '');
@@ -429,7 +429,7 @@ const NewsletterComponent = ({
             handleFileChange={handleFileChange}
             setFile={setFile}
             setFileName={setFileName}
-            availableHeaderTypes={['image', 'none'] || team.available_newsletter_header_types || []}
+            availableHeaderTypes={team.available_newsletter_header_types || []}
             headerType={headerType}
             fileName={fileName}
             overlayText={overlayText}

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -59,7 +59,6 @@ const NewsletterHeader = ({
       error={parentErrors.header_type || error}
       helpContent={parentErrors.header_type}
     >
-      <option />
       <option disabled={!availableHeaderTypes.includes('none')} value="none">{intl.formatMessage(messages.headerTypeNone)}</option>
       <option disabled={!availableHeaderTypes.includes('link_preview')} value="link_preview">{intl.formatMessage(messages.headerTypeLinkPreview)}</option>
       <option disabled={!availableHeaderTypes.includes('image')} value="image">{intl.formatMessage(messages.headerTypeImage)}</option>
@@ -109,7 +108,7 @@ const NewsletterHeader = ({
 NewsletterHeader.defaultProps = {
   disabled: false,
   availableHeaderTypes: [],
-  headerType: '',
+  headerType: 'link_preview',
   overlayText: null,
   fileName: '',
   error: false,

--- a/src/app/components/team/Newsletter/NewsletterRssFeed.js
+++ b/src/app/components/team/Newsletter/NewsletterRssFeed.js
@@ -77,7 +77,13 @@ const NewsletterRssFeed = ({
                     placeholder={placeholder}
                     disabled={disabled}
                     className={styles['rss-feed-url-field']}
-                    onChange={(e) => { setLocalRssFeedUrl(e.target.value); }}
+                    onChange={(e) => {
+                      let { value } = e.target;
+                      if (!/^https?:\/\//.test(value)) {
+                        value = `https://${value}`;
+                      }
+                      setLocalRssFeedUrl(value);
+                    }}
                     onBlur={(e) => {
                       if (e.target.value === '') {
                         onUpdateUrl(null);

--- a/src/app/components/team/Team.js
+++ b/src/app/components/team/Team.js
@@ -33,6 +33,7 @@ const Team = (props) => {
         `}
         variables={{
           teamSlug,
+          timestamp: new Date().getTime(), // FIXME: Forcing re-fetching data from the backend since Relay Modern mutations with file uploads don't update the Relay store yet
         }}
         render={data => renderQuery(data, props)}
       />

--- a/src/app/components/team/TeamDetails.js
+++ b/src/app/components/team/TeamDetails.js
@@ -34,6 +34,7 @@ const TeamDetails = ({
 
   const canEditTeam = can(team.permissions, 'update Team');
   const hasRssNewsletters = Boolean(team.tipline_newsletters.edges.find(tn => tn.node.content_type === 'rss'));
+  const hasScheduledNewsletters = Boolean(team.tipline_newsletters.edges.find(tn => tn.node.enabled));
 
   const handleImageChange = (file) => {
     setAvatar(file);
@@ -192,7 +193,7 @@ const TeamDetails = ({
                 description="Label for a switch where the user toggles link management in team details page"
               />}
               checked={shortenOutgoingUrls || hasRssNewsletters}
-              disabled={hasRssNewsletters}
+              disabled={hasRssNewsletters || hasScheduledNewsletters}
               helperContent={
                 hasRssNewsletters ?
                   <FormattedMessage id="teamDetails.linkManagementRss" defaultMessage="The link service cannot be disabled while RSS newsletters are configured in this workspace" description="Helper text for link management switcher when workspace has RSS newsletters configured" /> :
@@ -216,14 +217,14 @@ const TeamDetails = ({
                 onChange={e => setUtmCode(e.target.value)}
                 helperText={<FormattedMessage id="teamDetails.utmCodeHelp" defaultMessage="Customize the UTM code appended to links. Leave blank to disable UTM codes." description="Helper text for UTM code field" />}
                 variant="outlined"
-                required
+                disabled={hasScheduledNewsletters}
               /> : null
             }
             { shortenOutgoingUrls ?
               <Alert
                 type="warning"
                 title={<FormattedMessage id="teamDetails.warnTitle" defaultMessage="All links sent via Check are managed" description="Text displayed in a warning box on team details page when link shortening is on" />}
-                content={<FormattedMessage id="teamDetails.warnContent" defaultMessage="Links processed in the Check platform will be rewritten to match this example: https://chck.media/x1y2z3w4?utm_source=utm_code. The unique code in each link will redirect your users to the original final destination." description="Text displayed in a warning box on team details page when link shortening is on" />}
+                content={<FormattedMessage id="teamDetails.warnContent" defaultMessage="Links processed in the Check platform will be rewritten to match this example: https://chck.media/x1y2z3w4. The unique code in each link will redirect your users to the original final destination." description="Text displayed in a warning box on team details page when link shortening is on" />}
               /> : null
             }
           </div>
@@ -252,6 +253,7 @@ export default createFragmentContainer(withSetFlashMessage(TeamDetails), graphql
       edges {
         node {
           content_type
+          enabled
         }
       }
     }


### PR DESCRIPTION
## Description

* UTM code field should not be required
* UTM code field should be editable only while the newsletter is paused
* Changed the copy link management warning box
* When characters left are negative in the introduction and articles field, the helper text should be red - the entire field should be in error state
* RSS: Auto add “https://” if it’s missing from the field when clicking the load button
* Header default should be link preview, it’s empty

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Just manually and visually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

