### PR TITLE
Accessible status CV20-3596

### DIFF
--- a/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
@@ -1,14 +1,17 @@
 [
   {
     "id": "statusListItem.noDescription",
+    "description": "Empty state message if a status has no additional description",
     "defaultMessage": "No description"
   },
   {
     "id": "statusListItem.default",
+    "description": "The label of the user created status, with an additional note in parenthesis if the label is the default",
     "defaultMessage": "{statusLabel} (default)"
   },
   {
     "id": "statusListItem.makeDefault",
+    "description": "Menu item choice for making the label the default choice",
     "defaultMessage": "Make default"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
@@ -7,7 +7,7 @@
   {
     "id": "statusListItem.default",
     "description": "The label of the user created status, with an additional note in parenthesis if the label is the default",
-    "defaultMessage": "{statusLabel} (default)"
+    "defaultMessage": "{statusLabel}"
   },
   {
     "id": "statusListItem.makeDefault",

--- a/localization/react-intl/src/app/components/team/Statuses/StatusMessage.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusMessage.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "statusListItem.messageTooltip",
+    "description": "Tooltip to tell the user when this message will be sent out",
+    "defaultMessage": "This message will be sent to the user who requested the item when you change an item to this status"
+  }
+]

--- a/localization/react-intl/src/app/components/team/Statuses/StatusMessage.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusMessage.json
@@ -2,6 +2,6 @@
   {
     "id": "statusListItem.messageTooltip",
     "description": "Tooltip to tell the user when this message will be sent out",
-    "defaultMessage": "This message will be sent to the user who requested the item when you change an item to this status"
+    "defaultMessage": "When you change and item to this status, the user who requested will receive the following message:"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Statuses/TranslateStatuses.json
+++ b/localization/react-intl/src/app/components/team/Statuses/TranslateStatuses.json
@@ -1,26 +1,32 @@
 [
   {
     "id": "translateStatuses.status",
+    "description": "Label for TextField for the status translation",
     "defaultMessage": "Status"
   },
   {
     "id": "translateStatuses.message",
+    "description": "Label for the textarea where user can provide a translation for the automated message",
     "defaultMessage": "Message"
   },
   {
     "id": "translateStatuses.missingTranslations",
+    "description": "Modal Title informing the user that there are missing translations",
     "defaultMessage": "Missing translations"
   },
   {
     "id": "translateStatuses.missingTranslationsBody",
+    "description": "Modal paragraph description informing the user that there are missing translations",
     "defaultMessage": "Some statuses are missing translations. Users may not be able to read untranslated statuses."
   },
   {
     "id": "translateStatuses.missingTranslationsBody2",
+    "description": "Description paragraph telling the user what will happen is a translation is missing",
     "defaultMessage": "If the message for a status is not translated in a language, any requester using that language will not receive the message."
   },
   {
     "id": "translateStatuses.continueAndSave",
+    "description": "Label for confirmation to save the updated status translations",
     "defaultMessage": "Continue and save"
   }
 ]

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -22,6 +22,7 @@ const buttonThemes = {
 const buttonTheme = alertVariant => buttonThemes[alertVariant] || 'brand';
 
 const Alert = ({
+  className,
   title,
   content,
   variant,
@@ -36,6 +37,7 @@ const Alert = ({
     className={cx(
       styles['alert-wrapper'],
       {
+        [className]: true,
         [styles.info]: variant === 'info',
         [styles.success]: variant === 'success',
         [styles.warning]: variant === 'warning',
@@ -80,7 +82,9 @@ const Alert = ({
           />
         }
         >
-          <ButtonMain variant="text" size="small" theme={buttonTheme(variant)} iconCenter={<IconClose />} onClick={onClose} />
+          <span>
+            <ButtonMain variant="text" size="small" theme={buttonTheme(variant)} iconCenter={<IconClose />} onClick={onClose} />
+          </span>
         </Tooltip>
       </div>
     }
@@ -88,6 +92,7 @@ const Alert = ({
 );
 
 Alert.defaultProps = {
+  className: null,
   variant: 'info',
   content: '',
   title: '',
@@ -100,6 +105,7 @@ Alert.defaultProps = {
 };
 
 Alert.propTypes = {
+  className: PropTypes.string,
   title: PropTypes.object,
   content: PropTypes.object,
   floating: PropTypes.bool,

--- a/src/app/components/cds/alerts-and-prompts/Alert.module.css
+++ b/src/app/components/cds/alerts-and-prompts/Alert.module.css
@@ -48,7 +48,7 @@
 
   .contentWrapper {
     flex: 1 1 auto;
-    padding: 4px 0 0;
+    padding: 2px 0 0;
 
     .title + .content {
       margin: 6px 0 0;

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -17,10 +17,10 @@ import LockIcon from '../../icons/lock.svg';
 import styles from './media.module.css';
 
 const StatusLabel = props => (
-  <>
+  <span className={styles['status-label']}>
     <EllipseIcon style={{ color: props.color }} />
     {props.children}
-  </>
+  </span>
 );
 
 class MediaStatusCommon extends Component {
@@ -105,8 +105,8 @@ class MediaStatusCommon extends Component {
               onClick={() => this.handleStatusClick(status.id)}
             >
               <StatusLabel color={status.style.color}>
-                {status.label}
                 {status.should_send_message ? <ChatBubbleIcon /> : null}
+                {status.label}
               </StatusLabel>
             </MenuItem>
           ))}

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Button from '@material-ui/core/Button';
 import Popover from '@material-ui/core/Popover';
 import MenuItem from '@material-ui/core/MenuItem';
-import { makeStyles } from '@material-ui/core/styles';
-import styled from 'styled-components';
+import cx from 'classnames/bind';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import { can } from '../Can';
 import CheckContext from '../../CheckContext';
 import { getStatus, getErrorMessage, bemClass } from '../../helpers';
@@ -13,29 +12,16 @@ import { stringHelper } from '../../customHelpers';
 import { withSetFlashMessage } from '../FlashMessage';
 import ChatBubbleIcon from '../../icons/chat_bubble.svg';
 import ChevronDownIcon from '../../icons/chevron_down.svg';
+import EllipseIcon from '../../icons/ellipse.svg';
 import LockIcon from '../../icons/lock.svg';
+import styles from './media.module.css';
 
-const StyledMediaStatus = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-`;
-
-const useStyles = makeStyles({
-  statusLabel: props => ({
-    color: props.color,
-  }),
-});
-
-const StatusLabel = (props) => {
-  const classes = useStyles(props);
-
-  return (
-    <span className={classes.statusLabel}>
-      {props.children}
-    </span>
-  );
-};
+const StatusLabel = props => (
+  <>
+    <EllipseIcon style={{ color: props.color }} />
+    {props.children}
+  </>
+);
 
 class MediaStatusCommon extends Component {
   static currentStatusToClass(status) {
@@ -89,19 +75,19 @@ class MediaStatusCommon extends Component {
     const currentStatus = getStatus(media.team.verification_statuses, media.last_status || this.props.currentStatus);
 
     return (
-      <StyledMediaStatus className="media-status">
-        <Button
+      <div className={cx('media-status', styles['media-status-wrapper'])}>
+        <ButtonMain
           className={`media-status__label media-status__current ${MediaStatusCommon.currentStatusToClass(media.last_status || this.props.currentStatus)}`}
-          style={{ backgroundColor: currentStatus.style.color, color: 'var(--otherWhite)', minHeight: 41 }}
-          variant="contained"
-          disableElevation
+          customStyle={{ borderColor: currentStatus.style.color }}
+          variant="outlined"
+          theme="text"
+          size="default"
           onClick={e => this.setState({ anchorEl: e.currentTarget })}
           disabled={!this.canUpdate()}
-          startIcon={currentStatus.should_send_message ? <ChatBubbleIcon /> : null}
-          endIcon={this.canUpdate() ? <ChevronDownIcon /> : <LockIcon />}
-        >
-          {currentStatus.label}
-        </Button>
+          iconLeft={currentStatus.should_send_message ? <><ChatBubbleIcon style={{ color: currentStatus.style.color }} /><EllipseIcon style={{ color: currentStatus.style.color }} /></> : <EllipseIcon style={{ color: currentStatus.style.color }} />}
+          iconRight={this.canUpdate() ? <ChevronDownIcon /> : <LockIcon />}
+          label={currentStatus.label}
+        />
         <Popover
           anchorEl={this.state.anchorEl}
           open={Boolean(this.state.anchorEl)}
@@ -119,15 +105,13 @@ class MediaStatusCommon extends Component {
               onClick={() => this.handleStatusClick(status.id)}
             >
               <StatusLabel color={status.style.color}>
-                <StyledMediaStatus>
-                  {status.label}
-                  {status.should_send_message ? <ChatBubbleIcon /> : null}
-                </StyledMediaStatus>
+                {status.label}
+                {status.should_send_message ? <ChatBubbleIcon /> : null}
               </StatusLabel>
             </MenuItem>
           ))}
         </Popover>
-      </StyledMediaStatus>
+      </div>
     );
   }
 }

--- a/src/app/components/media/media.module.css
+++ b/src/app/components/media/media.module.css
@@ -11,3 +11,9 @@
   width: fit-content;
   z-index: 2;
 }
+
+.media-status-wrapper {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+}

--- a/src/app/components/media/media.module.css
+++ b/src/app/components/media/media.module.css
@@ -17,3 +17,9 @@
   display: flex;
   gap: 4px;
 }
+
+.status-label {
+  align-items: center;
+  display: flex;
+  gap: 2px;
+}

--- a/src/app/components/search/SearchResults.module.css
+++ b/src/app/components/search/SearchResults.module.css
@@ -1,3 +1,14 @@
+.search-results-status-cell {
+  max-width: 224px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  :global(.check-icon) {
+    vertical-align: text-top;
+  }
+}
+
 .searchResultsTitleWrapper {
   align-items: flex-start;
   color: var(--textSecondary);

--- a/src/app/components/search/SearchResultsTable/StatusCell.js
+++ b/src/app/components/search/SearchResultsTable/StatusCell.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TableCell from '@material-ui/core/TableCell';
-import { makeStyles } from '@material-ui/core/styles';
+import IconEllipse from '../../../icons/ellipse.svg';
+import styles from '../SearchResults.module.css';
 
 function findStatusObjectOrNull(statuses, statusId) {
   if (!statuses) {
@@ -14,27 +15,18 @@ function findStatusObjectOrNull(statuses, statusId) {
   return statuses[index];
 }
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    whiteSpace: 'nowrap',
-    maxWidth: theme.spacing(28),
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-}));
-
 export default function StatusCell({ projectMedia }) {
-  const classes = useStyles();
   const statusObject = findStatusObjectOrNull(
     projectMedia.team.verification_statuses.statuses,
     projectMedia.list_columns_values.status,
   );
   return (
-    <TableCell classes={classes}>
-      {statusObject ? statusObject.label : null}
+    <TableCell className={styles['search-results-status-cell']}>
+      {statusObject ? <><IconEllipse style={{ color: statusObject.style.color }} />{statusObject.label}</> : null}
     </TableCell>
   );
 }
+
 StatusCell.propTypes = {
   projectMedia: PropTypes.shape({
     team: PropTypes.shape({

--- a/src/app/components/team/Statuses/StatusLabel.js
+++ b/src/app/components/team/Statuses/StatusLabel.js
@@ -1,23 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
+import IconEllipse from '../../../icons/ellipse.svg';
 
-const useStyles = makeStyles({
-  statusLabel: props => ({
-    color: props.color,
-  }),
-});
-
-const StatusLabel = (props) => {
-  const classes = useStyles(props);
-
-  return (
-    <Typography className={classes.statusLabel} variant="h6" component="span">
-      {props.children}
-    </Typography>
-  );
-};
+const StatusLabel = props => (
+  <h6>
+    <IconEllipse style={{ color: props.color }} />
+    {props.children}
+  </h6>
+);
 
 StatusLabel.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/app/components/team/Statuses/StatusLabel.js
+++ b/src/app/components/team/Statuses/StatusLabel.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconEllipse from '../../../icons/ellipse.svg';
+import styles from './Statuses.module.css';
 
 const StatusLabel = props => (
-  <h6>
+  <h6 className={styles['status-label']}>
     <IconEllipse style={{ color: props.color }} />
     {props.children}
   </h6>

--- a/src/app/components/team/Statuses/StatusListItem.js
+++ b/src/app/components/team/Statuses/StatusListItem.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import ListItemText from '@material-ui/core/ListItemText';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import StatusLabel from './StatusLabel';
@@ -11,6 +8,7 @@ import StatusMessage from './StatusMessage';
 import { FormattedGlobalMessage } from '../../MappedMessage';
 import IconMoreVert from '../../../icons/more_vert.svg';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
+import styles from './Statuses.module.css';
 
 const StatusListItem = ({
   defaultLanguage,
@@ -56,37 +54,34 @@ const StatusListItem = ({
       localeStatus.message : null;
 
   return (
-    <ListItem className="status-list-item">
-      <ListItemText
-        disableTypography
-        primary={
-          isDefault ? (
-            <FormattedMessage
-              id="statusListItem.default"
-              defaultMessage="{statusLabel} (default)"
-              description="The label of the user created status, with an additional note in parenthesis if the label is the default"
-              values={{
-                statusLabel: (
-                  <StatusLabel color={status.style.color}>
-                    {statusLabel}
-                  </StatusLabel>
-                ),
-              }}
-            />
-          ) : (
-            <StatusLabel color={status.style.color}>
-              {statusLabel}
-            </StatusLabel>
-          )
+    <li className={styles['settings-status-listitem']}>
+      <div>
+        {isDefault ? (
+          <FormattedMessage
+            id="statusListItem.default"
+            defaultMessage="{statusLabel}"
+            description="The label of the user created status, with an additional note in parenthesis if the label is the default"
+            values={{
+              statusLabel: (
+                <StatusLabel color={status.style.color}>
+                  {statusLabel}
+                  <small>
+                    (default)
+                  </small>
+                </StatusLabel>
+              ),
+            }}
+          />
+        ) : (
+          <StatusLabel color={status.style.color}>
+            {statusLabel}
+          </StatusLabel>
+        )
         }
-        secondary={
-          <React.Fragment>
-            <p>{statusDescription}</p>
-            <StatusMessage message={statusMessage} />
-          </React.Fragment>
-        }
-      />
-      <ListItemSecondaryAction>
+        <p>{statusDescription}</p>
+        <StatusMessage message={statusMessage} />
+      </div>
+      <div className={styles['settings-status-menu']}>
         <ButtonMain className="status-actions__menu" iconCenter={<IconMoreVert />} variant="outlined" size="default" theme="text" onClick={e => setAnchorEl(e.target)} />
         <Menu
           anchorEl={anchorEl}
@@ -103,8 +98,8 @@ const StatusListItem = ({
             <FormattedGlobalMessage messageKey="delete" />
           </MenuItem>
         </Menu>
-      </ListItemSecondaryAction>
-    </ListItem>
+      </div>
+    </li>
   );
 };
 

--- a/src/app/components/team/Statuses/StatusListItem.js
+++ b/src/app/components/team/Statuses/StatusListItem.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -48,6 +47,7 @@ const StatusListItem = ({
       <FormattedMessage
         id="statusListItem.noDescription"
         defaultMessage="No description"
+        description="Empty state message if a status has no additional description"
       />
     );
 
@@ -58,11 +58,13 @@ const StatusListItem = ({
   return (
     <ListItem className="status-list-item">
       <ListItemText
+        disableTypography
         primary={
           isDefault ? (
             <FormattedMessage
               id="statusListItem.default"
               defaultMessage="{statusLabel} (default)"
+              description="The label of the user created status, with an additional note in parenthesis if the label is the default"
               values={{
                 statusLabel: (
                   <StatusLabel color={status.style.color}>
@@ -79,7 +81,7 @@ const StatusListItem = ({
         }
         secondary={
           <React.Fragment>
-            <span>{statusDescription}</span><br />
+            <p>{statusDescription}</p>
             <StatusMessage message={statusMessage} />
           </React.Fragment>
         }
@@ -92,7 +94,7 @@ const StatusListItem = ({
           onClose={handleClose}
         >
           <MenuItem className="status-actions__make-default" onClick={handleMakeDefault} disabled={isDefault}>
-            <FormattedMessage id="statusListItem.makeDefault" defaultMessage="Make default" />
+            <FormattedMessage id="statusListItem.makeDefault" defaultMessage="Make default" description="Menu item choice for making the label the default choice" />
           </MenuItem>
           <MenuItem className="status-actions__edit" onClick={handleEdit}>
             <FormattedGlobalMessage messageKey="edit" />

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';
-import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
-import CommentIcon from '../../../icons/chat_bubble.svg';
+import Alert from '../../cds/alerts-and-prompts/Alert';
 import styles from './Statuses.module.css';
 
 const StatusMessage = ({ message }) => {
@@ -12,19 +11,13 @@ const StatusMessage = ({ message }) => {
   }
 
   return (
-    <div className={cx(styles['status-message'], 'test__status-message')}>
-      <Tooltip
-        arrow
-        title={<FormattedMessage id="statusListItem.messageTooltip" defaultMessage="This message will be sent to the user who requested the item when you change an item to this status" description="Tooltip to tell the user when this message will be sent out" />}
-      >
-        <span>
-          <CommentIcon />
-        </span>
-      </Tooltip>
-      <p>
-        {message}
-      </p>
-    </div>
+    <Alert
+      className={cx(styles['status-message'], 'test__status-message')}
+      variant="info"
+      icon
+      title={<FormattedMessage id="statusListItem.messageTooltip" defaultMessage="When you change and item to this status, the user who requested will receive the following message:" description="Tooltip to tell the user when this message will be sent out" />}
+      content={message}
+    />
   );
 };
 

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -1,33 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
-import CommentIcon from '@material-ui/icons/Comment';
-
-const useStyles = makeStyles(() => ({
-  statusMessageText: {
-    fontSize: 12,
-    opacity: 0.7,
-  },
-  statusMessageIcon: {
-    color: 'var(--grayBorderAccent)',
-  },
-}));
+import cx from 'classnames/bind';
+import { FormattedMessage } from 'react-intl';
+import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
+import CommentIcon from '../../../icons/chat_bubble.svg';
+import styles from './Statuses.module.css';
 
 const StatusMessage = ({ message }) => {
-  const classes = useStyles();
-
   if (!message) {
     return null;
   }
 
   return (
-    <Box display="flex" alignItems="flex-start" mt={1} className="status-message" component="span">
-      <CommentIcon className={classes.statusMessageIcon} />
-      <Box className={classes.statusMessageText} ml={1} component="span">
+    <div className={cx(styles['status-message'], 'test__status-message')}>
+      <Tooltip
+        arrow
+        title={<FormattedMessage id="statusListItem.messageTooltip" defaultMessage="This message will be sent to the user who requested the item when you change an item to this status" description="Tooltip to tell the user when this message will be sent out" />}
+      >
+        <span>
+          <CommentIcon />
+        </span>
+      </Tooltip>
+      <p>
         {message}
-      </Box>
-    </Box>
+      </p>
+    </div>
   );
 };
 

--- a/src/app/components/team/Statuses/StatusMessage.test.js
+++ b/src/app/components/team/Statuses/StatusMessage.test.js
@@ -23,6 +23,6 @@ describe('<StatusMessage/>', () => {
       message="status message"
     />);
     expect(wrapper.html()).toMatch('status message');
-    expect(wrapper.find('.status-message').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.test__status-message').hostNodes()).toHaveLength(1);
   });
 });

--- a/src/app/components/team/Statuses/Statuses.module.css
+++ b/src/app/components/team/Statuses/Statuses.module.css
@@ -6,4 +6,78 @@
   :global(.check-icon) {
     font-size: 28px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   }
+
+  small {
+    @mixin typography-subtitle1;
+    color: var(--textSecondary);
+    margin: 3px 0 0 3px;
+  }
+}
+
+.settings-status-listitem {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  margin: 0 0 16px;
+
+  &:last-of-type {
+    margin: 0;
+  }
+
+  > div {
+    flex: 1 1 auto;
+
+    p {
+      color: var(--textSecondary);
+      margin: 3px 0 0 8px;
+    }
+
+    .status-message {
+      color: var(--textSecondary);
+      display: flex;
+      gap: 3px;
+      margin: 6px 0 0 8px;
+
+      :global(.check-icon) {
+        font-size: var(--iconSizeSmall);
+      }
+
+      p {
+        margin: 0;
+      }
+    }
+
+    &.settings-status-menu {
+      flex: 0 0 auto;
+    }
+  }
+}
+
+.settings-translated-statuses {
+  .settings-translated-rows {
+    border-bottom: solid 2px var(--grayBorderMain);
+    display: flex;
+    gap: 16px;
+    padding: 16px 0;
+
+    &:last-of-type {
+      border-bottom: 0;
+    }
+
+    > div {
+      display: flex;
+      flex: 1 1 50%;
+      flex-direction: column;
+      gap: 16px;
+    }
+  }
+
+  .settings-translated-row-header {
+    > div {
+      align-items: center;
+      flex-direction: row;
+      justify-content: space-between;
+      padding: 0 8px;
+    }
+  }
 }

--- a/src/app/components/team/Statuses/Statuses.module.css
+++ b/src/app/components/team/Statuses/Statuses.module.css
@@ -1,0 +1,9 @@
+.status-label {
+  align-items: center;
+  display: flex;
+  gap: 2px;
+
+  :global(.check-icon) {
+    font-size: 28px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  }
+}

--- a/src/app/components/team/Statuses/Statuses.module.css
+++ b/src/app/components/team/Statuses/Statuses.module.css
@@ -15,13 +15,17 @@
 }
 
 .settings-status-listitem {
-  align-items: center;
+  align-items: flex-start;
+  border-bottom: solid 2px var(--grayBorderMain);
   display: flex;
-  gap: 4px;
+  gap: 16px;
   margin: 0 0 16px;
+  padding: 0 0 16px;
 
   &:last-of-type {
+    border-bottom: 0;
     margin: 0;
+    padding: 0;
   }
 
   > div {
@@ -29,22 +33,12 @@
 
     p {
       color: var(--textSecondary);
-      margin: 3px 0 0 8px;
+      margin: 3px 0 0 32px;
     }
 
     .status-message {
-      color: var(--textSecondary);
-      display: flex;
-      gap: 3px;
-      margin: 6px 0 0 8px;
-
-      :global(.check-icon) {
-        font-size: var(--iconSizeSmall);
-      }
-
-      p {
-        margin: 0;
-      }
+      margin: 6px 0 0 28px;
+      width: calc(100% - 28px);
     }
 
     &.settings-status-menu {

--- a/src/app/components/team/Statuses/StatusesComponent.js
+++ b/src/app/components/team/Statuses/StatusesComponent.js
@@ -3,13 +3,11 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql, commitMutation } from 'react-relay/compat';
 import { Store } from 'react-relay/classic';
-import styled from 'styled-components';
 
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
-import List from '@material-ui/core/List';
 import { makeStyles } from '@material-ui/core/styles';
 
 import SettingsHeader from '../SettingsHeader';
@@ -20,7 +18,7 @@ import TranslateStatuses from './TranslateStatuses';
 import LanguageSwitcher from '../../LanguageSwitcher';
 import { stringHelper } from '../../../customHelpers';
 import { getErrorMessage } from '../../../helpers';
-import { ContentColumn, units } from '../../../styles/js/shared';
+import { ContentColumn } from '../../../styles/js/shared';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { languageName } from '../../../LanguageRegistry';
 
@@ -29,10 +27,6 @@ const useToolbarStyles = makeStyles(() => ({
     whiteSpace: 'nowrap',
   },
 }));
-
-const StyledBlurb = styled.div`
-  margin-top: ${units(4)};
-`;
 
 const StatusesComponent = ({ team, setFlashMessage }) => {
   const statuses = [...team.verification_statuses.statuses];
@@ -253,7 +247,7 @@ const StatusesComponent = ({ team, setFlashMessage }) => {
           <CardContent>
             {
               currentLanguage === defaultLanguage ? (
-                <List>
+                <ul>
                   { statuses.map(s => (
                     <StatusListItem
                       defaultLanguage={defaultLanguage}
@@ -266,16 +260,15 @@ const StatusesComponent = ({ team, setFlashMessage }) => {
                       status={s}
                     />
                   ))}
-                </List>
+                </ul>
               ) : (
                 <React.Fragment>
-                  <StyledBlurb>
-                    <FormattedMessage
-                      id="statusesComponent.blurbSecondary"
-                      defaultMessage="Translate statuses in secondary languages in order to display them in local languages in your fact checking reports."
-                      description="Message displayed on status translation page."
-                    />
-                  </StyledBlurb>
+                  <FormattedMessage
+                    tagName="p"
+                    id="statusesComponent.blurbSecondary"
+                    defaultMessage="Translate statuses in secondary languages in order to display them in local languages in your fact checking reports."
+                    description="Message displayed on status translation page."
+                  />
                   <TranslateStatuses
                     currentLanguage={currentLanguage}
                     defaultLanguage={defaultLanguage}

--- a/src/app/components/team/Statuses/TranslateStatuses.js
+++ b/src/app/components/team/Statuses/TranslateStatuses.js
@@ -1,34 +1,16 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Box from '@material-ui/core/Box';
-import Divider from '@material-ui/core/Divider';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-import styled from 'styled-components';
+import cx from 'classnames/bind';
+import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 import { languageLabel } from '../../../LanguageRegistry';
-import { units } from '../../../styles/js/shared';
 import { FormattedGlobalMessage } from '../../MappedMessage';
 import StatusLabel from './StatusLabel';
 import StatusMessage from './StatusMessage';
-
-const StyledTranslateStatusesContainer = styled.div`
-  margin: ${units(4)};
-`;
-
-const StyledColHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const StyledTextField = styled.div`
-  margin-top: ${units(2)};
-  margin-bottom: ${units(1)};
-`;
+import styles from './Statuses.module.css';
 
 const TranslateStatuses = ({
   statuses,
@@ -112,99 +94,92 @@ const TranslateStatuses = ({
   };
 
   return (
-    <StyledTranslateStatusesContainer>
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
-          <Typography variant="button">
-            { languageLabel(defaultLanguage) }
-          </Typography>
-        </Grid>
-        <Grid item xs={6}>
-          <StyledColHeader>
-            <Typography variant="button">
-              { languageLabel(currentLanguage) }
-            </Typography>
-            <Button className="translate-statuses__save" variant="contained" color="primary" onClick={handleSave}>
+    <div className={styles['settings-translated-statuses']}>
+      <div className={cx(styles['settings-translated-rows'], styles['settings-translated-row-header'])}>
+        <div className="typography-button">
+          { languageLabel(defaultLanguage) }
+        </div>
+        <div>
+          <span className="typography-button">
+            { languageLabel(currentLanguage) }
+          </span>
+          <ButtonMain
+            className="translate-statuses__save"
+            variant="contained"
+            theme="brand"
+            size="default"
+            onClick={handleSave}
+            label={
               <FormattedGlobalMessage messageKey="save" />
-            </Button>
-          </StyledColHeader>
-        </Grid>
-      </Grid>
+            }
+          />
+        </div>
+      </div>
       {statuses.map(s => (
-        <Box mt={1} key={s.id}>
-          <Divider />
-          <Grid
-            spacing={2}
-            container
-            direction="row"
-            alignItems="center"
-          >
-            <Grid item xs={6}>
-              <Typography variant="caption" component="div">
+        <div className={styles['settings-translated-rows']} key={s.id}>
+          <div>
+            <ul>
+              <li className={styles['settings-status-listitem']}>
+                <div>
+                  <StatusLabel color={s.style.color}>
+                    { s.locales[defaultLanguage] ?
+                      s.locales[defaultLanguage].label : s.label }
+                  </StatusLabel>
+                  <StatusMessage
+                    message={
+                      s.locales[defaultLanguage] && s.should_send_message ?
+                        s.locales[defaultLanguage].message : null
+                    }
+                  />
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <TextField
+              className="translate-statuses__input"
+              label={
                 <FormattedMessage
                   id="translateStatuses.status"
                   defaultMessage="Status"
+                  description="Label for TextField for the status translation"
                 />
-              </Typography>
-              <StatusLabel color={s.style.color}>
-                { s.locales[defaultLanguage] ?
-                  s.locales[defaultLanguage].label : s.label }
-              </StatusLabel>
-              <StatusMessage
-                message={
-                  s.locales[defaultLanguage] && s.should_send_message ?
-                    s.locales[defaultLanguage].message : null
-                }
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <StyledTextField>
-                <TextField
-                  className="translate-statuses__input"
-                  label={
-                    <FormattedMessage
-                      id="translateStatuses.status"
-                      defaultMessage="Status"
-                    />
-                  }
-                  defaultValue={
-                    s.locales[currentLanguage] ?
-                      s.locales[currentLanguage].label : ''
-                  }
-                  fullWidth
-                  id={`translate-statuses__input-${s.id}`}
-                  onChange={e => (handleTextChange(s.id, e.target.value))}
-                  size="small"
-                  variant="outlined"
-                />
-              </StyledTextField>
-              { s.should_send_message && s.locales[defaultLanguage] && s.locales[defaultLanguage].message ?
-                <StyledTextField>
-                  <TextField
-                    className="translate-statuses__message"
-                    label={
-                      <FormattedMessage
-                        id="translateStatuses.message"
-                        defaultMessage="Message"
-                      />
-                    }
-                    defaultValue={
-                      s.locales[currentLanguage] ?
-                        s.locales[currentLanguage].message : ''
-                    }
-                    fullWidth
-                    id={`translate-statuses__message-${s.id}`}
-                    multiline
-                    rows={3}
-                    rowsMax={Infinity}
-                    onChange={e => (handleMessageChange(s.id, e.target.value))}
-                    size="small"
-                    variant="outlined"
+              }
+              defaultValue={
+                s.locales[currentLanguage] ?
+                  s.locales[currentLanguage].label : ''
+              }
+              fullWidth
+              id={`translate-statuses__input-${s.id}`}
+              onChange={e => (handleTextChange(s.id, e.target.value))}
+              size="small"
+              variant="outlined"
+            />
+            { s.should_send_message && s.locales[defaultLanguage] && s.locales[defaultLanguage].message ?
+              <TextField
+                className="translate-statuses__message"
+                label={
+                  <FormattedMessage
+                    id="translateStatuses.message"
+                    defaultMessage="Message"
+                    description="Label for the textarea where user can provide a translation for the automated message"
                   />
-                </StyledTextField> : null }
-            </Grid>
-          </Grid>
-        </Box>
+                }
+                defaultValue={
+                  s.locales[currentLanguage] ?
+                    s.locales[currentLanguage].message : ''
+                }
+                fullWidth
+                id={`translate-statuses__message-${s.id}`}
+                multiline
+                rows={3}
+                rowsMax={Infinity}
+                onChange={e => (handleMessageChange(s.id, e.target.value))}
+                size="small"
+                variant="outlined"
+              /> : null }
+          </div>
+        </div>
       ))}
       <ConfirmProceedDialog
         open={showWarning}
@@ -212,14 +187,16 @@ const TranslateStatuses = ({
           <FormattedMessage
             id="translateStatuses.missingTranslations"
             defaultMessage="Missing translations"
+            description="Modal Title informing the user that there are missing translations"
           />
         }
         body={
-          <Box>
+          <div>
             <Typography variant="body1">
               <FormattedMessage
                 id="translateStatuses.missingTranslationsBody"
                 defaultMessage="Some statuses are missing translations. Users may not be able to read untranslated statuses."
+                description="Modal paragraph description informing the user that there are missing translations"
               />
             </Typography>
             <p />
@@ -227,9 +204,10 @@ const TranslateStatuses = ({
               <FormattedMessage
                 id="translateStatuses.missingTranslationsBody2"
                 defaultMessage="If the message for a status is not translated in a language, any requester using that language will not receive the message."
+                description="Description paragraph telling the user what will happen is a translation is missing"
               />
             </Typography>
-          </Box>
+          </div>
         }
         onCancel={handleDialogCancel}
         onProceed={handleSubmit}
@@ -237,10 +215,11 @@ const TranslateStatuses = ({
           <FormattedMessage
             id="translateStatuses.continueAndSave"
             defaultMessage="Continue and save"
+            description="Label for confirmation to save the updated status translations"
           />
         }
       />
-    </StyledTranslateStatusesContainer>
+    </div>
   );
 };
 

--- a/src/app/components/team/Statuses/TranslateStatuses.test.js
+++ b/src/app/components/team/Statuses/TranslateStatuses.test.js
@@ -59,7 +59,7 @@ describe('<TranslateStatuses/>', () => {
     expect(wrapper.find('#translate-statuses__input-1').at(0).prop('defaultValue')).toEqual('falso');
     expect(wrapper.find('#translate-statuses__input-2').at(1).prop('defaultValue')).toEqual('verdadeiro');
     expect(wrapper.find('#translate-statuses__input-3').at(2).prop('defaultValue')).toEqual('em progresso');
-    expect(wrapper.find('.status-message').hostNodes()).toHaveLength(0);
+    expect(wrapper.find('.test__status-message').hostNodes()).toHaveLength(0);
     expect(wrapper.find('.translate-statuses__message').hostNodes()).toHaveLength(0);
   });
 
@@ -72,7 +72,7 @@ describe('<TranslateStatuses/>', () => {
     />);
     expect(wrapper.html()).toMatch('False');
     expect(wrapper.find('#translate-statuses__input-1').at(0).prop('defaultValue')).toEqual('falso');
-    expect(wrapper.find('.status-message').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.test__status-message').hostNodes()).toHaveLength(1);
     expect(wrapper.html()).toMatch('message to be sent to the users');
     expect(wrapper.find('.translate-statuses__message').hostNodes()).toHaveLength(1);
   });

--- a/test/spec/status_spec.rb
+++ b/test/spec/status_spec.rb
@@ -11,7 +11,7 @@ shared_examples 'status' do
     item_page = @driver.current_url
     @driver.navigate.to "#{@config['self_url']}/#{get_team}/settings"
     wait_for_selector('.team-settings__statuses-tab').click
-    wait_for_selector("//span[contains(text(), 'default')]", :xpath)
+    wait_for_selector("//small[contains(text(), 'default')]", :xpath)
     expect(@driver.page_source.include?('Unstarted')).to be(true)
     wait_for_selector('.status-actions__menu').click
     # edit status name


### PR DESCRIPTION
## Description

Updating the styles of the status/rating display to improve the accessibility
- Replace background color approach to status display with a ellipsis of the same color
- Introduce the ellipsis to the search results table

References: [CV2-3596](https://meedan.atlassian.net/browse/CV2-3596)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual visual testing

## Things to pay attention to during code review

### AFTER - settings list
<img width="904" alt="Screenshot 2023-08-29 at 12 36 10 PM" src="https://github.com/meedan/check-web/assets/418001/3aaded17-3ec9-45c4-a2d5-2c9ed02f64c8">

### AFTER - settings list translation
<img width="901" alt="Screenshot 2023-08-29 at 12 36 01 PM" src="https://github.com/meedan/check-web/assets/418001/fc62d746-9bd4-472e-9205-7eadecb479b8">

### AFTER - search results table
<img width="229" alt="Screenshot 2023-08-29 at 12 51 31 PM" src="https://github.com/meedan/check-web/assets/418001/ae859a3e-6475-4eea-b360-ab0659fc7eba">

### AFTER - item header
<img width="230" alt="Screenshot 2023-08-25 at 2 45 49 PM" src="https://github.com/meedan/check-web/assets/418001/f64c4b81-0dc3-4ad4-97e5-932da2cd580d">

### AFTER - item header with message
<img width="298" alt="Screenshot 2023-08-29 at 12 55 12 PM" src="https://github.com/meedan/check-web/assets/418001/fa5ede68-89a9-4360-b503-a59705c74672">

### AFTER - item header flyout
<img width="280" alt="Screenshot 2023-08-29 at 1 01 17 PM" src="https://github.com/meedan/check-web/assets/418001/cad64b1d-e07b-464c-8a4f-93dd51ce1f15">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)



[CV2-3596]: https://meedan.atlassian.net/browse/CV2-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ