### PR TITLE
CV2-2826: remove code related to assign item to project after reject/…

### DIFF
--- a/localization/react-intl/src/app/components/media/Similarity/MediaRelationship.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaRelationship.json
@@ -12,7 +12,7 @@
   {
     "id": "mediaItem.detachedSuccessfully",
     "description": "Banner displayed after items are detached successfully",
-    "defaultMessage": "Item detached to '{toProject}'"
+    "defaultMessage": "Item detached"
   },
   {
     "id": "mediaItem.pinAsMain",

--- a/localization/react-intl/src/app/components/media/Similarity/MediaSuggestionsComponent.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSuggestionsComponent.json
@@ -5,11 +5,6 @@
     "defaultMessage": "{number} media rejected"
   },
   {
-    "id": "mediaSuggestionsComponent.flashBulkReject",
-    "description": "Text that appears in a popup to confirm that a 'bulk reject' action was successful",
-    "defaultMessage": "Added to the list \"{folder}\""
-  },
-  {
     "id": "mediaSuggestionsComponent.flashBulkConfirmTitle",
     "description": "Title that appears in a popup to confirm that a 'bulk accept' action was successful",
     "defaultMessage": "{number} suggested media matched"

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -127,7 +127,7 @@ const RelationshipMenu = ({
     });
   };
 
-  const handleDelete = (project) => {
+  const handleDelete = () => {
     setIsDialogOpen(false);
     const mutation = graphql`
       mutation MediaRelationshipDestroyRelationshipMutation($input: DestroyRelationshipInput!) {
@@ -169,7 +169,6 @@ const RelationshipMenu = ({
       variables: {
         input: {
           id,
-          add_to_project_id: project.dbid,
         },
       },
       configs: [
@@ -200,20 +199,11 @@ const RelationshipMenu = ({
         if (error) {
           handleError(error);
         } else {
-          const { title: projectTitle, dbid: projectId } = project;
           const message = (
             <FormattedMessage
               id="mediaItem.detachedSuccessfully"
-              defaultMessage="Item detached to '{toProject}'"
+              defaultMessage="Item detached"
               description="Banner displayed after items are detached successfully"
-              values={{
-                toProject: (
-                  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid
-                  <a onClick={() => browserHistory.push(`/${teamSlug}/project/${projectId}`)}>
-                    {projectTitle}
-                  </a>
-                ),
-              }}
             />
           );
           setFlashMessage(message, 'success');

--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -301,7 +301,6 @@ const MediaSuggestionsComponent = ({
         rejection: true,
         input: {
           ids: visibleItemIds,
-          add_to_project_id: targetProject.dbid,
           source_id: mainItem.dbid,
         },
       },
@@ -318,17 +317,6 @@ const MediaSuggestionsComponent = ({
                 description="Title that appears in a popup to confirm that a 'bulk reject' action was successful"
                 values={{
                   number: visibleItemIds.length,
-                }}
-              />
-            </Typography>
-            <div className={classes.break} />
-            <Typography variant="body1">
-              <FormattedMessage
-                id="mediaSuggestionsComponent.flashBulkReject"
-                defaultMessage='Added to the list "{folder}"'
-                description="Text that appears in a popup to confirm that a 'bulk reject' action was successful"
-                values={{
-                  folder: targetProject.title,
                 }}
               />
             </Typography>
@@ -510,7 +498,7 @@ const MediaSuggestionsComponent = ({
     });
   };
 
-  const handleReject = (targetProject) => {
+  const handleReject = () => {
     setIsDialogOpen(false);
 
     commitMutation(Store, {
@@ -520,7 +508,6 @@ const MediaSuggestionsComponent = ({
         rejection: true,
         input: {
           id: selectedRelationship.id,
-          add_to_project_id: targetProject.dbid,
         },
       },
       onCompleted: ({ response, error }) => {


### PR DESCRIPTION
## Description

Apply changes to make reject/bulk-reject/detach working after implement back-end related to CV2-2826 https://github.com/meedan/check-api/pull/1594 .

References: CV2-2826

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

