### PR TITLE
Avoid displaying second-page tag as "property deleted" in filter

### DIFF
--- a/src/app/components/search/SearchFields/SearchFieldTag.js
+++ b/src/app/components/search/SearchFields/SearchFieldTag.js
@@ -69,6 +69,15 @@ const SearchFieldTag = ({
           plainTagsTexts = props.team.tag_texts ? props.team.tag_texts.edges.map(t => t.node.text) : [];
           total = props.team.tag_texts_count;
         }
+
+        // Due to tags pagination, a tag used in a query can be on a not loaded yet page.
+        // Merge `query.tags` with plainTagsText even if they're not loaded from graphql.
+        let queryTags = [];
+        if (query.tags) {
+          queryTags = Array.isArray(query.tags) ? query.tags : [query.tags];
+        }
+        plainTagsTexts = [...new Set(queryTags.concat(plainTagsTexts))];
+
         const hasMore = total > pageSize;
         return (
           <FormattedMessage id="SearchFieldTag.label" defaultMessage="Tag is" description="Prefix label for field to filter by tags">


### PR DESCRIPTION
## Description

Due to tags pagination, a tag used in a query can be on a not loaded yet page.

Merge `query.tags` with plainTagsText even if they're not loaded from graphql.

References CV2-3336

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually that applying a tag filter selecting tags that are loaded after scrolling (on load more). After the filter is applied I verified that the filter is displayed correctly, instead of showing "Property deleted" for the not loaded tags.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

