### PR TITLE
Error state for newsletter "time" field.

### DIFF
--- a/src/app/components/cds/inputs/Time.js
+++ b/src/app/components/cds/inputs/Time.js
@@ -1,17 +1,27 @@
 import React from 'react';
+import ErrorIcon from '../../../icons/error.svg';
 import inputStyles from '../../../styles/css/inputs.module.css';
 import styles from './Time.module.css';
 
 const Time = ({
   variant,
+  error,
+  helpContent,
   ...inputProps
 }) => (
   <div className={`${inputStyles['input-container']} ${styles['time-container']}`}>
     <input
       type="time"
-      className={`${styles.input} ${variant === 'outlined' && styles.outlined}`}
+      error={error}
+      className={`${styles.input} ${error && styles.error} ${variant === 'outlined' && styles.outlined}`}
       {...inputProps}
     />
+    { helpContent && (
+      <div className={`${inputStyles['help-container']} ${error && inputStyles['error-label']}`}>
+        { error && <ErrorIcon className={inputStyles['error-icon']} />}
+        {helpContent}
+      </div>
+    )}
   </div>
 );
 

--- a/src/app/components/cds/inputs/Time.module.css
+++ b/src/app/components/cds/inputs/Time.module.css
@@ -37,5 +37,17 @@
       background-color: var(--grayDisabledBackground);
       color: var(--textDisabledInput);
     }
+
+    &.error {
+      border-color: var(--errorMain) !important;
+
+      &:hover {
+        border-color: var(--errorSecondary) !important;
+      }
+
+      &:focus {
+        border-color: var(--errorMain) !important;
+      }
+    }
   }
 }

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -144,6 +144,7 @@ const NewsletterComponent = ({
         err[0]?.data.introduction ||
         err[0]?.data.rss_feed_url ||
         err[0]?.data.send_on ||
+        err[0]?.data.time ||
         err[0]?.data.header_type ||
         err[0]?.data.header_file ||
         err[0]?.data.base

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -169,7 +169,14 @@ const NewsletterScheduler = ({
           <span className="typography-caption">
             <FormattedMessage id="newsletterScheduler.at" defaultMessage="at" description="This preposition is in the middle of a sentence like 'send this newsletter *at* 10h00'" />
           </span>
-          <Time value={time} onChange={(e) => { onUpdate('time', e.target.value); }} disabled={scheduled} required />
+          <Time
+            value={time}
+            onChange={(e) => { onUpdate('time', e.target.value); }}
+            disabled={scheduled}
+            error={parentErrors.time}
+            helpContent={parentErrors.time && parentErrors.time}
+            required
+          />
           <Select
             className={styles.select}
             // We check for both code ('Europe/London') and value ('Europe/London (GMT+1:00)') because default values in the browser will only guarantee the first, but if it's saved, the timezone is returned from the API with the offset appended. Doing it this way means we don't have to recalculate the offset in the parent NewsletterComponent)


### PR DESCRIPTION
## Description

If the backend returns an error for the newsletter time field, show the error message next to it and apply the error style (red border).

Fixes CV2-3212.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Go to the newsletter settings page and choose a time that is still in the present. Don't do anything. Come back to that page after that chosen time has passed. Try to save or schedule. The backend should return an error and you should see the time field in error state with an error message.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

