### PR TITLE
Fix browser support banner positioning CV2-3599

### DIFF
--- a/localization/react-intl/src/app/components/BrowserSupport.json
+++ b/localization/react-intl/src/app/components/BrowserSupport.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "browserSupport.message",
+    "description": "Banner message encouraging users to use the Google Chrome browser, as their current browser is not supported",
     "defaultMessage": "{appName} is optimized for Google Chrome on desktop."
   }
 ]

--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -1,34 +1,8 @@
 /* eslint-disable @calm/react-intl/missing-attribute */
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import styled from 'styled-components';
-import IconButton from '@material-ui/core/IconButton';
-import ClearIcon from '../icons/clear.svg';
 import { mapGlobalMessage } from './MappedMessage';
-
-import {
-  ContentColumn,
-  units,
-} from '../styles/js/shared';
-
-const Message = styled.div`
-  padding: ${units(1)};
-  color: var(--textSecondary);
-  background-color: var(--otherWhite);
-  > div {
-    display: flex;
-    align-items: center;
-  }
-
-  // Not sure why this is necessary for vertical alignment.
-  // Is there a bug in IconButton? I think we are using it correctly.
-  // - CGB 2017-7-12
-  //
-  button > div {
-    display: flex;
-    align-items: center;
-  }
-`;
+import Alert from './cds/alerts-and-prompts/Alert';
 
 class BrowserSupport extends Component {
   static supported() {
@@ -56,16 +30,13 @@ class BrowserSupport extends Component {
   render() {
     if (BrowserSupport.shouldShowMessage()) {
       return (
-        <Message>
-          <ContentColumn>
-            <IconButton style={{ fontSize: '20px', color: 'var(--textSecondary)' }} onClick={this.close.bind(this)}>
-              <ClearIcon />
-            </IconButton>
-            <div>
-              <FormattedMessage id="browserSupport.message" defaultMessage="{appName} is optimized for Google Chrome on desktop." values={{ appName: mapGlobalMessage(this.props.intl, 'appNameHuman') }} />
-            </div>
-          </ContentColumn>
-        </Message>
+        <Alert
+          title={<FormattedMessage id="browserSupport.message" defaultMessage="{appName} is optimized for Google Chrome on desktop." values={{ appName: mapGlobalMessage(this.props.intl, 'appNameHuman') }} />}
+          banner
+          icon
+          variant="warning"
+          onClose={this.close.bind(this)}
+        />
       );
     }
     return null;

--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { mapGlobalMessage } from './MappedMessage';
@@ -31,7 +30,7 @@ class BrowserSupport extends Component {
     if (BrowserSupport.shouldShowMessage()) {
       return (
         <Alert
-          title={<FormattedMessage id="browserSupport.message" defaultMessage="{appName} is optimized for Google Chrome on desktop." values={{ appName: mapGlobalMessage(this.props.intl, 'appNameHuman') }} />}
+          title={<FormattedMessage id="browserSupport.message" description="Banner message encouraging users to use the Google Chrome browser, as their current browser is not supported" defaultMessage="{appName} is optimized for Google Chrome on desktop." values={{ appName: mapGlobalMessage(this.props.intl, 'appNameHuman') }} />}
           banner
           icon
           variant="warning"

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -28,6 +28,7 @@ const Alert = ({
   buttonLabel,
   icon,
   floating,
+  banner,
   onButtonClick,
   onClose,
 }) => (
@@ -40,6 +41,7 @@ const Alert = ({
         [styles.warning]: variant === 'warning',
         [styles.error]: variant === 'error',
         [styles.floating]: floating,
+        [styles.banner]: banner,
       })
     }
   >
@@ -93,6 +95,7 @@ Alert.defaultProps = {
   onButtonClick: null,
   onClose: null,
   floating: false,
+  banner: false,
   icon: true,
 };
 
@@ -100,6 +103,7 @@ Alert.propTypes = {
   title: PropTypes.object,
   content: PropTypes.object,
   floating: PropTypes.bool,
+  banner: PropTypes.bool,
   icon: PropTypes.bool,
   buttonLabel: PropTypes.string,
   onButtonClick: PropTypes.func,

--- a/src/app/components/cds/alerts-and-prompts/Alert.module.css
+++ b/src/app/components/cds/alerts-and-prompts/Alert.module.css
@@ -9,8 +9,12 @@
 
   &.floating {
     border: solid 2px var(--brandSecondary);
-    box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 16px 0 rgba(0 0 0 / .1);
     max-width: 320px;
+  }
+
+  &.banner {
+    border-radius: 0;
   }
 
   &.success {

--- a/src/app/components/drawer/Drawer.module.css
+++ b/src/app/components/drawer/Drawer.module.css
@@ -7,8 +7,8 @@
 
   :global(.MuiDrawer-paperAnchorLeft) {
     border: 0;
-    left: 70px;
     padding: 0;
+    position: relative;
     width: var(--drawerWidth);
   }
 


### PR DESCRIPTION
## Description

- Fixes browser support banner positioning and z-index issue
- Updates browser support to use `<Alert..` component
- Updates `<Alert..` component to include new banner variant to remove border-radius for this application

References: [CV2-3599](https://meedan.atlassian.net/browse/CV2-3599)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

### BEFORE
<img width="1873" alt="Screenshot 2023-08-10 at 4 35 33 PM" src="https://github.com/meedan/check-web/assets/418001/5f9e663f-778a-416d-b393-10e8a021fb51">

### AFTER
<img width="1866" alt="Screenshot 2023-08-10 at 4 58 19 PM" src="https://github.com/meedan/check-web/assets/418001/77c73370-5d19-403b-b298-65ef76ab0123">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-3599]: https://meedan.atlassian.net/browse/CV2-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ