### PR TITLE
Make sure that the default timezone is a valid option.

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -77,8 +77,9 @@ const NewsletterComponent = ({
   // Just use the local timezone if it's one of the options
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   let defaultTimezone = null;
-  if (getTimeZoneOptions().find(item => item.code === localTimezone || item.value === localTimezone)) {
-    defaultTimezone = localTimezone;
+  const timezoneOption = getTimeZoneOptions().find(item => item.code === localTimezone || item.value === localTimezone);
+  if (timezoneOption) {
+    defaultTimezone = timezoneOption.value;
   }
   const [timezone, setTimezone] = React.useState(send_timezone || defaultTimezone);
 


### PR DESCRIPTION
## Description

Make sure that the default timezone is a valid option. It must be one of the options that are used to populate the timezones drop-down.

Fixes CV2-3214.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

* Create a new workspace
* Install the tipline
* Try to create a newsletter but don't change the default selected timezone

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

