### PR TITLE
[WIP] Unmatched/matched media filter

### DIFF
--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -80,6 +80,11 @@
     "defaultMessage": "Number of suggestions"
   },
   {
+    "id": "addFilterMenu.unmatched",
+    "description": "Menu option to enable searching items by whether they have matched or unmatched media",
+    "defaultMessage": "Media matched/unmatched"
+  },
+  {
     "id": "addFilterMenu.tiplineRequests",
     "description": "Menu option to enable searching items by tipline requests",
     "defaultMessage": "Number of requests"

--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -81,8 +81,8 @@
   },
   {
     "id": "addFilterMenu.unmatched",
-    "description": "Menu option to enable searching items by whether they have matched or unmatched media",
-    "defaultMessage": "Media matched/unmatched"
+    "description": "Menu option to enable searching items by whether they have media that has been unmatched at some point",
+    "defaultMessage": "Media unmatched"
   },
   {
     "id": "addFilterMenu.tiplineRequests",

--- a/localization/react-intl/src/app/components/search/SearchFields/index.json
+++ b/localization/react-intl/src/app/components/search/SearchFields/index.json
@@ -65,6 +65,16 @@
     "defaultMessage": "Unread"
   },
   {
+    "id": "search.mediaMatched",
+    "description": "Describes media that is matched as in \"Media is [matched]\"",
+    "defaultMessage": "Matched"
+  },
+  {
+    "id": "search.mediaUnmatched",
+    "description": "Describes media that is unmatched as in \"Media is [unmatched]\"",
+    "defaultMessage": "Unmatched"
+  },
+  {
     "id": "search.empty",
     "description": "Allow filtering by claim with no value set",
     "defaultMessage": "Empty"
@@ -128,6 +138,11 @@
     "id": "search.show",
     "description": "Prefix label for field to filter by media type",
     "defaultMessage": "Type is"
+  },
+  {
+    "id": "search.unmatched",
+    "description": "Prefix label for field to filter by matched/unmatched media",
+    "defaultMessage": "Media is"
   },
   {
     "id": "search.read",

--- a/localization/react-intl/src/app/components/search/SearchFields/index.json
+++ b/localization/react-intl/src/app/components/search/SearchFields/index.json
@@ -141,8 +141,8 @@
   },
   {
     "id": "search.unmatched",
-    "description": "Prefix label for field to filter by matched/unmatched media",
-    "defaultMessage": "Media is"
+    "description": "Label for field to filter by unmatched media",
+    "defaultMessage": "Media is unmatched"
   },
   {
     "id": "search.read",

--- a/localization/react-intl/src/app/components/search/SearchFields/index.json
+++ b/localization/react-intl/src/app/components/search/SearchFields/index.json
@@ -65,11 +65,6 @@
     "defaultMessage": "Unread"
   },
   {
-    "id": "search.mediaMatched",
-    "description": "Describes media that is matched as in \"Media is [matched]\"",
-    "defaultMessage": "Matched"
-  },
-  {
     "id": "search.mediaUnmatched",
     "description": "Describes media that is unmatched as in \"Media is [unmatched]\"",
     "defaultMessage": "Unmatched"

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -239,8 +239,8 @@ const AddFilterMenu = ({
       label: (
         <FormattedMessage
           id="addFilterMenu.unmatched"
-          defaultMessage="Media matched/unmatched"
-          description="Menu option to enable searching items by whether they have matched or unmatched media"
+          defaultMessage="Media unmatched"
+          description="Menu option to enable searching items by whether they have media that has been unmatched at some point"
         />
       ),
     });

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -22,6 +22,7 @@ import NoteAltIcon from '../../icons/note_alt.svg';
 import PersonIcon from '../../icons/person.svg';
 import ReportIcon from '../../icons/playlist_add_check.svg';
 import SettingsInputAntennaIcon from '../../icons/settings_input_antenna.svg';
+import UnmatchedIcon from '../../icons/unmatched.svg';
 
 const AddFilterMenu = ({
   team,
@@ -228,6 +229,18 @@ const AddFilterMenu = ({
           id="addFilterMenu.suggestedMedias"
           defaultMessage="Number of suggestions"
           description="Menu option to enable searching items by suggestions"
+        />
+      ),
+    });
+    options.push({
+      id: 'add-filter-menu__unmatched',
+      key: 'unmatched',
+      icon: <UnmatchedIcon />,
+      label: (
+        <FormattedMessage
+          id="addFilterMenu.unmatched"
+          defaultMessage="Media matched/unmatched"
+          description="Menu option to enable searching items by whether they have matched or unmatched media"
         />
       ),
     });

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -134,6 +134,7 @@ const MultiSelectFilter = ({
   single,
   onType,
   inputPlaceholder,
+  oneOption,
 }) => {
   const [showSelect, setShowSelect] = React.useState(false);
   const [version, setVersion] = React.useState(0);
@@ -156,6 +157,13 @@ const MultiSelectFilter = ({
     onChange(value);
   };
 
+  // On initial render, if we automatically pick one option and don't give the user a choice (for example, they select 'Media is unmatched' so we are only doing a query for that when selected), we assume that the options array as specified is the value we want.
+  React.useEffect(() => {
+    if (oneOption) {
+      handleSelect(options.filter(o => o.value !== '').map(o => o.value));
+    }
+  }, []);
+
   return (
     <div>
       <div className="multi-select-filter">
@@ -163,7 +171,7 @@ const MultiSelectFilter = ({
           <Box px={0.5} height={4.5} display="flex" alignItems="center" whiteSpace="nowrap">
             {label}
           </Box>
-          { selectedArray.map((value, index) => (
+          { !oneOption && selectedArray.map((value, index) => (
             <React.Fragment key={getLabelForValue(value)}>
               { index > 0 ? (
                 <OperatorToggle
@@ -178,13 +186,13 @@ const MultiSelectFilter = ({
               />
             </React.Fragment>
           )) }
-          { selectedArray.length > 0 && showSelect ? (
+          { !oneOption && selectedArray.length > 0 && showSelect ? (
             <OperatorToggle
               onClick={onToggleOperator}
               operator={operator}
             />
           ) : null }
-          { (selectedArray.length === 0 || showSelect) && !readOnly ? (
+          { !oneOption && (selectedArray.length === 0 || showSelect) && !readOnly ? (
             <CustomSelectDropdown
               allowSearch={allowSearch}
               options={options}
@@ -197,7 +205,7 @@ const MultiSelectFilter = ({
             />
           ) : null }
           { extraInputs }
-          { !readOnly && !single ? (
+          { !oneOption && !readOnly && !single ? (
             <PlusButton>
               <AddIcon fontSize="small" onClick={() => setShowSelect(true)} />
             </PlusButton>
@@ -267,6 +275,7 @@ MultiSelectFilter.defaultProps = {
   readOnly: false,
   onType: null,
   inputPlaceholder: null,
+  oneOption: false,
 };
 
 MultiSelectFilter.propTypes = {
@@ -288,6 +297,7 @@ MultiSelectFilter.propTypes = {
   readOnly: PropTypes.bool,
   onType: PropTypes.func,
   inputPlaceholder: PropTypes.string,
+  oneOption: PropTypes.bool,
 };
 
 export default MultiSelectFilter;

--- a/src/app/components/search/MultiSelectFilter.test.js
+++ b/src/app/components/search/MultiSelectFilter.test.js
@@ -10,7 +10,7 @@ describe('<MultiSelectFilter />', () => {
     { value: 'third', label: 'Third' },
   ];
 
-  it('should render a selected option', () => {
+  it('should render a label and selected option', () => {
     const wrapper = mountWithIntl(<MultiSelectFilter
       selected={['second']}
       label="bar"
@@ -20,6 +20,7 @@ describe('<MultiSelectFilter />', () => {
       icon={<CloseIcon />}
     />);
 
+    expect(wrapper.text().includes('bar')).toBe(true);
     expect(wrapper.find('Tag').text()).toBe('Second');
   });
 
@@ -34,6 +35,21 @@ describe('<MultiSelectFilter />', () => {
     />);
 
     expect(wrapper.find('Tag').text()).toBe('Property deleted');
+  });
+
+  it('should render only the label and no tags if oneOption is true', () => {
+    const wrapper = mountWithIntl(<MultiSelectFilter
+      selected={['foo']}
+      label="bar"
+      options={options}
+      onChange={() => {}}
+      onRemove={() => {}}
+      icon={<CloseIcon />}
+      oneOption
+    />);
+
+    expect(wrapper.find('Tag').length).toBe(0);
+    expect(wrapper.text()).toBe('bar');
   });
 });
 

--- a/src/app/components/search/SearchFields/SearchField.module.css
+++ b/src/app/components/search/SearchFields/SearchField.module.css
@@ -1,0 +1,12 @@
+.search-field-label {
+  border-left: 2px solid var(--otherWhite);
+  border-radius: 0;
+  border-right: 2px solid var(--otherWhite);
+  height: 36px;
+  margin: 0;
+  min-width: 0;
+
+  &:hover {
+    background: 'transparent';
+  }
+}

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -33,6 +33,7 @@ import LanguageIcon from '../../../icons/language.svg';
 import PersonIcon from '../../../icons/person.svg';
 import ReportIcon from '../../../icons/playlist_add_check.svg';
 import MarkunreadIcon from '../../../icons/mail.svg';
+import UnmatchedIcon from '../../../icons/unmatched.svg';
 
 const messages = defineMessages({
   claim: {
@@ -99,6 +100,16 @@ const messages = defineMessages({
     id: 'search.itemUnread',
     defaultMessage: 'Unread',
     description: 'Describes media unread',
+  },
+  matched: {
+    id: 'search.mediaMatched',
+    defaultMessage: 'Matched',
+    description: 'Describes media that is matched as in "Media is [matched]"',
+  },
+  unmatched: {
+    id: 'search.mediaUnmatched',
+    defaultMessage: 'Unmatched',
+    description: 'Describes media that is unmatched as in "Media is [unmatched]"',
   },
   empty: {
     id: 'search.empty',
@@ -262,6 +273,11 @@ const SearchFields = ({
     { value: '1', label: intl.formatMessage(messages.read) },
   ];
 
+  const unmatchedValues = [
+    { value: '0', label: intl.formatMessage(messages.matched) },
+    { value: '1', label: intl.formatMessage(messages.unmatched) },
+  ];
+
   const confirmedValues = [
     { value: CheckArchivedFlags.NONE.toString(), label: intl.formatMessage(messages.confirmed) },
     { value: CheckArchivedFlags.UNCONFIRMED.toString(), label: intl.formatMessage(messages.unconfirmed) },
@@ -376,6 +392,22 @@ const SearchFields = ({
             readOnly={readOnlyFields.includes('show')}
             onChange={(newValue) => { handleFilterClick(newValue, 'show'); }}
             onRemove={() => handleRemoveField('show')}
+          />
+        )}
+      </FormattedMessage>
+    ),
+    unmatched: (
+      <FormattedMessage id="search.unmatched" defaultMessage="Media is" description="Prefix label for field to filter by matched/unmatched media">
+        { label => (
+          <MultiSelectFilter
+            allowSearch={false}
+            label={label}
+            icon={<UnmatchedIcon />}
+            selected={query.unmatched}
+            options={unmatchedValues}
+            readOnly={readOnlyFields.includes('unmatched')}
+            onChange={(newValue) => { handleFilterClick(newValue, 'unmatched'); }}
+            onRemove={() => handleRemoveField('unmatched')}
           />
         )}
       </FormattedMessage>

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -274,7 +274,6 @@ const SearchFields = ({
   ];
 
   const unmatchedValues = [
-    { value: '0', label: intl.formatMessage(messages.matched) },
     { value: '1', label: intl.formatMessage(messages.unmatched) },
   ];
 
@@ -397,7 +396,7 @@ const SearchFields = ({
       </FormattedMessage>
     ),
     unmatched: (
-      <FormattedMessage id="search.unmatched" defaultMessage="Media is" description="Prefix label for field to filter by matched/unmatched media">
+      <FormattedMessage id="search.unmatched" defaultMessage="Media is unmatched" description="Label for field to filter by unmatched media">
         { label => (
           <MultiSelectFilter
             allowSearch={false}
@@ -405,6 +404,7 @@ const SearchFields = ({
             icon={<UnmatchedIcon />}
             selected={query.unmatched}
             options={unmatchedValues}
+            oneOption
             readOnly={readOnlyFields.includes('unmatched')}
             onChange={(newValue) => { handleFilterClick(newValue, 'unmatched'); }}
             onRemove={() => handleRemoveField('unmatched')}

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -101,11 +101,6 @@ const messages = defineMessages({
     defaultMessage: 'Unread',
     description: 'Describes media unread',
   },
-  matched: {
-    id: 'search.mediaMatched',
-    defaultMessage: 'Matched',
-    description: 'Describes media that is matched as in "Media is [matched]"',
-  },
   unmatched: {
     id: 'search.mediaUnmatched',
     defaultMessage: 'Unmatched',


### PR DESCRIPTION
I have some design questions about this and have kicked it back to product, but in the meantime the only technical change here is mapping a new filter menu item to a new query parameter, `unmatched`, which takes `[1]` to return items that had previously been suggested as matched media but manually unmatched by a user, and takes `[0]` to return the inverse of that set. (My design questions are around how useful the inverse of that set actually is!)

**Update:** Per comments from product, I have created a `oneOption` prop on `MultiSelectFilter`. This lets us have a filter item that offers no further inputs to the user when clicked -- rather, we pass in a predefined set of selections (aka array of string) and assume that is the only correct state when this filter is selected. You can see the visual of it here (the filter automatically shows up, correctly, when the user is on the "Unmatched media" page since `unmatched` is set to `['1']`).

![image](https://github.com/meedan/check-web/assets/266454/57ad74e9-1fc5-4758-a905-3132a8e2937d)

Reviewers please take note of the changes to `MultiSelectFilter`: https://github.com/meedan/check-web/pull/1561/files#diff-82a17f82f30136d63b96a9b4d62bbe87e3bcabb960a1dfa4ca8ab6ef430cb72dR137-R300

References: CV2-3528

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manual testing and I added a unit test (plus made an existing test a little stricter).

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

