### PR TITLE
Display "number of newsletters delivered" in the data dashboard

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
@@ -75,6 +75,11 @@
     "defaultMessage": "Current number of newsletter subscriptions."
   },
   {
+    "id": "teamDataComponent.newslettersDelivered",
+    "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
+    "defaultMessage": "Number of newsletters effectively delivered, accounting for user errors for each platform."
+  },
+  {
     "id": "teamDataComponent.title",
     "description": "Header for the stored data page of the current team",
     "defaultMessage": "Tipline engagement data"

--- a/src/app/components/team/TeamData/TeamDataComponent.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.js
@@ -126,6 +126,11 @@ const messages = defineMessages({
     defaultMessage: 'Current number of newsletter subscriptions.',
     description: messagesDescription,
   },
+  newslettersDelivered: {
+    id: 'teamDataComponent.newslettersDelivered',
+    defaultMessage: 'Number of newsletters effectively delivered, accounting for user errors for each platform.',
+    description: messagesDescription,
+  },
 });
 
 function descendingComparator(a, b, orderBy) {
@@ -214,6 +219,7 @@ const TeamDataComponent = ({
     'New newsletter subscriptions': intl.formatMessage(messages.newNewsletterSubscriptions),
     'Newsletter cancellations': intl.formatMessage(messages.newsletterCancellations),
     'Current subscribers': intl.formatMessage(messages.currentSubscribers),
+    'Newsletters delivered': intl.formatMessage(messages.newslettersDelivered),
   };
 
   const handleRequestSort = (event, property) => {


### PR DESCRIPTION
## Description

Adds a new column "newsletters delivered" to the workspace data dashboard table.

Currently depends on the Check API branch `feature/CV2-3026-CV2-2399-statistics-number-of-newsletters-delivered`. It's required to run `bundle exec rake check:data:statistics` from Check API in order to collect the new data point.

Reference: CV2-3299

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Go to the "Data" tab of a workspace that has an active tipline
* The last column should be "Newsletters delivered"

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

