### PR TITLE
Always display the "Imported" core list.

### DIFF
--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -256,19 +256,17 @@ const ProjectsComponent = ({
           </ListItem>
         }
 
-        { team.fetch_bot &&
-          <ListItem
-            button
-            onClick={() => { handleSpecialLists('imported-fact-checks'); }}
-            className={['projects-list__imported-fact-checks', styles.listItem, styles.listItem_containsCount, (activeItem.type === 'imported-fact-checks' ? styles.listItem_active : '')].join(' ')}
-          >
-            <FileDownloadIcon className={styles.listIcon} />
-            <ListItemText disableTypography className={styles.listLabel}>
-              <FormattedMessage tagName="span" id="projectsComponent.importedReports" defaultMessage="Imported" description="Label for a list displayed on the left sidebar that includes items from the 'Imported fact-checks' channel" />
-            </ListItemText>
-            <ListItemSecondaryAction className={styles.listItemCount} />
-          </ListItem>
-        }
+        <ListItem
+          button
+          onClick={() => { handleSpecialLists('imported-fact-checks'); }}
+          className={['projects-list__imported-fact-checks', styles.listItem, styles.listItem_containsCount, (activeItem.type === 'imported-fact-checks' ? styles.listItem_active : '')].join(' ')}
+        >
+          <FileDownloadIcon className={styles.listIcon} />
+          <ListItemText disableTypography className={styles.listLabel}>
+            <FormattedMessage tagName="span" id="projectsComponent.importedReports" defaultMessage="Imported" description="Label for a list displayed on the left sidebar that includes items from the 'Imported fact-checks' channel" />
+          </ListItemText>
+          <ListItemSecondaryAction className={styles.listItemCount} />
+        </ListItem>
 
         { team.alegre_bot && team.alegre_bot.alegre_settings.master_similarity_enabled &&
           <ListItem


### PR DESCRIPTION
## Description

The core list "Imported" should be always visible on the left sidebar, even if the Fetch integration is not turned on.

Reference: CV2-3602.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Go to a workspace
- Under the "Integrations" tab, be sure that Fetch is not installed
- Verify that you can see an option "Imported" as a core list on the left sidebar

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

