### PR TITLE
Display a human-friendly error when introduction is too long

### DIFF
--- a/localization/react-intl/src/app/components/team/Newsletter/NewsletterComponent.json
+++ b/localization/react-intl/src/app/components/team/Newsletter/NewsletterComponent.json
@@ -15,6 +15,11 @@
     "defaultMessage": "Introduction cannot be blank."
   },
   {
+    "id": "newsletterComponent.errorIntroductionTooLong",
+    "description": "Error message displayed when a user submits a form with an introduction field that is too long.",
+    "defaultMessage": "Introduction is too long"
+  },
+  {
     "id": "newsletterComponent.errorRssFeedUrl",
     "description": "Error message displayed when a user submits a form with a URL that the server does not recognize.",
     "defaultMessage": "RSS feed URL is invalid."

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -161,6 +161,15 @@ const NewsletterComponent = ({
           />
         );
       }
+      if (data.introduction && /is too long/.test(data.introduction[0])) {
+        data.introduction = (
+          <FormattedMessage
+            id="newsletterComponent.errorIntroductionTooLong"
+            defaultMessage="Introduction is too long"
+            description="Error message displayed when a user submits a form with an introduction field that is too long."
+          />
+        );
+      }
       if (data.rss_feed_url && data.rss_feed_url[0] === 'is invalid') {
         data.rss_feed_url = (
           <FormattedMessage


### PR DESCRIPTION
## Description

On newsletter settings page, display a human-friendly error when introduction is too long.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Go to newsletter settings page
* Write an introduction that has more than 180 characters
* Try to save
* You should see an error in red, "Introduction is too long", in the bottom of the field

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

