### PR TITLE
A couple of fixes for the newsletter RSS feed URL field.

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterRssFeed.js
+++ b/src/app/components/team/Newsletter/NewsletterRssFeed.js
@@ -56,7 +56,7 @@ const NewsletterRssFeed = ({
       }}
       render={({ error, props }) => {
         const invalid = (!!parentErrors?.rss_feed_url || (!!error && localRssFeedUrl && localRssFeedUrl === rssFeedUrl));
-        const loading = (!props && !invalid);
+        const loading = (!props && !invalid && !error);
         let articles = [];
         if (!loading && !error) {
           const rssFeedContent = props.root.current_team.smooch_bot?.smooch_bot_preview_rss_feed;
@@ -79,7 +79,7 @@ const NewsletterRssFeed = ({
                     className={styles['rss-feed-url-field']}
                     onChange={(e) => {
                       let { value } = e.target;
-                      if (!/^https?:\/\//.test(value)) {
+                      if (value && !/^https?:\/\//.test(value)) {
                         value = `https://${value}`;
                       }
                       setLocalRssFeedUrl(value);


### PR DESCRIPTION
## Description

1) Only prepend https:// when there is some value in the input field
2) Make sure that the "loading" state appears only when it should

Fixes CV2-3260.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

How to test this manually:

- Go to the newsletter settings page and enable RSS feed
- Add some invalid URL, like https://bla
- Save
- Reload the page
- Change the URL to some valid RSS feed URL
- Click "Load"
- It should load the articles successfully
- Save
- Reload the page
- Clear the RSS feed URL field
- Disable RSS feed
- Save
- Reload the page
- Enable RSS feed
- The RSS feed URL field should be empty

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

