### PR TITLE
Validate field length in newsletter settings

### DIFF
--- a/src/app/components/layout/inputs/LimitedTextArea.js
+++ b/src/app/components/layout/inputs/LimitedTextArea.js
@@ -9,6 +9,7 @@ const LimitedTextArea = ({
   setValue,
   onChange,
   helpContent,
+  onErrorTooLong,
   ...textFieldProps
 }) => {
   const [localError, setLocalError] = React.useState(false);
@@ -16,8 +17,10 @@ const LimitedTextArea = ({
   React.useEffect(() => {
     if ((value?.length || 0) > maxChars) {
       setLocalError(true);
+      onErrorTooLong(true);
     } else {
       setLocalError(false);
+      onErrorTooLong(false);
     }
   });
 
@@ -51,6 +54,7 @@ LimitedTextArea.defaultProps = {
   value: '',
   helpContent: null,
   textFieldProps: {},
+  onErrorTooLong: () => {},
 };
 
 LimitedTextArea.propTypes = {
@@ -58,6 +62,7 @@ LimitedTextArea.propTypes = {
   value: PropTypes.string,
   setValue: PropTypes.func.isRequired,
   helpContent: PropTypes.element,
+  onErrorTooLong: PropTypes.func,
   textFieldProps: PropTypes.object,
 };
 

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -60,6 +60,7 @@ const NewsletterComponent = ({
 
   const [saving, setSaving] = React.useState(false);
   const [disableSaveNoFile, setDisableSaveNoFile] = React.useState(false);
+  const [textfieldOverLength, setTextfieldOverLength] = React.useState(false);
   const [overlayText, setOverlayText] = React.useState(header_overlay_text || '');
   const [introductionText, setIntroductionText] = React.useState(introduction || '');
   const [articleNum, setArticleNum] = React.useState(number_of_articles || 0);
@@ -77,6 +78,7 @@ const NewsletterComponent = ({
   const [datetimeIsPast, setDatetimeIsPast] = React.useState(false);
 
   const numberOfArticles = (contentType === 'rss' && articleNum === 0) ? 1 : articleNum;
+  const introductionTextMaxChars = 180;
 
   // This triggers when a file or file name or header type is changed. If the header is an attachment type, it disables saving if there is no file attached.
   React.useEffect(() => {
@@ -417,7 +419,7 @@ const NewsletterComponent = ({
         }
         actionButton={
           <div>
-            <Button className="save-button" variant="contained" color="primary" onClick={handleSave} disabled={scheduled || saving || datetimeIsPast || disableSaveNoFile || !can(team.permissions, 'create TiplineNewsletter')}>
+            <Button className="save-button" variant="contained" color="primary" onClick={handleSave} disabled={scheduled || saving || datetimeIsPast || disableSaveNoFile || textfieldOverLength || !can(team.permissions, 'create TiplineNewsletter')}>
               <FormattedMessage id="newsletterComponent.save" defaultMessage="Save" description="Label for a button to save settings for the newsletter" />
             </Button>
           </div>
@@ -457,8 +459,11 @@ const NewsletterComponent = ({
           >
             { placeholder => (
               <LimitedTextArea
-                maxChars={180}
+                maxChars={introductionTextMaxChars}
                 disabled={scheduled}
+                onErrorTooLong={(error) => {
+                  setTextfieldOverLength(error);
+                }}
                 value={introductionText}
                 setValue={setIntroductionText}
                 placeholder={placeholder}
@@ -518,6 +523,7 @@ const NewsletterComponent = ({
                 numberOfArticles={numberOfArticles}
                 onUpdateNumberOfArticles={setArticleNum}
                 articles={articles}
+                setTextfieldOverLength={setTextfieldOverLength}
                 onUpdateArticles={setArticles}
               /> : null }
           </div>
@@ -530,7 +536,7 @@ const NewsletterComponent = ({
               time={time}
               parentErrors={errors}
               scheduled={scheduled}
-              disabled={saving || disableSaveNoFile || datetimeIsPast}
+              disabled={saving || disableSaveNoFile || datetimeIsPast || textfieldOverLength}
               subscribersCount={subscribers_count}
               lastSentAt={last_sent_at}
               lastScheduledAt={last_scheduled_at}

--- a/src/app/components/team/Newsletter/NewsletterStatic.js
+++ b/src/app/components/team/Newsletter/NewsletterStatic.js
@@ -10,6 +10,7 @@ const NewsletterStatic = ({
   numberOfArticles,
   onUpdateNumberOfArticles,
   articles,
+  setTextfieldOverLength,
   onUpdateArticles,
 }) => {
   const getMaxChars = () => {
@@ -49,6 +50,9 @@ const NewsletterStatic = ({
               key={x}
               disabled={disabled}
               error={!!articleErrors[i]}
+              onErrorTooLong={(error) => {
+                setTextfieldOverLength(error);
+              }}
               helpContent={articleErrors[i]}
               maxChars={getMaxChars()}
               value={articles[i]}
@@ -77,6 +81,7 @@ NewsletterStatic.propTypes = {
   articles: PropTypes.arrayOf(PropTypes.string),
   articleErrors: PropTypes.arrayOf(PropTypes.element),
   onUpdateArticles: PropTypes.func.isRequired,
+  setTextfieldOverLength: PropTypes.func.isRequired,
 };
 
 export default NewsletterStatic;


### PR DESCRIPTION
This commit adds an `onErrorTooLong` function prop to `LimitedTextArea` -- a function that is called, and passed a binary error state as its first and only parameter. This allows controlling forms to set state variables etc as needed when a `LimitedTextArea`'s error state changes due to going over or under the character limit.

Both `NewsletterScheduler` (for introduction) and `NewsletterStatic` (for article field length) use this new hook to communicate to the form validation.