### PR TITLE
Trigger revalidation of date error on contentType switch

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -120,7 +120,7 @@ const NewsletterComponent = ({
       errorsCopy.datetime_past = null;
     }
     setErrors(errorsCopy);
-  }, [sendOn, time, timezone]);
+  }, [contentType, sendOn, time, timezone]);
 
   const handleLanguageChange = (value) => {
     const { languageCode } = value;


### PR DESCRIPTION
Previously the `useEffect` to revalidate the dates was not triggering on a `contentType` change from static to RSS. By adding `contentType` to the list of states that trigger the effect, we revalidate the dates on switching to RSS and thus an error state on dates for static newsletter no longer applies to RSS.