### PR TITLE
add hover color, tooltip, and change icons for new list sorting compo…

### DIFF
--- a/localization/react-intl/src/app/components/cds/inputs/ListSort.json
+++ b/localization/react-intl/src/app/components/cds/inputs/ListSort.json
@@ -13,5 +13,10 @@
     "id": "listSort.status",
     "description": "Label for sort criteria option displayed in a drop-down in the fact-checks page.",
     "defaultMessage": "Rating"
+  },
+  {
+    "id": "listSort.changeDirection",
+    "description": "Tooltip to tell the user they can change the direction of the list sort",
+    "defaultMessage": "Change list sorting direction"
   }
 ]

--- a/src/app/components/cds/inputs/ListSort.js
+++ b/src/app/components/cds/inputs/ListSort.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import ArrowDropUpIcon from '../../../icons/arrow_drop_up.svg';
+import ArrowDropDownIcon from '../../../icons/arrow_drop_down.svg';
+import Tooltip from '../alerts-and-prompts/Tooltip';
 import Select from './Select';
 import styles from './ListSort.module.css';
 
@@ -26,10 +27,15 @@ const ListSort = ({ sort, sortType, onChange }) => {
           { label => (<option value="status_index">{label}</option>) }
         </FormattedMessage>
       </Select>
-      <button onClick={handleChangeSortDirection} className={`${styles.listSortDirectionButton} ${sortType === 'ASC' ? styles.listSortAsc : styles.listSortDesc} ${sortType === 'ASC' ? 'list-sort-asc' : 'list-sort-desc'}`}>
-        <ArrowDropUpIcon />
-        <ArrowDropDownIcon />
-      </button>
+      <Tooltip title={
+        <FormattedMessage id="listSort.changeDirection" defaultMessage="Change list sorting direction" description="Tooltip to tell the user they can change the direction of the list sort" />
+      }
+      >
+        <button onClick={handleChangeSortDirection} className={`${styles.listSortDirectionButton} ${sortType === 'ASC' ? styles.listSortAsc : styles.listSortDesc} ${sortType === 'ASC' ? 'list-sort-asc' : 'list-sort-desc'}`}>
+          <ArrowDropUpIcon />
+          <ArrowDropDownIcon />
+        </button>
+      </Tooltip>
     </div>
   );
 };

--- a/src/app/components/cds/inputs/ListSort.js
+++ b/src/app/components/cds/inputs/ListSort.js
@@ -31,7 +31,7 @@ const ListSort = ({ sort, sortType, onChange }) => {
         <FormattedMessage id="listSort.changeDirection" defaultMessage="Change list sorting direction" description="Tooltip to tell the user they can change the direction of the list sort" />
       }
       >
-        <button onClick={handleChangeSortDirection} className={`${styles.listSortDirectionButton} ${sortType === 'ASC' ? styles.listSortAsc : styles.listSortDesc} ${sortType === 'ASC' ? 'list-sort-asc' : 'list-sort-desc'}`}>
+        <button type="button" onClick={handleChangeSortDirection} className={`${styles.listSortDirectionButton} ${sortType === 'ASC' ? styles.listSortAsc : styles.listSortDesc} ${sortType === 'ASC' ? 'list-sort-asc' : 'list-sort-desc'}`}>
           <ArrowDropUpIcon />
           <ArrowDropDownIcon />
         </button>

--- a/src/app/components/cds/inputs/ListSort.module.css
+++ b/src/app/components/cds/inputs/ListSort.module.css
@@ -14,11 +14,16 @@
   flex-direction: column;
   justify-content: center;
   padding: 3px 8px;
+  transition: color 100ms linear, background-color 100ms linear, border-color 100ms linear;
   width: 32px;
 
   svg {
     color: var(--textPlaceholder);
     font-size: var(--iconSizeSmall);
+  }
+
+  &:hover {
+    background-color: var(--brandHoverAccent);
   }
 }
 

--- a/src/app/icons/arrow_drop_down.svg
+++ b/src/app/icons/arrow_drop_down.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12.4 14.4L7 9H17.8L12.4 14.4Z" /></svg>

--- a/src/app/icons/arrow_drop_up.svg
+++ b/src/app/icons/arrow_drop_up.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M7 14.4L12.4047 9L17.8093 14.4H7Z" /></svg>


### PR DESCRIPTION
## Description

Small tweak to new list sorting component for things found during QA:
- changed icons to custom svg
- added a tooltip
- added a hover transition color

References: CV2-3209

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

