### PR TITLE
Clear errors on newsletter header file upload component when file is cleared

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -100,6 +100,9 @@ const NewsletterComponent = ({
     } else if (!fileRequired) {
       setDisableSaveNoFile(false);
     }
+
+    // Reset any errors returned by the backend related to the previously uploaded file
+    setErrors({ ...errors, header_file: null, base: null });
   }, [file, fileName, headerType]);
 
   // This triggers when a file is changed. It rerenders the file name if a new file was attached.


### PR DESCRIPTION
## Description

In newsletter settings, if you choose a header of type Image (or another that does upload) and attach a file with the wrong file type (like PDF), you correctly see a message that says the file couldn’t be uploaded and needs to be of type png, jpg, or jpeg. But if you then attach a new file of type png/jpg/jpeg, the error message remains and says that the new file needs to be of the correct file type.

This fix clears out the error state when an attached file is removed or changed.

Fixes: CV2-3166.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Go to the newsletter settings page
* Choose a header type of Image and upload a PDF file
* Try to save and you'll get an error
* Click on the "X" icon in order to remove the uploaded file
* The error state in the upload component should be cleared

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

