### PR TITLE
CV2-2830: Always show shared feeds header in sidebar

### DIFF
--- a/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
@@ -60,6 +60,11 @@
     "defaultMessage": "New shared feed"
   },
   {
+    "id": "projectsComponent.noSharedFeeds",
+    "description": "Displayed under the shared feed header when there are no feeds in it",
+    "defaultMessage": "No shared feeds"
+  },
+  {
     "id": "projectsComponent.folders",
     "description": "Label for a collapsable panel displayed on the left sidebar.",
     "defaultMessage": "Folders"

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -327,22 +327,29 @@ const ProjectsComponent = ({
         </React.Fragment>
 
         {/* Shared feeds */}
-        { feeds.length > 0 &&
-          <React.Fragment>
-            <ListItem onClick={handleToggleFeedsExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>
-              { feedsExpanded ? <ExpandLessIcon className={styles.listChevron} /> : <ExpandMoreIcon className={styles.listChevron} /> }
-              <ListItemText disableTypography className={styles.listHeaderLabel}>
-                <FormattedMessage tagName="span" id="projectsComponent.sharedFeeds" defaultMessage="Shared feeds" description="Feeds of content shared across workspaces" />
-                <Can permissions={team.permissions} permission="create Feed">
-                  <Tooltip title={<FormattedMessage id="projectsComponent.newSharedFeed" defaultMessage="New shared feed" description="Tooltip for the button that navigates to shared feed creation page" />}>
-                    <IconButton onClick={(e) => { handleCreateFeed(); e.stopPropagation(); }} className={[styles.listHeaderLabelButton, 'projects-list__add-feed'].join(' ')}>
-                      <AddCircleIcon />
-                    </IconButton>
-                  </Tooltip>
-                </Can>
+        <ListItem onClick={handleToggleFeedsExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>
+          { feedsExpanded ? <ExpandLessIcon className={styles.listChevron} /> : <ExpandMoreIcon className={styles.listChevron} /> }
+          <ListItemText disableTypography className={styles.listHeaderLabel}>
+            <FormattedMessage tagName="span" id="projectsComponent.sharedFeeds" defaultMessage="Shared feeds" description="Feeds of content shared across workspaces" />
+            <Can permissions={team.permissions} permission="create Feed">
+              <Tooltip title={<FormattedMessage id="projectsComponent.newSharedFeed" defaultMessage="New shared feed" description="Tooltip for the button that navigates to shared feed creation page" />}>
+                <IconButton onClick={(e) => { handleCreateFeed(); e.stopPropagation(); }} className={[styles.listHeaderLabelButton, 'projects-list__add-feed'].join(' ')}>
+                  <AddCircleIcon />
+                </IconButton>
+              </Tooltip>
+            </Can>
+          </ListItemText>
+        </ListItem>
+        <Collapse in={feedsExpanded} className={styles.listCollapseWrapper}>
+          { feeds.length === 0 ?
+            <ListItem className={[styles.listItem, styles.listItem_containsCount, styles.listItem_empty].join(' ')}>
+              <ListItemText disableTypography className={styles.listLabel}>
+                <span>
+                  <FormattedMessage tagName="em" id="projectsComponent.noSharedFeeds" defaultMessage="No shared feeds" description="Displayed under the shared feed header when there are no feeds in it" />
+                </span>
               </ListItemText>
-            </ListItem>
-            <Collapse in={feedsExpanded} className={styles.listCollapseWrapper}>
+            </ListItem> :
+            <>
               {feeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map(feed => (
                 <ProjectsListItem
                   key={feed.id}
@@ -354,9 +361,9 @@ const ProjectsComponent = ({
                   isActive={isActive('feed', feed.dbid)}
                 />
               ))}
-            </Collapse>
-          </React.Fragment>
-        }
+            </>
+          }
+        </Collapse>
 
         {/* Folders: create new folder or collection */}
         <ListItem onClick={handleToggleFoldersExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>


### PR DESCRIPTION
## Description

Just make the Shared Feeds header in sidebar always visible, even when there are no shared feeds, so that the create (+) button is available.

References: CV2-2830

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. Shared feeds header shows in sidebar now.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

