### PR TITLE
Add a `deprecationNotice` to the tipline integration button component

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
@@ -34,8 +34,9 @@
     "defaultMessage": "Use this code or download the image to display the QR code on online or offline promotion. Scanning the QR code opens WhatsApp and starts a tipline conversation."
   },
   {
-    "id": "smoochBotIntegrations.account",
-    "defaultMessage": "Connected account: {link}"
+    "id": "smoochBotIntegrations.twitterDisabled",
+    "description": "Disclaimer displayed on Twitter tipline settings page.",
+    "defaultMessage": "The integration with Twitter is currently not available, following changes to the Twitter API on April 21, 2023."
   },
   {
     "id": "smoochBotIntegrations.page",

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -88,6 +88,7 @@ const SmoochBotIntegrationButton = ({
   skipUrlConfirmation,
   helpUrl,
   readOnly,
+  deprecationNotice,
   intl,
   setFlashMessage,
 }) => {
@@ -317,39 +318,41 @@ const SmoochBotIntegrationButton = ({
           />
         }
         body={
-          <Box>
-            {params.map(param => (
-              <Box key={param.key}>
-                <TextField
-                  key={param.key}
-                  label={param.label}
-                  id={`smooch-bot-integration-button__${type}-${param.key}`}
-                  onChange={(e) => { handleParam(param.key, e.target.value); }}
-                  variant="outlined"
-                  margin="normal"
-                  fullWidth
-                />
-              </Box>
-            ))}
+          deprecationNotice ?
+            <Box>{deprecationNotice}</Box> :
             <Box>
-              <Typography variant="body1" component="p" paragraph>
-                { url ?
-                  <FormattedMessage
-                    id="smoochBotIntegrationButton.disclaimerForUrl"
-                    defaultMessage="Before proceeding, make sure that you are logged in the {platform} account you wish to connect to the tipline."
-                    values={{ platform: label }}
-                    description="The platform here can be Twitter, Facebook, etc."
-                  /> :
-                  <FormattedMessage
-                    id="smoochBotIntegrationButton.disclaimer"
-                    defaultMessage="We don't store this information. This is just used to configure the integration."
+              {params.map(param => (
+                <Box key={param.key}>
+                  <TextField
+                    key={param.key}
+                    label={param.label}
+                    id={`smooch-bot-integration-button__${type}-${param.key}`}
+                    onChange={(e) => { handleParam(param.key, e.target.value); }}
+                    variant="outlined"
+                    margin="normal"
+                    fullWidth
                   />
-                }
-              </Typography>
+                </Box>
+              ))}
+              <Box>
+                <Typography variant="body1" component="p" paragraph>
+                  { url ?
+                    <FormattedMessage
+                      id="smoochBotIntegrationButton.disclaimerForUrl"
+                      defaultMessage="Before proceeding, make sure that you are logged in the {platform} account you wish to connect to the tipline."
+                      values={{ platform: label }}
+                      description="The platform here can be Twitter, Facebook, etc."
+                    /> :
+                    <FormattedMessage
+                      id="smoochBotIntegrationButton.disclaimer"
+                      defaultMessage="We don't store this information. This is just used to configure the integration."
+                    />
+                  }
+                </Typography>
+              </Box>
             </Box>
-          </Box>
         }
-        proceedDisabled={Object.keys(paramValues).sort().join(',') !== params.map(p => p.key).sort().join(',')}
+        proceedDisabled={deprecationNotice || Object.keys(paramValues).sort().join(',') !== params.map(p => p.key).sort().join(',')}
         proceedLabel={
           url ?
             <FormattedMessage id="smoochBotIntegrationButton.readyToConnect" defaultMessage="I'm ready to connect" /> :
@@ -403,6 +406,7 @@ const SmoochBotIntegrationButton = ({
 };
 
 SmoochBotIntegrationButton.defaultProps = {
+  deprecationNotice: null,
   url: null,
   params: [],
   info: null,
@@ -423,6 +427,7 @@ SmoochBotIntegrationButton.propTypes = {
   })), // if null, "url" must be provided
   online: PropTypes.bool.isRequired,
   info: PropTypes.node, // or null
+  deprecationNotice: PropTypes.node, // or null
   disabled: PropTypes.bool.isRequired,
   icon: PropTypes.node.isRequired,
   color: PropTypes.string.isRequired,

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
@@ -212,29 +212,22 @@ const SmoochBotIntegrations = ({ settings, enabledIntegrations, installationId }
           skipUrlConfirmation
         />
         <SmoochBotIntegrationButton
+          disabled={false}
+          readOnly={false}
+          online={false}
           installationId={installationId}
-          disabled={!isEnabled}
           type="twitter"
           label="Twitter"
-          url={settings.smooch_twitter_authorization_url}
+          url={null}
           helpUrl="http://help.checkmedia.org/en/articles/5189362-connecting-a-new-tipline#h_5cfcbe09c7"
           icon={<TwitterIcon />}
           color="var(--twitterBlue)"
-          online={isOnline('twitter')}
-          readOnly={!isSmoochSet}
-          info={
-            isOnline('twitter') ?
-              <FormattedMessage
-                id="smoochBotIntegrations.account"
-                defaultMessage="Connected account: {link}"
-                values={{
-                  link: (
-                    <a href={`https://twitter.com/messages/compose?recipient_id=${enabledIntegrations.twitter.userId}`} target="_blank" rel="noopener noreferrer">
-                      {enabledIntegrations.twitter.username}
-                    </a>
-                  ),
-                }}
-              /> : null
+          deprecationNotice={
+            <FormattedMessage
+              id="smoochBotIntegrations.twitterDisabled"
+              defaultMessage="The integration with Twitter is currently not available, following changes to the Twitter API on April 21, 2023. "
+              description="Disclaimer displayed on Twitter tipline settings page."
+            />
           }
         />
         <SmoochBotIntegrationButton


### PR DESCRIPTION
## Description

Add a `deprecationNotice` to the tipline integration button component and use it for the Twitter button.

Due to changes in Twitter API, we can't support Twitter DM tiplines at the moment. This commit shows a message about that when the user clicks on the Twitter button under the tipline settings page.

Reference: CV2-3303.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Go the tipline settings page, under the Settings tab, and click on the "Twitter" button. It should show a deprecation message and a disabled proceed button.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

