### PR TITLE
Hide unmatched items filter in shared feed

### DIFF
--- a/src/app/components/feed/Feed.js
+++ b/src/app/components/feed/Feed.js
@@ -108,6 +108,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               'read',
               'report_status',
               'show',
+              'unmatched',
             ]}
             {...commonSearchProps}
             title={feed.name}
@@ -157,6 +158,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               'cluster_teams',
               'archived',
               'read',
+              'unmatched',
             ]}
             {...commonSearchProps}
           />


### PR DESCRIPTION
Quick fix for CV2-3528 - hiding the "media unmatched" filter in the shared feeds view.