### PR TITLE
Revert "Deprecating next/previous media item nav"

### DIFF
--- a/src/app/components/media/MediaPage.js
+++ b/src/app/components/media/MediaPage.js
@@ -10,6 +10,7 @@ export default function MediaPage({ route, routeParams, location }) {
     listUrl,
     listQuery,
     listIndex,
+    buildSiblingUrl,
   } = getListUrlQueryAndIndex(routeParams, location.query);
 
   const teamSlug = routeParams.team;
@@ -31,11 +32,13 @@ export default function MediaPage({ route, routeParams, location }) {
         listUrl={listUrl}
         listQuery={listQuery}
         listIndex={listIndex}
+        buildSiblingUrl={buildSiblingUrl}
         teamSlug={teamSlug}
         projectId={projectId}
         listId={listId}
         projectMediaId={projectMediaId}
         view={currentView}
+        mediaNavList={location?.state?.mediaNavList}
         count={location?.state?.count}
       />
     </ErrorBoundary>

--- a/src/app/components/media/MediaPage.test.js
+++ b/src/app/components/media/MediaPage.test.js
@@ -24,6 +24,8 @@ describe('<MediaPage />', () => {
       expect(childProps.listQuery)
         .toEqual({ key1: 'value1', key2: 'value2' });
       expect(childProps.listIndex).toEqual(3);
+      expect(childProps.buildSiblingUrl(4, 5))
+        .toEqual(`/a-team/media/4?listPath=%2Fa-team%2Ftrash&listQuery=${encodeURIComponent('{"key1":"value1","key2":"value2"}')}&listIndex=5`);
     });
 
     it('should parse { listPath, listQuery, listIndex } from the /project query string', () => {
@@ -44,6 +46,8 @@ describe('<MediaPage />', () => {
       // listQuery has no offset (listIndex is the offset)
       expect(childProps.listQuery).toEqual({ key1: 'value1', key2: 'value2', projects: [1] });
       expect(childProps.listIndex).toEqual(3);
+      expect(childProps.buildSiblingUrl(4, 5))
+        .toEqual(`/a-team/project/1/media/4?listPath=%2Fa-team%2Fproject%2F1&listQuery=${encodeURIComponent('{"key1":"value1","key2":"value2"}')}&listIndex=5`);
     });
 
     it('should infer listUrl, listQuery and nulls when there is no query string or projectId', () => {
@@ -58,6 +62,7 @@ describe('<MediaPage />', () => {
       expect(childProps.listUrl).toEqual('/a-team/all-items');
       expect(childProps.listQuery).toEqual({});
       expect(childProps.listIndex).toBeNull();
+      expect(childProps.buildSiblingUrl).toBeNull();
     });
 
     it('should infer listUrl, listQuery and nulls when there is no query string but there is a projectId', () => {
@@ -72,6 +77,37 @@ describe('<MediaPage />', () => {
       expect(childProps.listUrl).toEqual('/a-team/project/1');
       expect(childProps.listQuery).toEqual({ projects: [1] });
       expect(childProps.listIndex).toBeNull();
+      expect(childProps.buildSiblingUrl).toBeNull();
+    });
+
+    it('should give a buildSiblingUrl() even when inferring listUrl and listQuery if there is no projectId', () => {
+      const childProps = shallow(<MediaPage
+        route={{}}
+        routeParams={{ team: 'a-team', mediaId: '2' }}
+        location={{
+          hash: 'hash',
+          query: { listIndex: '3' },
+        }}
+      />).find(MediaPageLayout).props();
+      expect(childProps.listUrl).toEqual('/a-team/all-items');
+      expect(childProps.listQuery).toEqual({});
+      expect(childProps.listIndex).toEqual(3);
+      expect(childProps.buildSiblingUrl(4, 5)).toEqual('/a-team/media/4?listIndex=5');
+    });
+
+    it('should give a buildSiblingUrl() even when inferring listUrl and listQuery if there is a projectId', () => {
+      const childProps = shallow(<MediaPage
+        route={{}}
+        routeParams={{ team: 'a-team', projectId: '1', mediaId: '2' }}
+        location={{
+          hash: 'hash',
+          query: { listIndex: '3' },
+        }}
+      />).find(MediaPageLayout).props();
+      expect(childProps.listUrl).toEqual('/a-team/project/1');
+      expect(childProps.listQuery).toEqual({ projects: [1] });
+      expect(childProps.listIndex).toEqual(3);
+      expect(childProps.buildSiblingUrl(4, 5)).toEqual('/a-team/project/1/media/4?listIndex=5');
     });
   });
 });

--- a/src/app/components/media/MediaPageLayout.js
+++ b/src/app/components/media/MediaPageLayout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Media from './Media';
 import MediaActionsBar from './MediaActionsBar';
+import NextPreviousLinks from './NextPreviousLinks';
 
 const StyledTopBar = styled.div`
   display: flex;
@@ -20,10 +21,20 @@ const StyledTopBar = styled.div`
 `;
 
 export default function MediaPageLayout({
-  listUrl, listQuery, listIndex, projectId, projectMediaId, view,
+  listUrl, buildSiblingUrl, listQuery, listIndex, projectId, projectMediaId, view, mediaNavList, count,
 }) {
   return (
     <div>
+      {buildSiblingUrl ? (
+        <NextPreviousLinks
+          buildSiblingUrl={buildSiblingUrl}
+          listQuery={listQuery}
+          listIndex={listIndex}
+          objectType="media"
+          mediaNavList={mediaNavList}
+          count={count}
+        />
+      ) : null}
       <StyledTopBar className="media-search__actions-bar">
         <MediaActionsBar
           key={`${listUrl}-${projectMediaId}` /* TODO test MediaActionsBar is sane, then nix key */}
@@ -41,6 +52,7 @@ export default function MediaPageLayout({
 
 MediaPageLayout.defaultProps = {
   listQuery: null,
+  buildSiblingUrl: null,
   listIndex: null,
   projectId: null,
   view: 'default',
@@ -48,6 +60,7 @@ MediaPageLayout.defaultProps = {
 
 MediaPageLayout.propTypes = {
   listUrl: PropTypes.string.isRequired,
+  buildSiblingUrl: PropTypes.func, // null or func(projectMediaId, listIndex) => String|null
   listQuery: PropTypes.object, // or null
   listIndex: PropTypes.number, // or null
   projectId: PropTypes.number, // or null


### PR DESCRIPTION
This reverts commit 281232fa97128b70dbb92b91b3b2ea4614cef73f.

CV-3661

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing unit tests have be re-instated and the feature works in dev just as it used to.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)