### PR TITLE
Add an error message  if video cannot be played on "item" page

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaPlayerCard.json
+++ b/localization/react-intl/src/app/components/media/MediaPlayerCard.json
@@ -1,6 +1,12 @@
 [
   {
-    "id": "media.normalSpeed",
-    "defaultMessage": "Normal speed"
+    "id": "mediaPlayer.errorTitle",
+    "description": "Text displayed in an error box on media page when the video cannot be played",
+    "defaultMessage": "A Playback Error Occurred."
+  },
+  {
+    "id": "mediaPlayer.errorContent",
+    "description": "Text displayed in an error box on media page when the video cannot be played",
+    "defaultMessage": "The video cannot be played because of an issue with the video file. Download the file to play locally."
   }
 ]

--- a/src/app/components/media/MediaPlayerCard.js
+++ b/src/app/components/media/MediaPlayerCard.js
@@ -1,9 +1,11 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import AspectRatio from '../layout/AspectRatio';
 import MediaControls from '../cds/media-cards/MediaControls.js';
+import Alert from '../cds/alerts-and-prompts/Alert';
 
 const useStyles = makeStyles(() => ({
   video: {
@@ -31,9 +33,46 @@ const MediaPlayerCard = ({
 }) => {
   const classes = useStyles();
   const videoRef = React.useRef();
+  const [errorAlert, setErrorAlert] = React.useState(false);
+
+  const handleVideoError = () => {
+    setErrorAlert(true);
+  };
+
+  const handleDownloadButtonClick = () => {
+    const downloadLink = document.createElement('a');
+    downloadLink.href = filePath;
+    downloadLink.download = filePath;
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+  };
 
   return (
     <article className="video-media-card" style={{ position: 'relative' }}>
+      { errorAlert &&
+      <Alert
+        banner
+        variant="error"
+        buttonLabel="Download video"
+        onButtonClick={handleDownloadButtonClick}
+        title={
+          <FormattedMessage
+            id="mediaPlayer.errorTitle"
+            defaultMessage="A Playback Error Occurred."
+            description="Text displayed in an error box on media page when the video cannot be played"
+          />
+        }
+        content={
+          <FormattedMessage
+            id="mediaPlayer.errorContent"
+            defaultMessage="The video cannot be played because of an issue with the video file. Download the file to play locally."
+            description="Text displayed in an error box on media page when the video cannot be played"
+          />
+        }
+        onClose={() => setErrorAlert(false)}
+      />
+      }
       <AspectRatio
         key={contentWarning}
         contentWarning={contentWarning}
@@ -71,6 +110,7 @@ const MediaPlayerCard = ({
                 src={filePath}
                 className={classes.video}
                 poster={isAudio ? poster : ''}
+                onError={handleVideoError}
               />
               <MediaControls videoRef={videoRef} />
             </>


### PR DESCRIPTION
## Description

Add Alert with an error message and button to download the video if the video cannot be played on "item" page

Reference: CV2-3486

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
- add a video that cannot be played on the browser
- go to the "item" page
- check that the Alert with the button to download the video is displyaed


## Checklist

- [ ] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

