### PR TITLE
Improve LimitedTextArea and TextField perf

### DIFF
--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -49,8 +49,6 @@ const SandboxComponent = ({ admin }) => {
   const [switchesHelp, setSwitchesHelp] = React.useState(Boolean(false));
   const [switched, setSwitchExample] = React.useState(Boolean(false));
   const [limitedText, setLimitedText] = React.useState('Hello this is the initial limited text state');
-  // eslint-disable-next-line
-  console.log('~~~RENDER');
 
   const [switchLabelPlacement, setSwitchLabelPlacement] = React.useState('top');
   const onChangeSwitchLabelPlacement = (event) => {

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -17,6 +17,7 @@ import AddIcon from '../icons/settings.svg';
 import ListIcon from '../icons/list.svg';
 import FigmaColorLogo from '../icons/figma_color.svg';
 import Card from './cds/media-cards/Card.js';
+import LimitedTextArea from './layout/inputs/LimitedTextArea';
 
 const SandboxComponent = ({ admin }) => {
   const isAdmin = admin?.is_admin;
@@ -47,6 +48,9 @@ const SandboxComponent = ({ admin }) => {
   const [switchesDisabled, setSwitchesDisabled] = React.useState(Boolean(false));
   const [switchesHelp, setSwitchesHelp] = React.useState(Boolean(false));
   const [switched, setSwitchExample] = React.useState(Boolean(false));
+  const [limitedText, setLimitedText] = React.useState('Hello this is the initial limited text state');
+  // eslint-disable-next-line
+  console.log('~~~RENDER');
 
   const [switchLabelPlacement, setSwitchLabelPlacement] = React.useState('top');
   const onChangeSwitchLabelPlacement = (event) => {
@@ -72,6 +76,7 @@ const SandboxComponent = ({ admin }) => {
   const onChangeButtonTheme = (event) => {
     setButtonTheme(event.target.value);
   };
+
   return (
     <div className={styles.sandbox}>
       <h5>
@@ -250,6 +255,26 @@ const SandboxComponent = ({ admin }) => {
             label="I am a textarea title"
             helpContent="I can be of help to textarea"
             required
+          />
+        </div>
+        <div className={styles.componentWrapper}>
+          <div className={cx('typography-subtitle2', [styles.componentName])}>
+            LimitedTextArea
+            <a
+              href="https://www.figma.com/file/bQWUXJItRRX8xO3uQ9FWdg/Multimedia-Newsletter-%2B-Report?type=design&node-id=656-50446&mode=design&t=PjtorENpol0lp5QG-4"
+              rel="noopener noreferrer"
+              target="_blank"
+              title="Figma Designs"
+              className={styles.figmaLink}
+            >
+              <FigmaColorLogo />
+            </a>
+          </div>
+          <LimitedTextArea
+            maxChars={500}
+            label="Limited text area"
+            value={limitedText}
+            setValue={setLimitedText}
           />
         </div>
         <div className={styles.componentWrapper}>

--- a/src/app/components/cds/inputs/SwitchComponent.js
+++ b/src/app/components/cds/inputs/SwitchComponent.js
@@ -69,7 +69,7 @@ SwitchComponent.propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.object,
   labelPlacement: PropTypes.oneOf(['bottom', 'end', 'start', 'top']),
-  helperContent: PropTypes.string,
+  helperContent: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onChange: PropTypes.func,
 };
 

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -2,11 +2,11 @@
 import React from 'react';
 import TextField from './TextField';
 
-const TextArea = ({
+const TextArea = React.forwardRef(({
   ...inputProps
-}) => (
-  <TextField textArea {...inputProps} />
-);
+}, ref) => (
+  <TextField textArea ref={ref} {...inputProps} />
+));
 
 // eslint-disable-next-line import/no-unused-modules
 export default TextArea;

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -21,7 +21,7 @@ function useEffectSkipFirst(fn, inputs) {
   }, inputs);
 }
 
-const TextField = ({
+const TextField = React.forwardRef(({
   className,
   disabled,
   error,
@@ -34,7 +34,7 @@ const TextField = ({
   variant,
   textArea,
   ...inputProps
-}) => {
+}, ref) => {
   const [internalError, setInternalError] = React.useState(suppressInitialError ? false : error);
 
   useEffectSkipFirst(() => {
@@ -81,6 +81,7 @@ const TextField = ({
                 [styles['input-icon-right']]: iconRight,
               })
             }
+            ref={ref}
             type="text"
             disabled={disabled}
             error={internalError}
@@ -99,6 +100,7 @@ const TextField = ({
                 [styles['input-icon-right']]: iconRight,
               })
             }
+            ref={ref}
             type="text"
             disabled={disabled}
             error={internalError}
@@ -125,7 +127,7 @@ const TextField = ({
       )}
     </div>
   );
-};
+});
 
 TextField.defaultProps = {
   className: '',

--- a/src/app/components/layout/inputs/LimitedTextArea.js
+++ b/src/app/components/layout/inputs/LimitedTextArea.js
@@ -1,3 +1,4 @@
+// DESIGNS: https://www.figma.com/file/bQWUXJItRRX8xO3uQ9FWdg/Multimedia-Newsletter-%2B-Report?type=design&node-id=656-50446&mode=design&t=PjtorENpol0lp5QG-4
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/components/layout/inputs/LimitedTextArea.js
+++ b/src/app/components/layout/inputs/LimitedTextArea.js
@@ -8,29 +8,47 @@ const LimitedTextArea = ({
   value,
   setValue,
   onChange,
+  onBlur,
   helpContent,
   onErrorTooLong,
   ...textFieldProps
 }) => {
   const [localError, setLocalError] = React.useState(false);
+  const [localText, setLocalText] = React.useState(value);
+
+  const inputRef = React.useRef();
 
   React.useEffect(() => {
-    if ((value?.length || 0) > maxChars) {
+    if ((localText.length || 0) > maxChars) {
       setLocalError(true);
       onErrorTooLong(true);
-    } else {
+    } else if (localError) { // only trigger this when we *transition* to an error state - this way it only rerenders the parent component when an error triggers, rather than transitioning from error=false to error=false
       setLocalError(false);
       onErrorTooLong(false);
     }
   });
 
   const handleChange = (e) => {
-    setValue(e.target.value);
+    setLocalText(inputRef.current.value);
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  const handleBlur = (e) => {
+    if (setValue) {
+      setValue(inputRef.current?.value);
+    }
+    if (onBlur) {
+      onBlur(e);
+    }
   };
 
   return (
     <TextArea
       required
+      ref={inputRef}
+      value={localText}
       helpContent={(
         <>
           {helpContent && (<>{helpContent}<br /></>)}
@@ -38,12 +56,12 @@ const LimitedTextArea = ({
             id="limitedTextAreaWithCounter.counter"
             defaultMessage="{remaining, plural, one {# character left} other {# characters left}}"
             description="Label that displays how many characters more can be typed"
-            values={{ remaining: maxChars - (value?.length || 0) }}
+            values={{ remaining: maxChars - (localText.length || 0) }}
           />
         </>
       )}
-      onChange={onChange || handleChange}
-      value={value}
+      onChange={handleChange}
+      onBlur={handleBlur}
       {...textFieldProps}
       error={localError || textFieldProps.error}
     />

--- a/src/app/components/team/Newsletter/NewsletterStatic.js
+++ b/src/app/components/team/Newsletter/NewsletterStatic.js
@@ -43,11 +43,14 @@ const NewsletterStatic = ({
           className="newsletter-article"
           defaultMessage="Add text or link"
           description="Placeholder text for a field where the user is supposed to enter text for an article, or a link to an article"
-          key={`${x}fm`}
+          // Initial values here are `undefined` on first render due to the fetch from the API -- since we only mutate this array by appending items and taking items off the end (rather than sorting), using an index for the key is fine here and in the child element
+          // eslint-disable-next-line react/no-array-index-key
+          key={`${i}fm`}
         >
           { placeholder => (
             <LimitedTextArea
-              key={x}
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
               disabled={disabled}
               error={!!articleErrors[i]}
               onErrorTooLong={(error) => {
@@ -57,7 +60,9 @@ const NewsletterStatic = ({
               label="&nbsp;"
               maxChars={getMaxChars()}
               value={articles[i]}
-              onChange={e => handleArticleUpdate(e.target.value, i)}
+              onBlur={(e) => {
+                handleArticleUpdate(e.target.value, i);
+              }}
               placeholder={placeholder}
               rows={4}
             />

--- a/src/app/components/team/Newsletter/NewsletterStatic.test.js
+++ b/src/app/components/team/Newsletter/NewsletterStatic.test.js
@@ -9,6 +9,7 @@ describe('<NewsletterStatic />', () => {
       onUpdateNumberOfArticles={() => {}}
       articles={['first', 'second', 'third']}
       onUpdateArticles={() => {}}
+      setTextfieldOverLength={() => {}}
     />);
     expect(newsletterStatic.find('.newsletter-static')).toHaveLength(1);
     expect(newsletterStatic.find('.newsletter-article')).toHaveLength(1);
@@ -20,6 +21,7 @@ describe('<NewsletterStatic />', () => {
       onUpdateNumberOfArticles={() => {}}
       articles={['first', 'second', 'third']}
       onUpdateArticles={() => {}}
+      setTextfieldOverLength={() => {}}
     />);
     expect(newsletterStatic.find('.newsletter-static')).toHaveLength(1);
     expect(newsletterStatic.find('.newsletter-article')).toHaveLength(3);


### PR DESCRIPTION
`TextField` and `TextArea` (and `LimitedTextArea`, which calls them) were rerendering their parent components on every keystroke. We normally solve this by switching from `onChange` to `onBlur` for setting values, but a problem arises with `LimitedTextArea`, which requires its own state to change on every keystroke (in order to display the number of remaining characters). If we did the normal `onBlur` solution then the character count would only update on blur.

`TextField` and `TextArea` now use the `forwardRef` pattern. This lets us set a `ref` on them just like we might do on an `input` element (by default in React, `ref` only works on basic HTML elements and not components -- using `forwardRef` allows us to use `ref` on components as well). Other than wrapping these in `forwardRef` and adding the forwarded `ref` to the `textarea` and `input` HTML elements, no changes were made to the functionality of these components.

So they behave exactly how they did before, they just also have the ability to take a `ref`. Importantly this means we have at least 3 options when using `TextField` and `TextArea`:

 - use a standard onChange pattern with `useState` where you pass `value={myText}` and `onChange={e => setMyText(e.target.value)}` (rerenders the parent every keystroke)
 - use an onBlur pattern with `useState` where you `value={myText}` and `onBlur={e => setMyText(e.target.value)}` (rerenders the parent on blur)
 - and, new as of this commit, declare `const inputRef = React.useRef()` in the parent component, pass `ref={inputRef}` on `TextField` or `TextArea`, and then refer to `inputRef.current.value` in the parent to get access to the value in the text component (NEVER rerenders the parent and in fact just behaves like an uncontrolled component). If you need a local state tied to the value of the input (like displaying character count) you can avoid a parent rerender by creating a local `useState` copy of the `ref` value and updating it on keystrokes but only ever referring to the state in the scope of the current component (so the current component rerenders but the parent doesn't, much more efficient). You can see how it's done in `LimitedTextArea.js` for an example of implementing this style of input.

Meanwhile, in addition to implementing the third solution above, `LimitedTextArea` gets a change in its `useEffect` for error handling. We do want to check for errors on every rerender of `LimitedTextArea` so the `useEffect` is correct here, but previously we were constantly updating the parent element's `onErrorTooLong` on every keystroke! So even with the `ref` stuff implemented we were *still* rerendering the parent (we had been rerendering its parents *twice* on every keystroke actually, the first case taken care of by using `ref` but the second case remained). This commit makes a change where we only update the error state on the parent when we *transition* from one error state to another. So ultimately, what triggers a rerender of the parent of `LimitedTextArea` is: an onBlur event, or a change in error state.

Other changes:

 - add `LimitedTextArea` to the UI sandbox
 - make `NewsletterStatic` update article values onBlur instead of onChange
 - updated the keys in `NewsletterStatic` to use index numbers and squashed the linter error - normally this is unadvised but in this case it's an array we only append items to or remove items from the end so it's fine, and there was a little hiccup where the keys were all `undefined` until the data loaded from the API so this squashes that warning
 - fix some unit test warnings

References: CV2-3373

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)

## How has this been tested?

Unit tests on the core components continue to pass, and I did extensive manual testing on the Newsletter settings page to make sure everything worked as needed. There's not actually any new or changed functionality on the components so tests continuing to pass for the text components should suffice.

## Things to pay attention to during code review

There's not any particular code I want to call out - my hope is that the description above makes sense and we can use this as a reference for future problems where need to streamline inputs.

The easiest way to see this in action is to go to the Newsletter settings page in production and see how slow it is, then check it on your local machine running this branch and see that it's very fast.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)