### PR TITLE
Display error message below RSS input field when RSS feed URL is invalid

### DIFF
--- a/localization/react-intl/src/app/components/team/Newsletter/NewsletterRssFeed.json
+++ b/localization/react-intl/src/app/components/team/Newsletter/NewsletterRssFeed.json
@@ -5,6 +5,11 @@
     "defaultMessage": "https://example.com/rss.xml"
   },
   {
+    "id": "newsletterRssFeed.error",
+    "description": "Error message displayed under RSS feed URL field",
+    "defaultMessage": "A valid RSS URL is required to load articles."
+  },
+  {
     "id": "newsletterRssFeed.load",
     "description": "Label for a button to load RSS feed entries",
     "defaultMessage": "Load"

--- a/src/app/components/team/Newsletter/NewsletterRssFeed.js
+++ b/src/app/components/team/Newsletter/NewsletterRssFeed.js
@@ -92,7 +92,7 @@ const NewsletterRssFeed = ({
                     value={localRssFeedUrl}
                     iconLeft={<LinkIcon />}
                     error={invalid}
-                    helpContent={helpContent}
+                    helpContent={helpContent || (invalid && <FormattedMessage id="newsletterRssFeed.error" defaultMessage="A valid RSS URL is required to load articles." description="Error message displayed under RSS feed URL field" />)}
                   />
                 )}
               </FormattedMessage>


### PR DESCRIPTION
## Description

We've been already applying the error state to the RSS feed URL input field when the URL is invalid, but it's more clear to also display an error message.

Fixes: CV2-3175.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Go to the newsletter settings page
* Turn on "RSS feed"
* Put an RSS feed URL that is not valid
* You should see an error message below the RSS feed URL input field

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)