### PR TITLE
Fix TypeErrors :"Cannot read properties of null

### DIFF
--- a/src/app/components/cds/media-cards/MediaControls.js
+++ b/src/app/components/cds/media-cards/MediaControls.js
@@ -52,10 +52,10 @@ const MediaControls = ({
   React.useEffect(() => {
     const video = videoRef.current;
     video.addEventListener('loadedmetadata', () => {
-      setDuration(videoRef.current.duration);
+      setDuration(videoRef.current?.duration);
     });
     video.addEventListener('timeupdate', () => {
-      setCurrentTime(videoRef.current.currentTime);
+      setCurrentTime(videoRef.current?.currentTime);
     });
     video.addEventListener('ended', () => {
       setIsPlaying(false);


### PR DESCRIPTION

## Description

Fix TypeErrors: "Cannot read properties of null (reading 'currentTime')/(reading 'duration')"

Fix Errbit errors by adding safe navigation before trying to access properties

Reference: CV2-3028

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

