### PR TITLE
[CV2-3243] Proposal to add classnames package to help manage css classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7171,9 +7171,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "cliui": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "babel-plugin-react-intl": "^3.5.1",
     "babel-plugin-relay": "^1.7.0",
     "babel-plugin-styled-components": "^1.10.7",
+    "classnames": "^2.3.2",
     "compression-webpack-plugin": "^0.3.2",
     "coordinate-parser": "^1.0.3",
     "core-js": "^3.6.4",

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -34,8 +34,8 @@ const TextField = ({
     )}
     <div className={cx(
       styles['textfield-container'],
+      inputStyles['input-container'],
       {
-        [inputStyles['input-container']]: textArea,
         [styles['textarea-container']]: textArea,
       })
     }

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';
 import ErrorIcon from '../../../icons/error.svg';
 import inputStyles from '../../../styles/css/inputs.module.css';
@@ -20,12 +21,25 @@ const TextField = ({
 }) => (
   <div className={className}>
     { (label || required) && (
-      <div className={`${inputStyles['label-container']} ${error && inputStyles['error-label']}`} >
+      <div className={cx(
+        [inputStyles['label-container']],
+        {
+          [inputStyles['error-label']]: error,
+        })
+      }
+      >
         { label && <label htmlFor="name">{label}</label> }
         { required && <span className={inputStyles.required}>*<FormattedMessage id="textfield.required" defaultMessage="Required" description="A label to indicate that a form field must be filled out" /></span>}
       </div>
     )}
-    <div className={`${inputStyles['input-container']} ${styles['textfield-container']} ${textArea && styles['textarea-container']}`}>
+    <div className={cx(
+      styles['textfield-container'],
+      {
+        [inputStyles['input-container']]: textArea,
+        [styles['textarea-container']]: textArea,
+      })
+    }
+    >
       { iconLeft && (
         <div className={inputStyles['input-icon-left-icon']}>
           {iconLeft}
@@ -33,7 +47,17 @@ const TextField = ({
       )}
       { textArea ? (
         <textarea
-          className={`typography-body1 ${styles.input} ${disabled && styles.disabled} ${error && styles.error} ${variant === 'outlined' && styles.outlined} ${iconLeft && styles['input-icon-left']} ${iconRight && styles['input-icon-right']}`}
+          className={cx(
+            'typography-body1',
+            [styles.input],
+            {
+              [styles.disabled]: disabled,
+              [styles.error]: error,
+              [styles.outlined]: variant === 'outlined',
+              [styles['input-icon-left']]: iconLeft,
+              [styles['input-icon-right']]: iconRight,
+            })
+          }
           type="text"
           disabled={disabled}
           error={error}
@@ -41,7 +65,17 @@ const TextField = ({
         />
       ) : (
         <input
-          className={`typography-body1 ${styles.input} ${disabled && styles.disabled} ${error && styles.error} ${variant === 'outlined' && styles.outlined} ${iconLeft && styles['input-icon-left']} ${iconRight && styles['input-icon-right']}`}
+          className={cx(
+            'typography-body1',
+            [styles.input],
+            {
+              [styles.disabled]: disabled,
+              [styles.error]: error,
+              [styles.outlined]: variant === 'outlined',
+              [styles['input-icon-left']]: iconLeft,
+              [styles['input-icon-right']]: iconRight,
+            })
+          }
           type="text"
           disabled={disabled}
           error={error}
@@ -55,7 +89,13 @@ const TextField = ({
       )}
     </div>
     { helpContent && (
-      <div className={`${inputStyles['help-container']} ${error && inputStyles['error-label']}`}>
+      <div className={cx(
+        [inputStyles['help-container']],
+        {
+          [inputStyles['error-label']]: error,
+        })
+      }
+      >
         { error && <ErrorIcon className={inputStyles['error-icon']} />}
         {helpContent}
       </div>


### PR DESCRIPTION
## Description

Discussion/Proposal PR to add the npm package [classnames](https://github.com/JedWatson/classnames) which is widely accepted as an easier way to manage multiple and conditional css classnames.
This PR:
- adds the package references
- updates the textfield component as an example on how to handle:
  - applying a global css class
  - handling multiple css module references

References: [CV2-3243](https://meedan.atlassian.net/browse/CV2-3243)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

- Take a look at the associated ticket to see the incorrect out of some class names from the textfield component:  [CV2-3243](https://meedan.atlassian.net/browse/CV2-3243)
- Link to the [classnames repo](https://github.com/JedWatson/classnames)
- Some other [interesting examples of its usage](https://mtm.dev/multiple-classnames-css-modules-react)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-3243]: https://meedan.atlassian.net/browse/CV2-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CV2-3243]: https://meedan.atlassian.net/browse/CV2-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ