### PR TITLE
Error message "newsletter should not be in the past" should be below the drop-downs

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -177,13 +177,13 @@ const NewsletterScheduler = ({
             { timezones.map(tz => <option key={tz.code} value={tz.value}>{tz.label}</option>) }
           </Select>
         </div>
-        { parentErrors.datetime_past && (
-          <div className={`typography-caption ${styles['help-container']} ${styles['error-label']}`}>
-            <ErrorOutlineIcon className={styles['error-icon']} />
-            &nbsp;{parentErrors.datetime_past}
-          </div>
-        )}
       </div>
+      { parentErrors.datetime_past && (
+        <div className={`typography-caption ${styles['help-container']} ${styles['error-label']}`}>
+          <ErrorOutlineIcon className={styles['error-icon']} />
+          &nbsp;{parentErrors.datetime_past}
+        </div>
+      )}
 
       <div className={styles['newsletter-schedule-actions']}>
         { scheduled ?


### PR DESCRIPTION
## Description

Error message "newsletter should not be in the past" should be below the drop-downs.

Fixes CV2-3328.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Visually.

Before:

![before](https://github.com/meedan/check-web/assets/117518/91814080-d6f9-4ddb-b6d5-8d0d32d0baea)

Now:

![after](https://github.com/meedan/check-web/assets/117518/20461583-e53a-4936-b5b8-338fc9a44126)

## Things to pay attention to during code review

I'm just wondering if this was really the issue we're trying to fix.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

