### PR TITLE
CV2-3165: Add Published default list

### DIFF
--- a/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
@@ -40,6 +40,11 @@
     "defaultMessage": "Unmatched media"
   },
   {
+    "id": "projectsComponent.published",
+    "description": "Label for a list displayed on the left sidebar that includes items that have published reports",
+    "defaultMessage": "Published"
+  },
+  {
     "id": "projectsComponent.lists",
     "description": "List of items with some filters applied",
     "defaultMessage": "Custom Lists"

--- a/localization/react-intl/src/app/components/team/Published.json
+++ b/localization/react-intl/src/app/components/team/Published.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "published.title",
+    "description": "Title of the Published list page",
+    "defaultMessage": "Published"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -19837,7 +19837,7 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -19,6 +19,7 @@ import TiplineInbox from './team/TiplineInbox';
 import ImportedReports from './team/ImportedReports';
 import SuggestedMatches from './team/SuggestedMatches';
 import UnmatchedMedia from './team/UnmatchedMedia';
+import Published from './team/Published';
 import Spam from './team/Spam';
 import Trash from './team/Trash';
 import SaveFeed from './feed/SaveFeed';
@@ -107,6 +108,7 @@ class Root extends Component {
                   <Route path=":team/imported-fact-checks(/:query)" component={ImportedReports} />
                   <Route path=":team/suggested-matches(/:query)" component={SuggestedMatches} />
                   <Route path=":team/unmatched-media(/:query)" component={UnmatchedMedia} />
+                  <Route path=":team/published(/:query)" component={Published} />
                   <Route path=":team/feed/:feedId/edit" component={EditFeed} />
                   <Route path=":team/feed/:feedId/:tab(/:query)" component={Feed} />
                   <Route path=":team/feed/create" component={SaveFeed} />

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -24,6 +24,7 @@ import FeedIcon from '../../../icons/dynamic_feed.svg';
 import FileDownloadIcon from '../../../icons/file_download.svg';
 import InboxIcon from '../../../icons/inbox.svg';
 import LightbulbIcon from '../../../icons/lightbulb.svg';
+import PublishedIcon from '../../../icons/playlist_add_check.svg';
 import UnmatchedIcon from '../../../icons/unmatched.svg';
 import Can from '../../Can';
 import { withSetFlashMessage } from '../../FlashMessage';
@@ -293,6 +294,20 @@ const ProjectsComponent = ({
             <UnmatchedIcon className={styles.listIcon} />
             <ListItemText disableTypography className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.unmatchedMedia" defaultMessage="Unmatched media" description="Label for a list displayed on the left sidebar that includes items that were unmatched from other items (detached or rejected)" />
+            </ListItemText>
+            <ListItemSecondaryAction className={styles.listItemCount} />
+          </ListItem>
+        }
+
+        { team.smooch_bot &&
+          <ListItem
+            button
+            onClick={() => { handleSpecialLists('published'); }}
+            className={['projects-list__published', styles.listItem, styles.listItem_containsCount, (activeItem.type === 'published' ? styles.listItem_active : '')].join(' ')}
+          >
+            <PublishedIcon className={styles.listIcon} />
+            <ListItemText disableTypography className={styles.listLabel}>
+              <FormattedMessage tagName="span" id="projectsComponent.published" defaultMessage="Published" description="Label for a list displayed on the left sidebar that includes items that have published reports" />
             </ListItemText>
             <ListItemSecondaryAction className={styles.listItemCount} />
           </ListItem>

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -299,19 +299,17 @@ const ProjectsComponent = ({
           </ListItem>
         }
 
-        { team.smooch_bot &&
-          <ListItem
-            button
-            onClick={() => { handleSpecialLists('published'); }}
-            className={['projects-list__published', styles.listItem, styles.listItem_containsCount, (activeItem.type === 'published' ? styles.listItem_active : '')].join(' ')}
-          >
-            <PublishedIcon className={styles.listIcon} />
-            <ListItemText disableTypography className={styles.listLabel}>
-              <FormattedMessage tagName="span" id="projectsComponent.published" defaultMessage="Published" description="Label for a list displayed on the left sidebar that includes items that have published reports" />
-            </ListItemText>
-            <ListItemSecondaryAction className={styles.listItemCount} />
-          </ListItem>
-        }
+        <ListItem
+          button
+          onClick={() => { handleSpecialLists('published'); }}
+          className={['projects-list__published', styles.listItem, styles.listItem_containsCount, (activeItem.type === 'published' ? styles.listItem_active : '')].join(' ')}
+        >
+          <PublishedIcon className={styles.listIcon} />
+          <ListItemText disableTypography className={styles.listLabel}>
+            <FormattedMessage tagName="span" id="projectsComponent.published" defaultMessage="Published" description="Label for a list displayed on the left sidebar that includes items that have published reports" />
+          </ListItemText>
+          <ListItemSecondaryAction className={styles.listItemCount} />
+        </ListItem>
 
         {/* Lists Header */}
         <ListItem onClick={handleToggleListsExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -82,7 +82,7 @@ const SaveList = ({
   query,
   setFlashMessage,
 }) => {
-  const currentPath = window.location.pathname.match(/^\/[^/]+\/(list|project|all-items|collection|tipline-inbox|suggested-matches|feed|unmatched-media)(\/([0-9]+))?/);
+  const currentPath = window.location.pathname.match(/^\/[^/]+\/(list|project|all-items|collection|tipline-inbox|suggested-matches|feed|unmatched-media|published)(\/([0-9]+))?/);
 
   if (!currentPath) {
     return null;
@@ -99,7 +99,7 @@ const SaveList = ({
   const [showExistingDialog, setShowExistingDialog] = React.useState(false);
 
   // Just show the button on some pages
-  if (['all-items', 'project', 'list', 'collection', 'tipline-inbox', 'suggested-matches', 'feed', 'unmatched-media'].indexOf(objectType) === -1) {
+  if (['all-items', 'project', 'list', 'collection', 'tipline-inbox', 'suggested-matches', 'feed', 'unmatched-media', 'published'].indexOf(objectType) === -1) {
     return null;
   }
 
@@ -285,7 +285,7 @@ const SaveList = ({
 
   const handleClick = () => {
     // From the "All Items" page, collection page, unmatched media and a folder page, we can just create a new list
-    if (objectType === 'all-items' || objectType === 'project' || objectType === 'collection' || objectType === 'unmatched-media') {
+    if (objectType === 'all-items' || objectType === 'project' || objectType === 'collection' || objectType === 'unmatched-media' || objectType === 'published') {
       setShowNewDialog(true);
     // From a list page, we can either create a new one or update the one we're seeing
     } else if (objectType === 'list') {

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -65,7 +65,7 @@ const Toolbar = ({
           <span className="toolbar__title">{title}</span>
           {actions}
         </Row>
-        {['trash', 'collection', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media'].indexOf(page) === -1 && resultType !== 'feed' ? (
+        {['trash', 'collection', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published'].indexOf(page) === -1 && resultType !== 'feed' ? (
           <Can {...perms}>
             <OffsetButton>
               <CreateProjectMedia search={search} project={project} team={team} />
@@ -82,7 +82,7 @@ Toolbar.defaultProps = {
 };
 
 Toolbar.propTypes = {
-  page: PropTypes.oneOf(['trash', 'collection', 'folder', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['trash', 'collection', 'folder', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published']), // FIXME find a cleaner way to render Trash differently
   // FIXME: Define other PropTypes
 };
 

--- a/src/app/components/team/Published.js
+++ b/src/app/components/team/Published.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { safelyParseJSON } from '../../helpers';
+import Search from '../search/Search';
+import PublishedIcon from '../../icons/playlist_add_check.svg';
+
+const Published = ({ routeParams }) => {
+  const query = {
+    report_status: 'published',
+    sort: 'recent_activity',
+    sort_type: 'DESC',
+    ...safelyParseJSON(routeParams.query, {}),
+  };
+  return (
+    <Search
+      searchUrlPrefix={`/${routeParams.team}/published`}
+      mediaUrlPrefix={`/${routeParams.team}/media`}
+      title={<FormattedMessage id="published.title" defaultMessage="Published" description="Title of the Published list page" />}
+      icon={<PublishedIcon />}
+      teamSlug={routeParams.team}
+      query={query}
+      hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+      page="published"
+    />
+  );
+};
+
+Published.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    query: PropTypes.string, // JSON-encoded value; can be empty/null/invalid
+  }).isRequired,
+};
+
+export default Published;


### PR DESCRIPTION
## Description

This PR adds a new default list: Published (as in published reports)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually that there's a new list heading Published on the sidebar and it opens the Published list page, with the "Report is published" filter active.
As far as I understand no new integration tests are needed, there are enough of them testing the search/filters mechanism.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

