### PR TITLE
Fixing date parsing in French (and possibly other languages)

### DIFF
--- a/src/app/components/annotations/TiplineRequest.js
+++ b/src/app/components/annotations/TiplineRequest.js
@@ -136,7 +136,7 @@ const TiplineRequest = ({
       >
         {text => (
           <span title={text}>
-            <RequestSubscription lastCalledAt={smoochReportReceivedAt.toLocaleString(locale)} />
+            <RequestSubscription lastCalledAt={smoochReportReceivedAt} />
           </span>
         )}
       </FormattedMessage>
@@ -154,7 +154,7 @@ const TiplineRequest = ({
       >
         {text => (
           <span title={text}>
-            <RequestSubscription lastCalledAt={smoochReportUpdateReceivedAt.toLocaleString(locale)} />
+            <RequestSubscription lastCalledAt={smoochReportUpdateReceivedAt} />
           </span>
         )}
       </FormattedMessage>
@@ -180,7 +180,7 @@ const TiplineRequest = ({
 
 TiplineRequest.propTypes = {
   annotation: PropTypes.shape({
-    value_json: PropTypes.string.isRequired,
+    value_json: PropTypes.object.isRequired,
     created_at: PropTypes.string.isRequired,
     smooch_user_slack_channel_url: PropTypes.string.isRequired,
     smooch_user_external_identifier: PropTypes.string.isRequired,

--- a/src/app/components/annotations/TiplineRequest.test.js
+++ b/src/app/components/annotations/TiplineRequest.test.js
@@ -49,4 +49,15 @@ describe('<TiplineRequest />', () => {
     expect(wrapper.html()).toMatch('22 août 2023');
     expect(wrapper.html()).not.toMatch('Invalid Date');
   });
+
+  it('should localize date in request card 2', () => {
+    const wrapper = mountWithIntlProvider((
+      <TiplineRequest
+        annotation={{ ...annotation, smooch_report_update_received_at: 1691636400 }}
+        annotated={media}
+      />
+    ), { locale: 'fr' });
+    expect(wrapper.html()).toMatch('10 août 2023');
+    expect(wrapper.html()).not.toMatch('08 oct. 2023');
+  });
 });

--- a/src/app/components/annotations/TiplineRequest.test.js
+++ b/src/app/components/annotations/TiplineRequest.test.js
@@ -1,20 +1,33 @@
 import React from 'react';
 import TiplineRequest from './TiplineRequest';
 import Request from '../cds/requests-annotations/Request';
-import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { mountWithIntl, mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
+
+const media = {
+  id: 'TWVkaWEvMQ==\n',
+  picture: 'foo',
+  media: {
+    file_path: '',
+  },
+};
+
+const annotation = {
+  created_at: '1692731080',
+  smooch_report_received_at: 1692731090,
+  smooch_report_update_received_at: 1692731095,
+  smooch_user_slack_channel_url: 'https://test.slack.com/user/123',
+  smooch_user_external_identifier: 'test',
+  associated_graphql_id: 'UHJvamVjdE1lZGlhLzE=\n',
+  value_json: {
+    text: 'Hello Meedan',
+    source: {
+      type: 'whatsapp',
+    },
+  },
+};
 
 describe('<TiplineRequest />', () => {
-  it('should display render Request card with proper data', () => {
-    const media = { picture: 'foo' };
-    const annotation = {
-      smooch_report_received_at: 1666157415,
-      value_json: {
-        text: 'Hello Meedan',
-        source: {
-          type: 'whatsapp',
-        },
-      },
-    };
+  it('should display request card with proper data', () => {
     const wrapper = mountWithIntl((
       <TiplineRequest
         annotation={annotation}
@@ -22,7 +35,18 @@ describe('<TiplineRequest />', () => {
       />
     ));
     expect(wrapper.find(Request).length).toEqual(1);
-    expect(wrapper.html()).toMatch('Report sent on Oct 19, 2022');
+    expect(wrapper.html()).toMatch('Report update sent on Aug 22, 2023');
     expect(wrapper.html()).toMatch('Hello Meedan');
+  });
+
+  it('should localize date in request card', () => {
+    const wrapper = mountWithIntlProvider((
+      <TiplineRequest
+        annotation={annotation}
+        annotated={media}
+      />
+    ), { locale: 'fr' });
+    expect(wrapper.html()).toMatch('22 août 2023');
+    expect(wrapper.html()).not.toMatch('Invalid Date');
   });
 });

--- a/src/app/components/feed/RequestSubscription.js
+++ b/src/app/components/feed/RequestSubscription.js
@@ -52,7 +52,7 @@ const RequestSubscription = ({
 
 RequestSubscription.propTypes = {
   subscribed: PropTypes.bool,
-  lastCalledAt: PropTypes.string,
+  lastCalledAt: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]), // Any value that FormattedMessage understands
 };
 
 RequestSubscription.defaultProps = {


### PR DESCRIPTION
## Description

In the request card, when using the application in French, the date a report was received is not displayed correctly. It either shows "invalid date" or a date where month and day are swapped (for example, "August 10" in English shows as "October 8" in French).

This is because the `<RequestSubscription />` component passes its `lastCalledAt` `prop` as the `value` `prop` of a `<FormattedDate />` component, so it's expected to be a timestamp (string or number) or a date object, not a formatted string.

Possibly happens to other languages too - it doesn't happen with English though.

I implemented unit tests that were able to reproduce the issue. The tests passed after the fix.

I also took the opportunity to fix some `PropTypes` warnings raised by the unit tests.

Fixes: CV2-3594.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

TDD. I added two unit tests that reproduce the issue. The tests failed before the fix:

![Captura de tela de 2023-08-22 16-26-15](https://github.com/meedan/check-web/assets/117518/e4812e52-093f-41b0-a47a-ea36d5887985)

![Captura de tela de 2023-08-22 16-45-06](https://github.com/meedan/check-web/assets/117518/ed32254d-56d7-442b-8699-20b71e45527f)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

