### PR TITLE
In the newsletter scheduler, just use the local timezone if it's one of the available options

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -13,6 +13,7 @@ import SwitchComponent from '../../cds/inputs/SwitchComponent';
 import styles from './NewsletterComponent.module.css';
 import LanguagePickerSelect from '../../cds/forms/LanguagePickerSelect';
 import SettingsHeader from '../SettingsHeader';
+import { getTimeZoneOptions } from '../../../helpers';
 import { can } from '../../Can';
 import { withSetFlashMessage } from '../../FlashMessage';
 
@@ -72,7 +73,15 @@ const NewsletterComponent = ({
   const [contentType, setContentType] = React.useState(content_type || 'static');
   const [sendEvery, setSendEvery] = React.useState(send_every || ['wednesday']);
   const [sendOn, setSendOn] = React.useState(send_on || null);
-  const [timezone, setTimezone] = React.useState(send_timezone || null);
+
+  // Just use the local timezone if it's one of the options
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  let defaultTimezone = null;
+  if (getTimeZoneOptions().find(item => item.code === localTimezone || item.value === localTimezone)) {
+    defaultTimezone = localTimezone;
+  }
+  const [timezone, setTimezone] = React.useState(send_timezone || defaultTimezone);
+
   const [time, setTime] = React.useState(send_time || '09:00');
   const [scheduled, setScheduled] = React.useState(enabled || false);
   const [datetimeIsPast, setDatetimeIsPast] = React.useState(false);
@@ -537,7 +546,7 @@ const NewsletterComponent = ({
               type={contentType}
               sendEvery={sendEvery}
               sendOn={sendOn}
-              timezone={timezone || Intl.DateTimeFormat().resolvedOptions().timeZone}
+              timezone={timezone}
               time={time}
               parentErrors={errors}
               scheduled={scheduled}

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -6,8 +6,8 @@ import Tooltip from '@material-ui/core/Tooltip';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import PauseIcon from '@material-ui/icons/Pause';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
-import { getTimeZones } from '@vvo/tzdb';
 import { ToggleButton, ToggleButtonGroup } from '../../cds/inputs/ToggleButtonGroup';
+import { getTimeZoneOptions } from '../../../helpers';
 import Alert from '../../cds/alerts-and-prompts/Alert';
 import Select from '../../cds/inputs/Select';
 import DatePicker from '../../cds/inputs/DatePicker';
@@ -15,17 +15,7 @@ import Time from '../../cds/inputs/Time';
 import styles from './NewsletterComponent.module.css';
 import ErrorOutlineIcon from '../../../icons/error_outline.svg';
 
-const timezones = getTimeZones({ includeUtc: true }).map((option) => {
-  const offset = option.currentTimeOffsetInMinutes / 60;
-  const fullOffset = option.currentTimeFormat.split(' ')[0];
-  const sign = offset < 0 ? '' : '+';
-  const newOption = {
-    code: option.name,
-    label: `${option.name} (GMT${sign}${offset})`,
-    value: `${option.name} (GMT${fullOffset})`,
-  };
-  return newOption;
-});
+const timezones = getTimeZoneOptions();
 
 const NewsletterScheduler = ({
   type,

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -3,6 +3,7 @@ import Button from '@material-ui/core/Button';
 import { FormattedMessage } from 'react-intl';
 import LinkifyIt from 'linkify-it';
 import { toArray } from 'react-emoji-render';
+import { getTimeZones } from '@vvo/tzdb';
 import styled from 'styled-components';
 import CheckError from './CheckError';
 import { units } from './styles/js/shared';
@@ -365,6 +366,24 @@ function escapeHtml(url) {
     .replace(/'/g, '&#x27;');
 }
 
+/**
+ * Return a list of timezone objects
+ */
+function getTimeZoneOptions() {
+  const timezones = getTimeZones({ includeUtc: true }).map((option) => {
+    const offset = option.currentTimeOffsetInMinutes / 60;
+    const fullOffset = option.currentTimeFormat.split(' ')[0];
+    const sign = offset < 0 ? '' : '+';
+    const newOption = {
+      code: option.name,
+      label: `${option.name} (GMT${sign}${offset})`,
+      value: `${option.name} (GMT${fullOffset})`,
+    };
+    return newOption;
+  });
+  return timezones;
+}
+
 export { // eslint-disable-line import/no-unused-modules
   bemClass,
   safelyParseJSON,
@@ -388,4 +407,5 @@ export { // eslint-disable-line import/no-unused-modules
   botName,
   getMediaType,
   escapeHtml,
+  getTimeZoneOptions,
 };


### PR DESCRIPTION
## Description

* Extract logic of building timezone options as a helper function, so it can be used by different components
* Use that function in order to map the local timezone to one of the options of the timezone drop-down field

Fixes CV2-3214.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Try to create a newsletter for the first time. If the local timezone is supported, it should be automatically selected in the timezones drop-down and saving should succeed. Otherwise, the timezone drop-down should be blank.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

