### PR TITLE
Make "Month" column sticky on data dashboard.

### DIFF
--- a/src/app/components/team/TeamData/TeamDataComponent.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.js
@@ -47,6 +47,17 @@ const useStyles = makeStyles(theme => ({
   typographyBody1: {
     fontSize: 14,
   },
+  sticky: {
+    position: 'sticky',
+    left: 0,
+    background: 'var(--otherWhite)',
+  },
+  stickyHeader: {
+    position: 'sticky',
+    left: 0,
+    background: 'var(--otherWhite)',
+    zIndex: '9999',
+  },
 }));
 
 const messagesDescription = 'Explanation on table header, when hovering the "help" icon, on data settings page';
@@ -313,7 +324,7 @@ const TeamDataComponent = ({
                 <TableHead>
                   <TableRow>
                     {headers.map(header => (
-                      <TableCell key={header} className={classes.tableCell} sortDirection={orderBy === header ? order : false}>
+                      <TableCell key={header} className={[classes.tableCell, header === 'Month' ? classes.stickyHeader : ''].join(' ')} sortDirection={orderBy === header ? order : false}>
                         <TableSortLabel active={orderBy === header} direction={orderBy === header ? order : 'asc'} onClick={createSortHandler(header)}>
                           <Box display="flex" alignItems="center">
                             <Typography variant="button" className={classes.typographyButton}>
@@ -334,7 +345,7 @@ const TeamDataComponent = ({
                   {rows.map(row => (
                     <TableRow key={row.ID}>
                       {headers.map(header => (
-                        <TableCell key={`${row.ID}-${header}`} className={classes.tableCell}>
+                        <TableCell key={`${row.ID}-${header}`} className={[classes.tableCell, header === 'Month' ? classes.sticky : ''].join(' ')}>
                           <Typography variant="body1" className={classes.typographyBody1}>
                             {formatValue(header, row[header])}
                           </Typography>


### PR DESCRIPTION
## Description

Freezing the month column to make it easier to track dates when scrolling right on the data dashboard.

Reference: CV2-2750.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

* Go to the data dashboard
* Scroll right
* The "Month" column should stay sticky

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

