### PR TITLE
"Unmatched media" list should be sorted by "Updated" by default.

### DIFF
--- a/localization/react-intl/src/app/components/source/UserAssignments.json
+++ b/localization/react-intl/src/app/components/source/UserAssignments.json
@@ -5,6 +5,7 @@
   },
   {
     "id": "userAssignments.blank",
+    "description": "Text for empty state when there are no user assignments",
     "defaultMessage": "No activity"
   }
 ]

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -202,7 +202,7 @@ const SaveList = ({
     }
     // If it's the unmatched media page, unmatched media is a default filter
     if (objectType === 'unmatched-media') {
-      queryToBeSaved = { unmatched: [1] };
+      queryToBeSaved = { unmatched: [1], sort: 'recent_activity', sort_type: 'DESC' };
     }
     queryToBeSaved = { ...queryToBeSaved, ...query };
 

--- a/src/app/components/team/UnmatchedMedia.js
+++ b/src/app/components/team/UnmatchedMedia.js
@@ -8,6 +8,8 @@ import UnmatchedIcon from '../../icons/unmatched.svg';
 const UnmatchedMedia = ({ routeParams }) => {
   const query = {
     unmatched: [1],
+    sort: 'recent_activity',
+    sort_type: 'DESC',
     ...safelyParseJSON(routeParams.query, {}),
   };
   return (


### PR DESCRIPTION
## Description

Unlike other lists, the default sorting criteria for the "unmatched media" list should be "Updated", which maps to the key "recent_activity".

Fixes: CV2-3434.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Create items 1A and 1B, and add 1B as similar to 1A
- Create items 2A and 2B, and add 2B as similar to 2B
- Detach item 2B
- Detach item 2A
- Go to the "Unmatched Media" list
- Item 2A should be the first in the list, followed by 2B, since the former was detached last

## Things to pay attention to during code review

Nothing special.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

