### PR TITLE
Should not be able to delete the default folder.

### DIFF
--- a/src/app/components/drawer/Projects/ProjectActions.js
+++ b/src/app/components/drawer/Projects/ProjectActions.js
@@ -256,8 +256,8 @@ const ProjectActions = ({
     }
   };
 
-  // Should disable delete from objectType = 'Project' if user has no permissions to destroy
-  const disableDeleteProject = objectType === 'Project' && !can(projectPermissions, 'destroy Project');
+  // Should disable delete from objectType = 'Project' if user has no permissions to destroy or if project is default
+  const disableDeleteProject = objectType === 'Project' && (!can(projectPermissions, 'destroy Project') || object.is_default);
 
   return (
     <Can permissions={team.permissions} permission="create Project">


### PR DESCRIPTION
## Description

This is validated on the backend, but it's more clear for the user if the "Delete" option is disabled for the default folder.

Reference: CV2-3554.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

For the default folder, the "Delete" option should be disabled in the folder actions menu.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

