### PR TITLE
Fixing regression on saving list filters.

### DIFF
--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -366,7 +366,7 @@ const SaveList = ({
           body={
             <FormControl fullWidth>
               <RadioGroup value={operation} onChange={(e) => { setOperation(e.target.value); }}>
-                { savedSearch?.is_part_of_feeds ?
+                { savedSearch ?
                   <>
                     <FormControlLabel
                       value="UPDATE"
@@ -387,7 +387,7 @@ const SaveList = ({
                           </ul>
                         }
                       />
-                      : null}
+                      : null }
                   </>
                   :
                   <FormControlLabel


### PR DESCRIPTION
## Description

Fixing error that prevents list filters to be saved unless the list is part of a feed.

Fixes CV2-3331.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Create a list
* Don't add the list to any feed
* Set filters for the list
* Save the list
* Reload the page
* Filters should persist

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

