### PR TITLE
WIP Feature/2957 turn off language detection

### DIFF
--- a/localization/react-intl/src/app/components/team/Languages/LanguagesComponent.json
+++ b/localization/react-intl/src/app/components/team/Languages/LanguagesComponent.json
@@ -1,10 +1,27 @@
 [
   {
     "id": "languagesComponent.title",
-    "defaultMessage": "Languages"
+    "description": "Title of Language settings page",
+    "defaultMessage": "Language"
   },
   {
-    "id": "languagesComponent.blurb",
-    "defaultMessage": "Add new languages to your workspace in order to create reports, tipline bots and statuses in multiple languages when communicating with users."
+    "id": "languagesComponent.languageDetection",
+    "description": "Title of the Language detection section in language settings page",
+    "defaultMessage": "Language detection"
+  },
+  {
+    "id": "languagesComponent.description",
+    "description": "Instructions for the language detection toggle switch",
+    "defaultMessage": "If language detection is <strong>enabled</strong>, the Check Tipline bot will automatically recognize and respond in the language of your user's request.\n              If <strong>disabled</strong>, the Check Tipline bot will respond in the workspace default language: <strong>{defaultLanguage}</strong>"
+  },
+  {
+    "id": "languagesComponent.languageDetectionSwitch",
+    "description": "Label for a switch where the user toggles auto language detection",
+    "defaultMessage": "Enable language detection"
+  },
+  {
+    "id": "languagesComponent.languages",
+    "description": "Title of the active languages list section in language settings page",
+    "defaultMessage": "Languages"
   }
 ]

--- a/localization/react-intl/src/app/components/team/TeamComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamComponent.json
@@ -1,14 +1,17 @@
 [
   {
     "id": "teamSettings.workspace",
+    "description": "Label for the Workspace settings tab",
     "defaultMessage": "Workspace"
   },
   {
     "id": "teamSettings.members",
+    "description": "Label for the Members settings tab",
     "defaultMessage": "Members"
   },
   {
     "id": "teamSettings.lists",
+    "description": "Label for the Columns settings tab",
     "defaultMessage": "Columns"
   },
   {
@@ -18,6 +21,7 @@
   },
   {
     "id": "teamSettings.tipline",
+    "description": "Label for the Tipline settings tab",
     "defaultMessage": "Tipline"
   },
   {
@@ -27,34 +31,42 @@
   },
   {
     "id": "teamSettings.data",
+    "description": "Label for the Data settings tab",
     "defaultMessage": "Data"
   },
   {
     "id": "teamSettings.rules",
+    "description": "Label for the Rules settings tab",
     "defaultMessage": "Rules"
   },
   {
     "id": "teamSettings.Tags",
+    "description": "Label for the Tags settings tab",
     "defaultMessage": "Tags"
   },
   {
     "id": "teamSettings.similarity",
+    "description": "Label for the Similarity settings tab",
     "defaultMessage": "Similarity"
   },
   {
     "id": "teamSettings.languages",
-    "defaultMessage": "Languages"
+    "description": "Label for the Language settings tab",
+    "defaultMessage": "Language"
   },
   {
     "id": "teamSettings.statuses",
+    "description": "Label for the Statuses settings tab",
     "defaultMessage": "Statuses"
   },
   {
     "id": "teamSettings.report",
+    "description": "Label for the Report settings tab",
     "defaultMessage": "Report"
   },
   {
     "id": "teamSettings.integrations",
+    "description": "Label for the Integrations settings tab",
     "defaultMessage": "Integrations"
   }
 ]

--- a/src/app/components/team/Languages/LanguageListItem.js
+++ b/src/app/components/team/Languages/LanguageListItem.js
@@ -133,7 +133,6 @@ const LanguageListItem = ({ code, team, intl }) => {
     const onFailure = (errors) => {
       setIsSaving(false);
       setDeleteDialogOpen(false);
-      console.error(errors); // eslint-disable-line no-console
       setFlashMessage((
         getErrorMessageForRelayModernProblem(errors)
         || <GenericUnknownErrorMessage />
@@ -164,7 +163,6 @@ const LanguageListItem = ({ code, team, intl }) => {
     const onFailure = (errors) => {
       setIsSaving(false);
       setDefaultDialogOpen(false);
-      console.error(errors); // eslint-disable-line no-console
       setFlashMessage((
         getErrorMessageForRelayModernProblem(errors)
         || <GenericUnknownErrorMessage />

--- a/src/app/components/team/Languages/LanguagesComponent.js
+++ b/src/app/components/team/Languages/LanguagesComponent.js
@@ -1,17 +1,16 @@
-/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import List from '@material-ui/core/List';
 import AddLanguageAction from './AddLanguageAction';
 import LanguageListItem from './LanguageListItem';
 import SettingsHeader from '../SettingsHeader';
+import SwitchComponent from '../../cds/inputs/SwitchComponent';
 import { safelyParseJSON } from '../../../helpers';
 import { compareLanguages } from '../../../LanguageRegistry';
 import { ContentColumn } from '../../../styles/js/shared';
+import styles from './LanguagesComponent.module.css';
 
 const LanguagesComponent = ({ team }) => {
   const defaultCode = team.get_language || 'en';
@@ -26,13 +25,8 @@ const LanguagesComponent = ({ team }) => {
           title={
             <FormattedMessage
               id="languagesComponent.title"
-              defaultMessage="Languages"
-            />
-          }
-          subtitle={
-            <FormattedMessage
-              id="languagesComponent.blurb"
-              defaultMessage="Add new languages to your workspace in order to create reports, tipline bots and statuses in multiple languages when communicating with users."
+              defaultMessage="Language"
+              description="Title of Language settings page"
             />
           }
           helpUrl="https://help.checkmedia.org/en/articles/4498863-languages"
@@ -40,19 +34,57 @@ const LanguagesComponent = ({ team }) => {
             <AddLanguageAction team={team} />
           }
         />
-        <Card>
-          <CardContent>
-            <List>
-              {languages.map(l => (
-                <LanguageListItem
-                  code={l}
-                  key={l}
-                  team={team}
+        <div className={styles['team-languages-section']}>
+          <div className="typography-subtitle2">
+            <FormattedMessage
+              id="languagesComponent.languageDetection"
+              defaultMessage="Language detection"
+              description="Title of the Language detection section in language settings page"
+            />
+          </div>
+          <div className="typography-body2">
+            <FormattedHTMLMessage
+              id="languagesComponent.description"
+              defaultMessage="If language detection is <strong>enabled</strong>, the Check Tipline bot will automatically recognize and respond in the language of your user's request.
+              If <strong>disabled</strong>, the Check Tipline bot will respond in the workspace default language: <strong>{defaultLanguage}</strong>"
+              description="Instructions for the language detection toggle switch"
+              values={{ defaultLanguage: team.get_language }}
+            />
+          </div>
+          <div>
+            <SwitchComponent
+              label={
+                <FormattedMessage
+                  id="languagesComponent.languageDetectionSwitch"
+                  defaultMessage="Enable language detection"
+                  description="Label for a switch where the user toggles auto language detection"
                 />
-              ))}
-            </List>
-          </CardContent>
-        </Card>
+              }
+              checked
+              onChange={() => {
+
+              }}
+            />
+          </div>
+        </div>
+        <div className={styles['team-languages-section']}>
+          <div className="typography-subtitle2">
+            <FormattedMessage
+              id="languagesComponent.languages"
+              defaultMessage="Languages"
+              description="Title of the active languages list section in language settings page"
+            />
+          </div>
+          <List>
+            {languages.map(l => (
+              <LanguageListItem
+                code={l}
+                key={l}
+                team={team}
+              />
+            ))}
+          </List>
+        </div>
       </ContentColumn>
     </React.Fragment>
   );
@@ -60,7 +92,6 @@ const LanguagesComponent = ({ team }) => {
 
 LanguagesComponent.propTypes = {
   team: PropTypes.shape({
-    id: PropTypes.string.isRequired,
     get_language: PropTypes.string.isRequired,
     get_languages: PropTypes.string.isRequired,
   }).isRequired,
@@ -68,9 +99,9 @@ LanguagesComponent.propTypes = {
 
 export default createFragmentContainer(LanguagesComponent, graphql`
   fragment LanguagesComponent_team on Team {
-    id
     get_language
     get_languages
+    get_language_detection
     ...LanguageListItem_team
     ...AddLanguageAction_team
   }

--- a/src/app/components/team/Languages/LanguagesComponent.module.css
+++ b/src/app/components/team/Languages/LanguagesComponent.module.css
@@ -1,0 +1,11 @@
+.team-languages-section {
+  background: var(--otherWhite);
+  border: 2px solid var(--grayBorderMain);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 32px;
+  padding: 16px;
+  width: 100%;
+}

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -1,4 +1,4 @@
-/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
+/* eslint-disable relay/unused-fields */
 import React, { Component } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
@@ -118,6 +118,7 @@ class TeamComponent extends Component {
                 <FormattedMessage
                   id="teamSettings.workspace"
                   defaultMessage="Workspace"
+                  description="Label for the Workspace settings tab"
                 />
               }
               value="workspace"
@@ -128,6 +129,7 @@ class TeamComponent extends Component {
                 <FormattedMessage
                   id="teamSettings.members"
                   defaultMessage="Members"
+                  description="Label for the Members settings tab"
                 />
               }
               value="members"
@@ -139,6 +141,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.lists"
                     defaultMessage="Columns"
+                    description="Label for the Columns settings tab"
                   />
                 }
                 value="columns"
@@ -164,6 +167,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.tipline"
                     defaultMessage="Tipline"
+                    description="Label for the Tipline settings tab"
                   />
                 }
                 value="tipline"
@@ -189,6 +193,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.data"
                     defaultMessage="Data"
+                    description="Label for the Data settings tab"
                   />
                 }
                 value="data"
@@ -201,6 +206,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.rules"
                     defaultMessage="Rules"
+                    description="Label for the Rules settings tab"
                   />
                 }
                 value="rules"
@@ -213,6 +219,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.Tags"
                     defaultMessage="Tags"
+                    description="Label for the Tags settings tab"
                   />
                 }
                 value="tags"
@@ -224,6 +231,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.similarity"
                     defaultMessage="Similarity"
+                    description="Label for the Similarity settings tab"
                   />
                 }
                 value="similarity"
@@ -235,7 +243,8 @@ class TeamComponent extends Component {
                 label={
                   <FormattedMessage
                     id="teamSettings.languages"
-                    defaultMessage="Languages"
+                    defaultMessage="Language"
+                    description="Label for the Language settings tab"
                   />
                 }
                 value="languages"
@@ -248,6 +257,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.statuses"
                     defaultMessage="Statuses"
+                    description="Label for the Statuses settings tab"
                   />
                 }
                 value="statuses"
@@ -260,6 +270,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.report"
                     defaultMessage="Report"
+                    description="Label for the Report settings tab"
                   />
                 }
                 value="report"
@@ -272,6 +283,7 @@ class TeamComponent extends Component {
                   <FormattedMessage
                     id="teamSettings.integrations"
                     defaultMessage="Integrations"
+                    description="Label for the Integrations settings tab"
                   />
                 }
                 value="integrations"


### PR DESCRIPTION
## Description

This PR adds a Language Detection toggle in the Language settings page along with a mutation to persist this setting.
Also the styles were updated in that page to match current designs and a few string descriptions were sneaked in too.

References: CV2-2957

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually that the mutation is sent and the value is persisted and updated on the page.

## Things to pay attention to during code review

Nothing special going on here. Just let's make sure we're following all current coding guidelines.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

