### PR TITLE
l10n: Fix mid-sentence capitalized word

### DIFF
--- a/localization/react-intl/src/app/components/cds/inputs/Upload.json
+++ b/localization/react-intl/src/app/components/cds/inputs/Upload.json
@@ -22,7 +22,7 @@
   {
     "id": "upload.selectFile",
     "description": "Text for a link that when a user clicks it, it pulls up the file selector dialog for their local device operating system.",
-    "defaultMessage": "Select a local file"
+    "defaultMessage": "select a local file"
   },
   {
     "id": "upload.removeUpload",

--- a/src/app/components/cds/inputs/Upload.js
+++ b/src/app/components/cds/inputs/Upload.js
@@ -96,7 +96,7 @@ function Upload({
         </span>
         &nbsp;
         <a className="typography-button" href="#!" onClick={handleClick}>
-          <FormattedMessage id="upload.selectFile" defaultMessage="Select a local file" description="Text for a link that when a user clicks it, it pulls up the file selector dialog for their local device operating system." />
+          <FormattedMessage id="upload.selectFile" defaultMessage="select a local file" description="Text for a link that when a user clicks it, it pulls up the file selector dialog for their local device operating system." />
         </a>.
       </div>
     );


### PR DESCRIPTION
## Description

Just a simple l10n fix. Undo mid-sentence capitalized word.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

