### PR TITLE
Fix crash when adding new item to blank media (imported report)

### DIFF
--- a/localization/react-intl/src/app/components/media/BlankMediaButton.json
+++ b/localization/react-intl/src/app/components/media/BlankMediaButton.json
@@ -1,18 +1,22 @@
 [
   {
     "id": "blankMediaButton.defaultErrorMessage",
+    "description": "Error message displayed when saving an item fails",
     "defaultMessage": "Could not save item"
   },
   {
     "id": "blankMediaButton.addToImportedReport",
+    "description": "Header to dialog in which the user adds media to already existing (imported) fact-checks",
     "defaultMessage": "Add to imported fact-check"
   },
   {
     "id": "blankMediaButton.addToReport",
+    "description": "Submit button label to dialog in which the user adds media to already existing (imported) fact-check report",
     "defaultMessage": "Add to report"
   },
   {
     "id": "blankMediaButton.addItem",
+    "description": "Button label that opens dialog in which the user can add a media item to an existing fact-check",
     "defaultMessage": "Add item"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaStatusCommon.json
+++ b/localization/react-intl/src/app/components/media/MediaStatusCommon.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "mediaStatus.error",
+    "description": "Error message displayed when a status change fails",
     "defaultMessage": "Sorry, an error occurred while updating the status. Please try again and contact {supportEmail} if the condition persists."
   }
 ]

--- a/src/app/components/media/BlankMediaButton.js
+++ b/src/app/components/media/BlankMediaButton.js
@@ -1,5 +1,5 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
+import { browserHistory } from 'react-router';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { graphql, commitMutation } from 'react-relay/compat';
@@ -20,7 +20,7 @@ const BlankMediaButton = ({
   const [pending, setPending] = React.useState(false);
 
   const handleError = (error) => {
-    let errorMessage = <FormattedMessage id="blankMediaButton.defaultErrorMessage" defaultMessage="Could not save item" />;
+    let errorMessage = <FormattedMessage id="blankMediaButton.defaultErrorMessage" defaultMessage="Could not save item" description="Error message displayed when saving an item fails" />;
     const json = safelyParseJSON(error.source);
     if (json && json.errors && json.errors[0] && json.errors[0].message) {
       errorMessage = json.errors[0].message;
@@ -40,7 +40,7 @@ const BlankMediaButton = ({
   const handleSuccess = (projectMediaDbid) => {
     const teamSlug = window.location.pathname.match(/^\/([^/]+)/)[1];
     const newPath = `/${teamSlug}/media/${projectMediaDbid}`;
-    window.location.href = window.location.href.replace(window.location.pathname, newPath);
+    browserHistory.push(newPath);
   };
 
   const handleSubmitExisting = (projectMedia) => {
@@ -82,6 +82,7 @@ const BlankMediaButton = ({
       new CreateProjectMediaMutation({
         ...value,
         team,
+        skipOptimisticResponse: true,
       }),
       {
         onSuccess: (response) => {
@@ -102,6 +103,7 @@ const BlankMediaButton = ({
             <FormattedMessage
               id="blankMediaButton.addToImportedReport"
               defaultMessage="Add to imported fact-check"
+              description="Header to dialog in which the user adds media to already existing (imported) fact-checks"
             /> : null
         }
         team={team}
@@ -117,6 +119,7 @@ const BlankMediaButton = ({
           <FormattedMessage
             id="blankMediaButton.addToReport"
             defaultMessage="Add to report"
+            description="Submit button label to dialog in which the user adds media to already existing (imported) fact-check report"
           />
         )}
         showFilters
@@ -133,6 +136,7 @@ BlankMediaButton.defaultProps = {
       <FormattedMessage
         id="blankMediaButton.addItem"
         defaultMessage="Add item"
+        description="Button label that opens dialog in which the user can add a media item to an existing fact-check"
       />
     </Button>
   ),

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -114,7 +114,6 @@ class CreateRelatedMediaDialog extends React.Component {
                 isSubmitting={this.props.isSubmitting}
                 onSubmit={this.props.onSubmit}
                 team={this.props.team}
-                noSource
               />
             }
             { mode === 'existing' &&

--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -1,3 +1,10 @@
+/* eslint-disable relay/unused-fields */
+/*
+  FIXME: had to skip this relay/unused-fields rule unfortunately because of the team fragment that is needed
+  for MediaStatusCommon (some 4 levels up the component tree) and is very difficult to
+  make a proper chain of fragmentContainers at this moment because the BlankMediaButton
+  is entangled in a few different places.
+*/
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { graphql, createFragmentContainer, QueryRenderer } from 'react-relay/compat';
@@ -134,6 +141,12 @@ MediaCardLarge.defaultProps = {
 const MediaCardLargeContainer = createFragmentContainer(MediaCardLarge, graphql`
   fragment MediaCardLarge_projectMedia on ProjectMedia {
     id
+    team {
+      id
+      dbid
+      slug
+      verification_statuses
+    }
     media {
       type
       url

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -1,8 +1,6 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { browserHistory } from 'react-router';
 import Button from '@material-ui/core/Button';
 import Popover from '@material-ui/core/Popover';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -56,13 +54,6 @@ class MediaStatusCommon extends Component {
     this.setState({ anchorEl: null });
   };
 
-  handleEdit() {
-    const { media } = this.props;
-    const projectId = media.project_id;
-    const projectPart = projectId ? `/project/${projectId}` : '';
-    browserHistory.push(`/${media.team.slug}${projectPart}/media/${media.dbid}/embed`);
-  }
-
   handleStatusClick = (clickedStatus) => {
     const { media } = this.props;
     const store = new CheckContext(this).getContextStore();
@@ -79,6 +70,7 @@ class MediaStatusCommon extends Component {
       <FormattedMessage
         id="mediaStatus.error"
         defaultMessage="Sorry, an error occurred while updating the status. Please try again and contact {supportEmail} if the condition persists."
+        description="Error message displayed when a status change fails"
         values={{ supportEmail: stringHelper('SUPPORT_EMAIL') }}
       />
     );

--- a/src/app/relay/mutations/CreateProjectMediaMutation.js
+++ b/src/app/relay/mutations/CreateProjectMediaMutation.js
@@ -26,6 +26,8 @@ class CreateProjectMediaMutation extends Relay.Mutation {
   }
 
   getOptimisticResponse() {
+    if (this.props.skipOptimisticResponse) return null;
+
     const optimisticResponse =
       optimisticProjectMedia(
         this.props.title,


### PR DESCRIPTION
## Description

This commit adds a team fragment to MediaCardLarge so MediaStatusCommon doesn't crash when creating a new media for an imported report. It also skips the mutations optimisticResponse when performing this action. The optimisticResponse was another point of crash in this operation but it is only needed when creating new items from the list view, so the fastest fix was to skip it.

This also includes assorted fixes like cleaning up unused stuff and adding description to translatables.

References: CV2-2984

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually.
Testing steps:
1. Go to an imported report (Blank media type)
2. Click "Add item" in the media card
3. Select the "Add new item" tab
4. Create new item sucessfully

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

