### PR TITLE
fix  border color on group choice buttons when the items are disabled and selected

### DIFF
--- a/src/app/components/cds/inputs/ToggleButtonGroup.module.css
+++ b/src/app/components/cds/inputs/ToggleButtonGroup.module.css
@@ -37,7 +37,12 @@
 
   :global(.MuiButtonBase-root.Mui-disabled.Mui-selected) {
     background-color: var(--textDisabled);
+    border-color: var(--textDisabled);
     color: var(--otherWhite);
+
+    + :global(.MuiButtonBase-root.Mui-disabled.Mui-selected) {
+      border-color: var(--textDisabled);
+    }
   }
 
   button:not(:first-child) {


### PR DESCRIPTION
## Description

There was an incorrectly applied border color on selected disabled group buttons

References: [CV2-3178](https://meedan.atlassian.net/browse/CV2-3178)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

### BEFORE
<img width="365" alt="Screenshot 2023-06-02 at 11 15 39 AM" src="https://github.com/meedan/check-web/assets/418001/82f978f2-124c-4594-a001-55a74a933f4a">

### AFTER
<img width="411" alt="Screenshot 2023-06-02 at 11 13 45 AM" src="https://github.com/meedan/check-web/assets/418001/423f710f-2f3d-4a49-b75a-8d48f48f0744">


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-3178]: https://meedan.atlassian.net/browse/CV2-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ