### PR TITLE
Feature/775 lists and filters ux cleanup

### DIFF
--- a/localization/react-intl/src/app/components/search/SaveList.json
+++ b/localization/react-intl/src/app/components/search/SaveList.json
@@ -45,11 +45,6 @@
     "defaultMessage": "Saving changes will update shared feeds:"
   },
   {
-    "id": "saveList.updateSpecialPage",
-    "description": "'Save' here is an infinitive verb",
-    "defaultMessage": "Save changes to the list"
-  },
-  {
     "id": "saveList.create",
     "description": "'Create' here is an infinitive verb",
     "defaultMessage": "Create new list"

--- a/localization/react-intl/src/app/components/search/SaveList.json
+++ b/localization/react-intl/src/app/components/search/SaveList.json
@@ -21,14 +21,17 @@
   },
   {
     "id": "saveList.newList",
+    "description": "Dialog title and submit button label for saving changes to lists",
     "defaultMessage": "Save list"
   },
   {
     "id": "saveList.title",
+    "description": "Prompt for editing list name",
     "defaultMessage": "Enter new list name"
   },
   {
     "id": "saveList.cancel",
+    "description": "Cancel list editing button label",
     "defaultMessage": "Cancel"
   },
   {

--- a/localization/react-intl/src/app/components/search/SearchFields/index.json
+++ b/localization/react-intl/src/app/components/search/SearchFields/index.json
@@ -185,6 +185,16 @@
     "defaultMessage": "Organization is"
   },
   {
+    "id": "search.spam",
+    "description": "Label for spam filter field",
+    "defaultMessage": "Item is marked as spam"
+  },
+  {
+    "id": "search.trash",
+    "description": "Label for spam filter field",
+    "defaultMessage": "Item is in the Trash"
+  },
+  {
     "id": "search.resetFilter",
     "description": "Button label to reset search filters.",
     "defaultMessage": "Reset"

--- a/localization/react-intl/src/app/components/team/TiplineInbox.json
+++ b/localization/react-intl/src/app/components/team/TiplineInbox.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "tiplineInbox.title",
+    "description": "Title for the tipline inbox listing of items",
     "defaultMessage": "Tipline inbox"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Trash.json
+++ b/localization/react-intl/src/app/components/team/Trash.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "trash.title",
+    "description": "Title for the trash listing of items",
     "defaultMessage": "Trash"
   }
 ]

--- a/src/app/components/feed/Feed.js
+++ b/src/app/components/feed/Feed.js
@@ -56,6 +56,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               ...feed.filters,
               ...routeQuery,
             }}
+            defaultQuery={feed.filters}
             feedTeam={{
               id: feedTeam.id,
               filters: feedTeam.filters,
@@ -81,6 +82,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               feed_id: feed.dbid,
               ...feed.filters,
             }}
+            defaultQuery={feed.filters}
             resultType="factCheck"
             hideFields={[
               'feed_fact_checked_by',
@@ -129,6 +131,7 @@ export const FeedComponent = ({ routeParams, ...props }) => {
               clusterize: true,
               ...feed.filters,
             }}
+            defaultQuery={feed.filters}
             resultType="feed"
             hideFields={[
               'feed_fact_checked_by',

--- a/src/app/components/feed/FeedRequestsTable.js
+++ b/src/app/components/feed/FeedRequestsTable.js
@@ -171,7 +171,7 @@ const FeedRequestsTable = ({
             <SearchKeyword
               query={{ keyword: filters.keyword }}
               team={{ verification_statuses: {} }}
-              setQuery={(query) => {
+              setStateQuery={(query) => {
                 // Clear
                 if (!query.keyword || query.keyword === '') {
                   const newFilters = { ...filters };

--- a/src/app/components/media/BulkActions.js
+++ b/src/app/components/media/BulkActions.js
@@ -258,14 +258,10 @@ class BulkActions extends React.Component {
   }
 }
 
-BulkActions.defaultProps = {
-  page: null,
-};
-
 BulkActions.propTypes = {
   setFlashMessage: PropTypes.func.isRequired,
   team: PropTypes.object.isRequired,
-  page: PropTypes.string,
+  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
   selectedMedia: PropTypes.array.isRequired,
   selectedProjectMedia: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
   onUnselectAll: PropTypes.func.isRequired,

--- a/src/app/components/search/AllItems.js
+++ b/src/app/components/search/AllItems.js
@@ -7,18 +7,21 @@ import { safelyParseJSON } from '../../helpers';
 import CategoryIcon from '../../icons/category.svg';
 
 export default function AllItems({ routeParams }) {
+  const defaultQuery = { sort: 'recent_activity' };
   return (
     <ErrorBoundary component="AllItems">
       <Search
         searchUrlPrefix={`/${routeParams.team}/all-items`}
         mediaUrlPrefix={`/${routeParams.team}/media`}
         title={<FormattedMessage id="search.allClaimsTitle" defaultMessage="All items" description="Page title for listing all items in check" />}
-        query={safelyParseJSON(routeParams.query, {})}
+        query={safelyParseJSON(routeParams.query, defaultQuery)}
+        defaultQuery={defaultQuery}
         icon={<CategoryIcon />}
         teamSlug={routeParams.team}
         hideFields={[
           'cluster_teams', 'cluster_published_reports', 'feed_fact_checked_by',
         ]}
+        page="all-items"
       />
     </ErrorBoundary>
   );

--- a/src/app/components/search/AllItems.js
+++ b/src/app/components/search/AllItems.js
@@ -7,7 +7,9 @@ import { safelyParseJSON } from '../../helpers';
 import CategoryIcon from '../../icons/category.svg';
 
 export default function AllItems({ routeParams }) {
-  const defaultQuery = { sort: 'recent_activity' };
+  // Adding sort key to defaultQuery breaks optimisticUpdate and appending new item to list
+  // const defaultQuery = { sort: 'recent_activity' };
+  const defaultQuery = {};
   return (
     <ErrorBoundary component="AllItems">
       <Search

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -81,6 +81,10 @@ const SaveList = ({
     return null;
   }
 
+  if (['spam', 'trash'].includes(page)) {
+    return null;
+  }
+
   const classes = useStyles();
 
   const objectType = currentPath[1];
@@ -95,10 +99,6 @@ const SaveList = ({
   // Create, Update SavedSearch
   // Update Feed
   if (!can(team.permissions, 'update Team')) {
-    return null;
-  }
-
-  if (['spam', 'trash'].includes(page)) {
     return null;
   }
 
@@ -223,6 +223,7 @@ const SaveList = ({
   };
 
   const handleClick = () => {
+    // FIXME: declare core lists globally.
     // From these pages we can just create a new list
     const coreLists = ['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published'];
     if (coreLists.includes(objectType)) {

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -102,16 +102,6 @@ const SaveList = ({
     return null;
   }
 
-  // // Don't even show the button if there is nothing to be saved
-  // if (!query || JSON.stringify(query) === '{}') {
-  //   return null;
-  // }
-
-  // // Don't show the button if it's a list and nothing changed
-  // if (objectType === 'list' && savedSearch && JSON.stringify(query) === savedSearch.filters) {
-  //   return null;
-  // }
-
   const feedFilters = {};
   if (objectType === 'feed') {
     // Don't show the button if it's a shared feed and nothing changed
@@ -129,27 +119,6 @@ const SaveList = ({
       return null;
     }
   }
-
-  // // Don't show the button if it's a tipline inbox or suggested media page and nothing changed
-  // if (['tipline-inbox', 'suggested-matches'].indexOf(objectType) !== -1) {
-  //   let defaultQuery = {};
-  //   let savedQuery = '{}';
-  //   if (objectType === 'tipline-inbox') {
-  //     defaultQuery = { read: ['0'], projects: ['-1'], verification_status: [team.verification_statuses.default] };
-  //     savedQuery = team.get_tipline_inbox_filters;
-  //   } else if (objectType === 'suggested-matches') {
-  //     defaultQuery = { suggestions_count: { min: 1 } };
-  //     savedQuery = team.get_suggested_matches_filters;
-  //   }
-  //   // Don't show the button if it's a saved search or a default list
-  //   if (savedQuery) {
-  //     if (JSON.stringify(query) === JSON.stringify(savedQuery)) {
-  //       return null;
-  //     }
-  //   } else if (JSON.stringify(query) === JSON.stringify(defaultQuery)) {
-  //     return null;
-  //   }
-  // }
 
   const handleClose = () => {
     setShowNewDialog(false);

--- a/src/app/components/search/SavedSearch.js
+++ b/src/app/components/search/SavedSearch.js
@@ -45,10 +45,8 @@ const SavedSearch = ({ routeParams }) => (
         if (!error && props) {
           // Weird Relay error happens here if "filters" is a JSON object instead of a JSON string...
           // "Uncaught TypeError: Cannot assign to read only property '<filter name>' of object '#<Object>'"
-          const savedQuery = props.saved_search.filters || '{}';
-          const query = routeParams.query ?
-            safelyParseJSON(routeParams.query, {}) :
-            safelyParseJSON(savedQuery, {});
+          const defaultQuery = safelyParseJSON(props.saved_search.filters, {});
+          const query = routeParams.query ? safelyParseJSON(routeParams.query, {}) : defaultQuery;
 
           return (
             <div className="saved-search search-results-wrapper">
@@ -92,6 +90,7 @@ const SavedSearch = ({ routeParams }) => (
                 listSubtitle={<FormattedMessage id="savedSearch.subtitle" defaultMessage="Custom List" description="Displayed on top of the custom list title on the search results page." />}
                 teamSlug={routeParams.team}
                 query={query}
+                defaultQuery={defaultQuery}
                 savedSearch={props.saved_search}
                 hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
                 page="list"

--- a/src/app/components/search/Search.js
+++ b/src/app/components/search/Search.js
@@ -29,7 +29,7 @@ function noFilters(query_) {
     delete query.archived;
     delete query.parent;
   }
-  if (/\/(tipline-inbox|imported-reports)+/.test(window.location.pathname)) {
+  if (/\/(tipline-inbox|imported-fact-checks)+/.test(window.location.pathname)) {
     delete query.channels;
   }
   if (/\/(unmatched-media)+/.test(window.location.pathname)) {

--- a/src/app/components/search/Search.js
+++ b/src/app/components/search/Search.js
@@ -8,12 +8,12 @@ function searchQueryFromUrlQuery(urlQuery) {
 }
 
 export function searchQueryFromUrl() {
-  const queryString = window.location.pathname.match(/.*\/(all-items|trash|project\/[0-9]+)(?:\/[a-z]+)?\/(.*)/);
+  const queryString = window.location.pathname.match(/.*\/(all-items|trash)(?:\/[a-z]+)?\/(.*)/);
   return queryString ? searchQueryFromUrlQuery(queryString[2]) : {};
 }
 
 function searchPrefixFromUrl() {
-  const queryString = window.location.pathname.match(/.*\/(all-items|trash|project\/[0-9]+)/);
+  const queryString = window.location.pathname.match(/.*\/(all-items|trash)/);
   return queryString ? queryString[0] : null;
 }
 
@@ -22,30 +22,12 @@ export function urlFromSearchQuery(query, path) {
   return Object.keys(query).length === 0 ? prefix : `${prefix}/${encodeURIComponent(JSON.stringify(query))}`;
 }
 
-function noFilters(query_, project, projectGroup) {
+function noFilters(query_) {
   const query = { ...query_ };
   delete query.timestamp;
   if (Object.keys(query).indexOf('archived') > -1) {
     delete query.archived;
     delete query.parent;
-  }
-  if (
-    query.projects &&
-    (query.projects.length === 0 ||
-      (project &&
-        query.projects.length === 1 &&
-        query.projects[0] === project.dbid))
-  ) {
-    delete query.projects;
-  }
-  if (
-    query.project_group_id &&
-    (query.project_group_id.length === 0 ||
-      (projectGroup &&
-        query.project_group_id.length === 1 &&
-        query.project_group_id[0] === projectGroup.dbid))
-  ) {
-    delete query.project_group_id;
   }
   if (/\/(tipline-inbox|imported-reports)+/.test(window.location.pathname)) {
     delete query.channels;
@@ -79,12 +61,11 @@ export default function Search({
   page,
   listSubtitle,
   teamSlug,
-  project,
-  projectGroup,
   feed,
   feedTeam,
   savedSearch,
   query,
+  defaultQuery,
   searchUrlPrefix,
   title,
   icon,
@@ -93,7 +74,7 @@ export default function Search({
   extra,
 }) {
   let timestampedQuery = query;
-  if (!noFilters(query, project, projectGroup)) {
+  if (!noFilters(query)) {
     timestampedQuery = { ...query, timestamp: new Date().getTime() };
   }
 
@@ -103,8 +84,6 @@ export default function Search({
       mediaUrlPrefix={mediaUrlPrefix}
       listSubtitle={listSubtitle}
       teamSlug={teamSlug}
-      project={project}
-      projectGroup={projectGroup}
       feed={feed}
       feedTeam={feedTeam}
       savedSearch={savedSearch}
@@ -115,6 +94,7 @@ export default function Search({
       title={title}
       icon={icon}
       query={timestampedQuery}
+      defaultQuery={defaultQuery}
       showExpand={showExpand}
       resultType={resultType}
       extra={extra}
@@ -123,12 +103,9 @@ export default function Search({
 }
 
 Search.defaultProps = {
-  project: null,
-  projectGroup: null,
   feedTeam: null,
   feed: null,
   savedSearch: null,
-  page: undefined, // FIXME find a cleaner way to render Trash differently
   hideFields: [],
   readOnlyFields: [],
   listActions: undefined,
@@ -143,8 +120,6 @@ Search.propTypes = {
   searchUrlPrefix: PropTypes.string.isRequired,
   mediaUrlPrefix: PropTypes.string.isRequired,
   listActions: PropTypes.node, // or undefined
-  project: PropTypes.object, // or null
-  projectGroup: PropTypes.object, // or null
   feedTeam: PropTypes.object, // or null
   feed: PropTypes.object, // or null
   savedSearch: PropTypes.object, // or null
@@ -154,8 +129,9 @@ Search.propTypes = {
   icon: PropTypes.node,
   hideFields: PropTypes.arrayOf(PropTypes.string.isRequired), // or undefined
   readOnlyFields: PropTypes.arrayOf(PropTypes.string.isRequired), // or undefined
-  page: PropTypes.oneOf(['trash', 'list', 'suggested-matches', 'feed', 'tipline-inbox', 'unmatched-media']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
   query: PropTypes.object.isRequired, // may be empty
+  defaultQuery: PropTypes.object.isRequired, // may be empty
   showExpand: PropTypes.bool,
   resultType: PropTypes.string, // 'default' or 'feed', for now
   extra: PropTypes.node, // or null

--- a/src/app/components/search/SearchFields/SearchFieldChannel.js
+++ b/src/app/components/search/SearchFields/SearchFieldChannel.js
@@ -46,6 +46,7 @@ const SearchFieldChannelComponent = ({
   onChange,
   onRemove,
   about,
+  page,
   readOnly,
   intl,
 }) => {
@@ -67,13 +68,19 @@ const SearchFieldChannelComponent = ({
     SHARED_DATABASE: intl.formatMessage(messages.sharedDatabase),
   };
 
-  let options = Object.keys(channels).filter(key => key !== 'TIPLINE').map(key => ({ label: optionLabels[key], value: `${channels[key]}` }));
+  let options = [];
+
+  const nonTiplines = Object.keys(channels).filter(key => key !== 'TIPLINE').map(key => ({ label: optionLabels[key], value: `${channels[key]}` }));
+  const tiplines = Object.keys(channels.TIPLINE).map(key => ({ label: optionLabels[key], value: `${channels.TIPLINE[key]}`, parent: 'any_tipline' }));
+
+  if (page !== 'tipline-inbox') {
+    options = options.concat(nonTiplines);
+  }
 
   options = options.concat([
     { label: intl.formatMessage(messages.anyTipline), value: 'any_tipline', hasChildren: true },
   ]);
 
-  const tiplines = Object.keys(channels.TIPLINE).map(key => ({ label: optionLabels[key], value: `${channels.TIPLINE[key]}`, parent: 'any_tipline' }));
   options = options.concat(tiplines);
 
   const handleChange = (channelIds) => {
@@ -86,10 +93,10 @@ const SearchFieldChannelComponent = ({
   };
 
   let selectedChannels = [];
-  if (/tipline-inbox/.test(window.location.pathname)) {
+  if (page === 'tipline-inbox') {
     selectedChannels = [CheckChannels.ANYTIPLINE];
   }
-  if (/imported-fact-checks/.test(window.location.pathname)) {
+  if (page === 'imported-fact-checks') {
     selectedChannels = [CheckChannels.FETCH];
   }
 
@@ -102,7 +109,7 @@ const SearchFieldChannelComponent = ({
           selected={query.channels || selectedChannels}
           options={options}
           onChange={handleChange}
-          onRemove={onRemove}
+          onRemove={(page !== 'tipline-inbox') ? onRemove : null}
           readOnly={readOnly}
         />
       )}
@@ -135,6 +142,7 @@ SearchFieldChannel.propTypes = {
   query: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
+  page: PropTypes.string.isRequired,
 };
 
 export default injectIntl(SearchFieldChannel);

--- a/src/app/components/search/SearchFields/SearchFieldDummy.js
+++ b/src/app/components/search/SearchFields/SearchFieldDummy.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import RemoveableWrapper from '../RemoveableWrapper';
 
@@ -15,5 +16,19 @@ const SearchFieldDummy = ({
     </Box>
   </RemoveableWrapper>
 );
+
+SearchFieldDummy.defaultProps = {
+  readOnly: false,
+  onRemove: null,
+  version: undefined,
+};
+
+SearchFieldDummy.propTypes = {
+  icon: PropTypes.node.isRequired,
+  label: PropTypes.node.isRequired,
+  readOnly: PropTypes.bool,
+  onRemove: PropTypes.func,
+  version: PropTypes.string,
+};
 
 export default SearchFieldDummy;

--- a/src/app/components/search/SearchFields/SearchFieldDummy.js
+++ b/src/app/components/search/SearchFields/SearchFieldDummy.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import RemoveableWrapper from '../RemoveableWrapper';
+
+const SearchFieldDummy = ({
+  icon,
+  label,
+  readOnly,
+  onRemove,
+  version,
+}) => (
+  <RemoveableWrapper icon={icon} readOnly={readOnly} onRemove={onRemove} key={version}>
+    <Box px={0.5} height={4.5} display="flex" alignItems="center" whiteSpace="nowrap">
+      {label}
+    </Box>
+  </RemoveableWrapper>
+);
+
+export default SearchFieldDummy;

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -238,6 +238,7 @@ const SearchFields = ({
   const handleClickClear = () => {
     const { keyword } = query;
     const newQuery = keyword ? { keyword } : {};
+    newQuery.sort = 'clear';
     setQuery(newQuery);
     onChange(newQuery);
   };
@@ -644,13 +645,16 @@ const SearchFields = ({
     return ret;
   };
 
-  const queryWithoutTimestamp = stripTimestamp(query);
-  const currentQueryWithoutTimestamp = stripTimestamp(currentQuery);
+  const stateQueryWithoutTimestamp = stripTimestamp(query);
+  const appliedQueryWithoutTimestamp = stripTimestamp(currentQuery);
 
-  // We can apply if the state query has differed from what is currently shown
-  const canApply = JSON.stringify(queryWithoutTimestamp) !== JSON.stringify(currentQueryWithoutTimestamp);
-  // We can save if the
-  const canSave = JSON.stringify(defaultQuery) !== JSON.stringify(currentQueryWithoutTimestamp);
+  console.log('stateQueryWithoutTimestamp', stateQueryWithoutTimestamp); // eslint-disable-line
+  console.log('appliedQueryWithoutTimestamp', appliedQueryWithoutTimestamp); // eslint-disable-line
+
+  // We can apply if the state query is dirty (differs from what is applied)
+  const canApply = JSON.stringify(stateQueryWithoutTimestamp) !== JSON.stringify(appliedQueryWithoutTimestamp);
+  // We can save if the applied query is different from the default query
+  const canSave = JSON.stringify(appliedQueryWithoutTimestamp) !== JSON.stringify(defaultQuery);
   const canReset = canApply || canSave;
 
   return (
@@ -722,7 +726,6 @@ const SearchFields = ({
 };
 
 SearchFields.defaultProps = {
-  page: null,
   savedSearch: null,
   feedTeam: null,
   readOnlyFields: [],

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -140,12 +140,12 @@ const messages = defineMessages({
 const SearchFields = ({
   intl,
   team,
-  query,
-  currentQuery,
+  stateQuery,
+  appliedQuery,
   defaultQuery,
   feedTeam,
   readOnlyFields,
-  setQuery,
+  setStateQuery,
   onChange,
   page,
   handleSubmit,
@@ -160,92 +160,92 @@ const SearchFields = ({
   */
   const updateStateQueryArrayValue = (key, newArray) => {
     if (newArray === undefined) {
-      const newQuery = { ...query };
+      const newQuery = { ...stateQuery };
       delete newQuery[key];
       return newQuery;
     }
-    return { ...query, [key]: newArray };
+    return { ...stateQuery, [key]: newArray };
   };
 
   const handleAddField = (field) => {
-    const newQuery = { ...query };
+    const newQuery = { ...stateQuery };
 
     if (field === 'team_tasks') {
-      newQuery.team_tasks = query.team_tasks ?
-        [...query.team_tasks, {}] : [{}];
+      newQuery.team_tasks = stateQuery.team_tasks ?
+        [...stateQuery.team_tasks, {}] : [{}];
     } else if (field === 'range') {
       newQuery.range = { created_at: {} };
     } else {
       newQuery[field] = [];
     }
 
-    setQuery(newQuery);
+    setStateQuery(newQuery);
   };
 
   const handleRemoveField = (field) => {
-    const newQuery = { ...query };
+    const newQuery = { ...stateQuery };
     delete newQuery[field];
-    setQuery(newQuery);
+    setStateQuery(newQuery);
   };
 
   // const filterIsActive = () => Object.keys(query).filter(k => k !== 'keyword').length > 0;
 
   const handleDateChange = (value) => {
-    const newQuery = { ...query, range: value };
-    setQuery(newQuery);
+    const newQuery = { ...stateQuery, range: value };
+    setStateQuery(newQuery);
   };
 
   const handleLanguageChange = (value) => {
-    const newQuery = { ...query, language_filter: value };
-    setQuery(newQuery);
+    const newQuery = { ...stateQuery, language_filter: value };
+    setStateQuery(newQuery);
   };
 
   const handleNumericRange = (filterKey, value) => {
-    const newQuery = { ...query };
+    const newQuery = { ...stateQuery };
     newQuery[filterKey] = value;
-    setQuery(newQuery);
+    setStateQuery(newQuery);
   };
 
   const handleCustomFilterChange = (value) => {
-    const newQuery = { ...query, ...value };
+    const newQuery = { ...stateQuery, ...value };
     if (JSON.stringify(value) === '{}') {
       delete newQuery.team_tasks;
     }
-    setQuery(newQuery);
+    setStateQuery(newQuery);
   };
 
   const handleFilterClick = (values, filterName) => {
-    setQuery(
+    setStateQuery(
       updateStateQueryArrayValue(filterName, values),
     );
   };
 
   const switchOperatorIs = (operator, key) => {
     let currentOperator = 'or'; // "or" is the default
-    if (query && query[key]) {
-      currentOperator = query[key];
+    if (stateQuery && stateQuery[key]) {
+      currentOperator = stateQuery[key];
     }
     return currentOperator === operator;
   };
 
   const handleSwitchOperator = (key) => {
     const operator = switchOperatorIs('or', key) ? 'and' : 'or';
-    const newQuery = { ...query };
+    const newQuery = { ...stateQuery };
     newQuery[key] = operator;
-    setQuery(newQuery);
+    setStateQuery(newQuery);
   };
 
   const handleClickClear = () => {
-    const { keyword } = query;
+    const { keyword } = stateQuery;
     const newQuery = keyword ? { keyword } : {};
     newQuery.sort = 'clear';
-    setQuery(newQuery);
+    setStateQuery(newQuery);
     onChange(newQuery);
   };
 
   const handleOperatorClick = () => {
-    const operator = query.operator === 'OR' ? 'AND' : 'OR';
-    setQuery(
+    const operator = stateQuery.operator === 'OR' ? 'AND' : 'OR';
+    setStateQuery(
       updateStateQueryArrayValue('operator', operator),
     );
   };
@@ -306,7 +306,7 @@ const SearchFields = ({
     }
     return (
       <Button {...operatorProps}>
-        { query.operator === 'OR' ?
+        { stateQuery.operator === 'OR' ?
           <FormattedMessage id="search.fieldOr" defaultMessage="or" description="Logical operator 'OR' to be applied when filtering by multiple fields" /> :
           <FormattedMessage id="search.fieldAnd" defaultMessage="and" description="Logical operator 'AND' to be applied when filtering by multiple fields" />
         }
@@ -322,7 +322,7 @@ const SearchFields = ({
             label={label}
             icon={<LabelIcon />}
             allowSearch={false}
-            selected={query.has_claim}
+            selected={stateQuery.has_claim}
             options={hasClaimOptions}
             readOnly={readOnlyFields.includes('has_claim')}
             onChange={(newValue) => { handleFilterClick(newValue, 'has_claim'); }}
@@ -335,7 +335,7 @@ const SearchFields = ({
       <Box maxWidth="900px">
         <DateRangeFilter
           onChange={handleDateChange}
-          value={query.range}
+          value={stateQuery.range}
           readOnly={readOnlyFields.includes('range')}
           optionsToHide={['request_created_at']}
           onRemove={() => handleRemoveField('range')}
@@ -345,10 +345,10 @@ const SearchFields = ({
     tags: (
       <SearchFieldTag
         teamSlug={team.slug}
-        query={query}
+        query={stateQuery}
         onChange={(newValue) => { handleFilterClick(newValue, 'tags'); }}
         onToggleOperator={() => handleSwitchOperator('tags_operator')}
-        operator={query.tags_operator}
+        operator={stateQuery.tags_operator}
         readOnly={readOnlyFields.includes('tags')}
         onRemove={() => handleRemoveField('tags')}
       />
@@ -360,7 +360,7 @@ const SearchFields = ({
             allowSearch={false}
             label={label}
             icon={<DescriptionIcon />}
-            selected={query.show}
+            selected={stateQuery.show}
             options={types}
             readOnly={readOnlyFields.includes('show')}
             onChange={(newValue) => { handleFilterClick(newValue, 'show'); }}
@@ -376,7 +376,7 @@ const SearchFields = ({
             allowSearch={false}
             label={label}
             icon={<UnmatchedIcon />}
-            selected={query.unmatched}
+            selected={stateQuery.unmatched}
             options={unmatchedValues}
             oneOption
             readOnly={readOnlyFields.includes('unmatched')}
@@ -393,7 +393,7 @@ const SearchFields = ({
             allowSearch={false}
             label={label}
             icon={<MarkunreadIcon />}
-            selected={query.read}
+            selected={stateQuery.read}
             options={readValues}
             readOnly={readOnlyFields.includes('read')}
             onChange={(newValue) => { handleFilterClick(newValue, 'read'); }}
@@ -408,7 +408,7 @@ const SearchFields = ({
           <MultiSelectFilter
             label={label}
             icon={<LabelIcon />}
-            selected={query.verification_status}
+            selected={stateQuery.verification_status}
             options={statuses.map(s => ({ label: s.label, value: s.id }))}
             readOnly={readOnlyFields.includes('verification_status')}
             onChange={(newValue) => { handleFilterClick(newValue, 'verification_status'); }}
@@ -424,7 +424,7 @@ const SearchFields = ({
             teamSlug={team.slug}
             label={label}
             icon={<PersonIcon />}
-            selected={query.users}
+            selected={stateQuery.users}
             onChange={(newValue) => { handleFilterClick(newValue, 'users'); }}
             readOnly={readOnlyFields.includes('users')}
             onRemove={() => handleRemoveField('users')}
@@ -434,8 +434,9 @@ const SearchFields = ({
     ),
     channels: (
       <SearchFieldChannel
-        query={query}
+        query={stateQuery}
         onChange={(newValue) => { handleFilterClick(newValue, 'channels'); }}
+        page={page}
         onRemove={() => handleRemoveField('channels')}
         readOnly={readOnlyFields.includes('channels')}
       />
@@ -447,7 +448,7 @@ const SearchFields = ({
             allowSearch={false}
             label={label}
             icon={<ErrorIcon />}
-            selected={query.archived}
+            selected={stateQuery.archived}
             options={confirmedValues}
             readOnly={readOnlyFields.includes('archived')}
             onChange={(newValue) => { handleFilterClick(newValue, 'archived'); }}
@@ -462,7 +463,7 @@ const SearchFields = ({
         <NumericRangeFilter
           filterKey="linked_items_count"
           onChange={handleNumericRange}
-          value={query.linked_items_count}
+          value={stateQuery.linked_items_count}
           readOnly={readOnlyFields.includes('linked_items_count')}
           onRemove={() => handleRemoveField('linked_items_count')}
         />
@@ -473,7 +474,7 @@ const SearchFields = ({
         <NumericRangeFilter
           filterKey="suggestions_count"
           onChange={handleNumericRange}
-          value={query.suggestions_count}
+          value={stateQuery.suggestions_count}
           onRemove={() => handleRemoveField('suggestions_count')}
           readOnly={readOnlyFields.includes('suggestions_count')}
         />
@@ -485,7 +486,7 @@ const SearchFields = ({
           filterKey="demand"
           onChange={handleNumericRange}
           readOnly={readOnlyFields.includes('demand')}
-          value={query.demand}
+          value={stateQuery.demand}
           onRemove={() => handleRemoveField('demand')}
         />
       </Box>
@@ -497,7 +498,7 @@ const SearchFields = ({
             allowSearch={false}
             label={label}
             icon={<ReportIcon />}
-            selected={query.report_status}
+            selected={stateQuery.report_status}
             options={reportStatusOptions}
             readOnly={readOnlyFields.includes('report_status')}
             onChange={(newValue) => { handleFilterClick(newValue, 'report_status'); }}
@@ -513,7 +514,7 @@ const SearchFields = ({
             teamSlug={team.slug}
             label={label}
             icon={<HowToRegIcon />}
-            selected={query.published_by}
+            selected={stateQuery.published_by}
             onChange={(newValue) => { handleFilterClick(newValue, 'published_by'); }}
             readOnly={readOnlyFields.includes('published_by')}
             onRemove={() => handleRemoveField('published_by')}
@@ -528,12 +529,12 @@ const SearchFields = ({
             teamSlug={team.slug}
             label={label}
             icon={<PersonIcon />}
-            selected={query.annotated_by}
+            selected={stateQuery.annotated_by}
             onChange={(newValue) => { handleFilterClick(newValue, 'annotated_by'); }}
             readOnly={readOnlyFields.includes('annotated_by')}
             onRemove={() => handleRemoveField('annotated_by')}
             onToggleOperator={() => handleSwitchOperator('annotated_by_operator')}
-            operator={query.annotated_by_operator}
+            operator={stateQuery.annotated_by_operator}
           />
         )}
       </FormattedMessage>
@@ -542,7 +543,7 @@ const SearchFields = ({
       <Box maxWidth="900px">
         <LanguageFilter
           onChange={handleLanguageChange}
-          value={query.language_filter}
+          value={stateQuery.language_filter}
           readOnly={readOnlyFields.includes('language_filter')}
           onRemove={() => handleRemoveField('language_filter')}
           teamSlug={team.slug}
@@ -556,7 +557,7 @@ const SearchFields = ({
             teamSlug={team.slug}
             label={label}
             icon={<PersonIcon />}
-            selected={query.assigned_to}
+            selected={stateQuery.assigned_to}
             onChange={(newValue) => { handleFilterClick(newValue, 'assigned_to'); }}
             readOnly={readOnlyFields.includes('assigned_to')}
             onRemove={() => handleRemoveField('assigned_to')}
@@ -569,14 +570,14 @@ const SearchFields = ({
       <CustomFiltersManager
         onFilterChange={handleCustomFilterChange}
         team={team}
-        query={query}
+        query={stateQuery}
         operatorToggle={<OperatorToggle />}
       />
     ),
     sources: (
       <SearchFieldSource
         teamSlug={team.slug}
-        selected={query.sources}
+        selected={stateQuery.sources}
         readOnly={readOnlyFields.includes('sources')}
         onChange={(newValue) => { handleFilterClick(newValue, 'sources'); }}
         onRemove={() => handleRemoveField('sources')}
@@ -589,7 +590,7 @@ const SearchFields = ({
             label={label}
             icon={<CorporateFareIcon />}
             teamSlug={team.slug}
-            selected={query.cluster_teams}
+            selected={stateQuery.cluster_teams}
             readOnly={readOnlyFields.includes('cluster_teams')}
             onChange={(newValue) => { handleFilterClick(newValue, 'cluster_teams'); }}
             onRemove={() => handleRemoveField('cluster_teams')}
@@ -604,7 +605,7 @@ const SearchFields = ({
             label={label}
             icon={<HowToRegIcon />}
             teamSlug={team.slug}
-            selected={query.cluster_published_reports}
+            selected={stateQuery.cluster_published_reports}
             readOnly={readOnlyFields.includes('cluster_published_reports')}
             onChange={(newValue) => { handleFilterClick(newValue, 'cluster_published_reports'); }}
             onRemove={() => handleRemoveField('cluster_published_reports')}
@@ -635,7 +636,7 @@ const SearchFields = ({
   if (page === 'spam') fieldKeys.push('spam');
   if (page === 'trash') fieldKeys.push('trash');
 
-  fieldKeys = fieldKeys.concat(Object.keys(query).filter(k => k !== 'keyword' && !hideFields.includes(k) && fieldComponents[k]));
+  fieldKeys = fieldKeys.concat(Object.keys(stateQuery).filter(k => k !== 'keyword' && !hideFields.includes(k) && fieldComponents[k]));
 
   const addedFields = fieldKeys.filter(i => i !== 'team_tasks');
 
@@ -645,8 +646,8 @@ const SearchFields = ({
     return ret;
   };
 
-  const stateQueryWithoutTimestamp = stripTimestamp(query);
-  const appliedQueryWithoutTimestamp = stripTimestamp(currentQuery);
+  const stateQueryWithoutTimestamp = stripTimestamp(stateQuery);
+  const appliedQueryWithoutTimestamp = stripTimestamp(appliedQuery);
 
   console.log('stateQueryWithoutTimestamp', stateQueryWithoutTimestamp); // eslint-disable-line
   console.log('appliedQueryWithoutTimestamp', appliedQueryWithoutTimestamp); // eslint-disable-line
@@ -714,7 +715,7 @@ const SearchFields = ({
         { canSave && (
           <SaveList
             team={team}
-            query={query}
+            query={stateQuery}
             savedSearch={savedSearch}
             feedTeam={feedTeam}
             page={page}
@@ -742,10 +743,10 @@ SearchFields.propTypes = {
     title: PropTypes.string.isRequired,
     filters: PropTypes.string.isRequired,
   }),
-  query: PropTypes.object.isRequired, // FIXME rename to stateQuery
-  currentQuery: PropTypes.object.isRequired, // FIXME rename to appliedQuery
+  stateQuery: PropTypes.object.isRequired,
+  appliedQuery: PropTypes.object.isRequired,
   defaultQuery: PropTypes.object.isRequired,
-  setQuery: PropTypes.func.isRequired, // FIXME rename to setStateQuery
+  setStateQuery: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired, // onChange({ ... /* query */ }) => undefined
   team: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -654,14 +654,12 @@ const SearchFields = ({
 
   const stateQueryWithoutTimestamp = stripTimestamp(stateQuery);
   const appliedQueryWithoutTimestamp = stripTimestamp(appliedQuery);
-
-  console.log('stateQueryWithoutTimestamp', stateQueryWithoutTimestamp); // eslint-disable-line
-  console.log('appliedQueryWithoutTimestamp', appliedQueryWithoutTimestamp); // eslint-disable-line
+  const defaultQueryWithoutTimestamp = stripTimestamp(defaultQuery);
 
   // We can apply if the state query is dirty (differs from what is applied)
   const canApply = JSON.stringify(stateQueryWithoutTimestamp) !== JSON.stringify(appliedQueryWithoutTimestamp);
   // We can save if the applied query is different from the default query
-  const canSave = JSON.stringify(appliedQueryWithoutTimestamp) !== JSON.stringify(defaultQuery);
+  const canSave = JSON.stringify(appliedQueryWithoutTimestamp) !== JSON.stringify(defaultQueryWithoutTimestamp);
   const canReset = canApply || canSave;
 
   return (

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -193,8 +193,6 @@ const SearchFields = ({
     setStateQuery(newQuery);
   };
 
-  // const filterIsActive = () => Object.keys(query).filter(k => k !== 'keyword').length > 0;
-
   const handleDateChange = (value) => {
     const newQuery = { ...stateQuery, range: value };
     setStateQuery(newQuery);

--- a/src/app/components/search/SearchKeyword.js
+++ b/src/app/components/search/SearchKeyword.js
@@ -58,7 +58,7 @@ class SearchKeyword extends React.Component {
     this.setState({
       isSaving: false,
     });
-    this.props.setQuery(cleanQuery);
+    this.props.setStateQuery(cleanQuery);
     this.props.handleSubmit();
   };
 
@@ -73,7 +73,7 @@ class SearchKeyword extends React.Component {
     delete cleanQuery.file_handle;
     delete cleanQuery.file_url;
     delete cleanQuery.file_name;
-    this.props.setQuery(cleanQuery);
+    this.props.setStateQuery(cleanQuery);
   }
 
   keywordIsActive = () => {
@@ -106,7 +106,7 @@ class SearchKeyword extends React.Component {
     if (Object.keys(value.keyword_fields).length === 0) {
       delete newQuery.keyword_fields;
     }
-    this.props.setQuery(newQuery);
+    this.props.setStateQuery(newQuery);
     this.props.handleSubmit(null, newQuery);
   }
 
@@ -150,7 +150,7 @@ class SearchKeyword extends React.Component {
       newQuery.keyword = newKeyword;
       newQuery.sort = 'score';
     }
-    this.props.setQuery(newQuery);
+    this.props.setStateQuery(newQuery);
   }
 
   /*
@@ -178,7 +178,7 @@ class SearchKeyword extends React.Component {
         name: '',
       },
     });
-    this.props.setQuery(cleanQuery);
+    this.props.setStateQuery(cleanQuery);
   };
 
   subscribe() {
@@ -196,26 +196,11 @@ class SearchKeyword extends React.Component {
       }
       return false;
     });
-
-    pusher.subscribe(team.pusher_channel).bind('project_updated', 'SearchKeyword', (data, run) => {
-      if (clientSessionId !== data.actor_session_id) {
-        if (run) {
-          this.props.relay.forceFetch();
-          return true;
-        }
-        return {
-          id: `team-${team.dbid}`,
-          callback: this.props.relay.forceFetch,
-        };
-      }
-      return false;
-    });
   }
 
   unsubscribe() {
     const { pusher, team } = this.props;
     pusher.unsubscribe(team.pusher_channel, 'tagtext_updated', 'SearchKeyword');
-    pusher.unsubscribe(team.pusher_channel, 'project_updated', 'SearchKeyword');
   }
 
   handleUpload = (e) => {
@@ -324,7 +309,7 @@ SearchKeyword.propTypes = {
   pusher: pusherShape.isRequired,
   clientSessionId: PropTypes.string.isRequired,
   query: PropTypes.object.isRequired,
-  setQuery: PropTypes.func.isRequired,
+  setStateQuery: PropTypes.func.isRequired,
   team: PropTypes.shape({
     dbid: PropTypes.number.isRequired,
     pusher_channel: PropTypes.string.isRequired,

--- a/src/app/components/search/SearchKeyword.test.js
+++ b/src/app/components/search/SearchKeyword.test.js
@@ -33,7 +33,7 @@ describe('<SearchKeyword />', () => {
         keyword: 'search keyword',
       }}
       clientSessionId=""
-      setQuery={() => {}}
+      setStateQuery={() => {}}
       cleanupQuery={() => {}}
       handleSubmit={() => {}}
     />);
@@ -52,7 +52,7 @@ describe('<SearchKeyword />', () => {
       project={project}
       query={{}}
       clientSessionId=""
-      setQuery={() => {}}
+      setStateQuery={() => {}}
       cleanupQuery={() => {}}
       handleSubmit={() => {}}
     />);

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -552,7 +552,6 @@ SearchResultsComponent.defaultProps = {
   showExpand: false,
   icon: null,
   listActions: undefined,
-  page: undefined,
   resultType: 'default',
   hideFields: [],
   readOnlyFields: [],

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -26,33 +26,21 @@ import SearchRoute from '../../relay/SearchRoute';
 import { pageSize } from '../../urlHelpers';
 
 /**
- * Delete `esoffset`, `timestamp`, and maybe `projects`, `project_group_id` and `channels` -- whenever
+ * Delete `esoffset`, `timestamp` and `channels` -- whenever
  * they can be inferred from the URL or defaults.
  *
  * This is useful for building simple-as-possible URLs.
  */
-function simplifyQuery(query, project, projectGroup) {
+function simplifyQuery(query) {
   const ret = { ...query };
   delete ret.esoffset;
   delete ret.timestamp;
-  if (
-    ret.projects &&
-    (ret.projects.length === 1 && project && ret.projects[0] === project.dbid)
-  ) {
-    delete ret.projects;
-  }
-  if (
-    ret.project_group_id &&
-    (ret.project_group_id.length === 1 && projectGroup && ret.project_group_id[0] === projectGroup.dbid)
-  ) {
-    delete ret.project_group_id;
-  }
   if (ret.keyword && !ret.keyword.trim()) {
     delete ret.keyword;
   }
-  if (/\/(tipline-inbox|imported-reports)+/.test(window.location.pathname)) {
-    delete ret.channels;
-  }
+  // if (/\/(tipline-inbox|imported-reports)+/.test(window.location.pathname)) {
+  //   delete ret.channels;
+  // }
   if (/\/(unmatched-media)+/.test(window.location.pathname)) {
     delete ret.unmatched;
   }
@@ -63,10 +51,9 @@ function simplifyQuery(query, project, projectGroup) {
 function SearchResultsComponent({
   pusher,
   clientSessionId,
-  query: defaultQuery,
+  query: currentQuery,
+  defaultQuery,
   search,
-  project,
-  projectGroup,
   feedTeam,
   feed,
   searchUrlPrefix,
@@ -86,12 +73,11 @@ function SearchResultsComponent({
 }) {
   let pusherChannel = null;
   const [selectedProjectMediaIds, setSelectedProjectMediaIds] = React.useState([]);
-  const [query, setQuery] = React.useState(defaultQuery);
+  const [query, setQuery] = React.useState(currentQuery);
 
-  React.useEffect(() => {
-    const projectId = project ? project.dbid : 0;
-    relay.setVariables({ projectId });
-  }, []); // run only once, on load
+  console.log('defaultQuery', defaultQuery); // eslint-disable-line
+  console.log('currentQuery', currentQuery); // eslint-disable-line
+  console.log('query', query); // eslint-disable-line
 
   const onUnselectAll = () => {
     setSelectedProjectMediaIds([]);
@@ -164,7 +150,7 @@ function SearchResultsComponent({
       newQuery.sort = sortParams.key;
       newQuery.sort_type = sortParams.ascending ? 'ASC' : 'DESC';
     }
-    const cleanQuery = simplifyQuery(newQuery, project, projectGroup);
+    const cleanQuery = simplifyQuery(newQuery);
     navigateToQuery(cleanQuery);
   };
 
@@ -174,7 +160,7 @@ function SearchResultsComponent({
   if other filter is applied, the new query should keep the previous sort parameter
   */
   const handleChangeQuery = (newQuery) => {
-    const cleanQuery = simplifyQuery(newQuery, project, projectGroup);
+    const cleanQuery = simplifyQuery(newQuery);
     if (query.sort) {
       cleanQuery.sort = query.sort;
     }
@@ -189,7 +175,7 @@ function SearchResultsComponent({
   };
 
   const buildSearchUrlAtOffset = (offset) => {
-    const cleanQuery = simplifyQuery(query, project, projectGroup);
+    const cleanQuery = simplifyQuery(query);
     if (offset > 0) {
       cleanQuery.esoffset = offset;
     }
@@ -214,6 +200,7 @@ function SearchResultsComponent({
     return buildSearchUrlAtOffset(getBeginIndex() - pageSize);
   };
 
+  // Remove any malformed, partially formed or empty values from query
   const cleanupQuery = (oldQuery) => {
     const cleanQuery = { ...oldQuery };
     if (oldQuery.team_tasks) {
@@ -261,7 +248,7 @@ function SearchResultsComponent({
    * The URL will have a `listIndex` (so the ProjectMedia page can paginate). It
    * will also include `listPath` and `listQuery` ... _unless_ those parameters
    * are redundant. (For instance, if the query is
-   * `{ timestamp, esoffset, projects: [projectId] }` then the result can be `{}`
+   * `{ timestamp, esoffset }` then the result can be `{}`
    * because enough data is in `mediaUrlPrefix` to infer the properties.
    */
   const buildProjectMediaUrl = (projectMedia) => {
@@ -269,7 +256,7 @@ function SearchResultsComponent({
       return null;
     }
 
-    const cleanQuery = simplifyQuery(query, project, projectGroup);
+    const cleanQuery = simplifyQuery(query);
     const itemIndexInPage = search.medias.edges.findIndex(edge => edge.node === projectMedia);
     const listIndex = getBeginIndex() + itemIndexInPage;
     const urlParams = new URLSearchParams();
@@ -439,8 +426,6 @@ function SearchResultsComponent({
             <SearchKeyword
               query={query}
               setQuery={setQuery}
-              project={project}
-              hideFields={hideFields}
               title={title}
               team={team}
               showExpand={showExpand}
@@ -455,10 +440,10 @@ function SearchResultsComponent({
         <Box m={2}>
           <SearchFields
             query={query}
+            currentQuery={currentQuery}
+            defaultQuery={defaultQuery}
             setQuery={setQuery}
             onChange={handleChangeQuery}
-            project={project}
-            projectGroup={projectGroup}
             feedTeam={feedTeam}
             feed={feed}
             savedSearch={savedSearch}
@@ -480,7 +465,6 @@ function SearchResultsComponent({
               <BulkActions
                 team={team}
                 page={page}
-                project={project}
                 selectedProjectMedia={selectedProjectMedia}
                 selectedMedia={filteredSelectedProjectMediaIds}
                 onUnselectAll={onUnselectAll}
@@ -555,7 +539,6 @@ function SearchResultsComponent({
               </span>
             </span> : null
           }
-          project={project}
           page={page}
           search={search}
         />
@@ -566,12 +549,10 @@ function SearchResultsComponent({
 }
 
 SearchResultsComponent.defaultProps = {
-  project: null,
-  projectGroup: null,
   showExpand: false,
   icon: null,
   listActions: undefined,
-  page: undefined, // FIXME find a cleaner way to render Trash differently
+  page: undefined,
   resultType: 'default',
   hideFields: [],
   readOnlyFields: [],
@@ -592,14 +573,6 @@ SearchResultsComponent.propTypes = {
     id: PropTypes.string.isRequired, // TODO fill in props
     medias: PropTypes.shape({ edges: PropTypes.array.isRequired }).isRequired,
   }).isRequired,
-  project: PropTypes.shape({
-    id: PropTypes.string.isRequired, // TODO fill in props
-    dbid: PropTypes.number.isRequired,
-  }), // may be null
-  projectGroup: PropTypes.shape({
-    id: PropTypes.string.isRequired, // TODO fill in props
-    dbid: PropTypes.number.isRequired,
-  }), // may be null
   feedTeam: PropTypes.shape({
     id: PropTypes.string.isRequired,
     filters: PropTypes.object,
@@ -618,7 +591,7 @@ SearchResultsComponent.propTypes = {
   listSubtitle: PropTypes.object,
   icon: PropTypes.node,
   listActions: PropTypes.node, // or undefined
-  page: PropTypes.oneOf(['trash', 'list', 'feed']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
   resultType: PropTypes.string, // 'default' or 'feed', for now
   hideFields: PropTypes.arrayOf(PropTypes.string.isRequired), // or undefined
   readOnlyFields: PropTypes.arrayOf(PropTypes.string.isRequired), // or undefined
@@ -631,7 +604,6 @@ export { SearchResultsComponent as SearchResultsComponentTest };
 
 const SearchResultsContainer = Relay.createContainer(withPusher(SearchResultsComponent), {
   initialVariables: {
-    projectId: 0,
     pageSize,
   },
   fragments: {
@@ -690,10 +662,6 @@ const SearchResultsContainer = Relay.createContainer(withPusher(SearchResultsCom
                 first_item_at
                 last_item_at
               }
-              project {
-                dbid
-                id
-              }
               team {
                 slug
                 verification_statuses
@@ -745,25 +713,15 @@ function encodeQueryToMimicTheWayCheckApiGeneratesIds(query, teamSlug) {
   if (nKeys === 0) {
     return `{"parent":{"type":"team","slug":${JSON.stringify(teamSlug)}}}`;
   }
-  if (nKeys === 1 && query.projects && query.projects.length === 1) {
-    // JSON.stringify is pedantic -- the ID is a Number to begin with
-    const id = JSON.stringify(query.projects[0]);
-    return `{"parent":{"type":"project","id":${id}},"projects":[${id}]}`;
-  }
   // In all but these two cases, generate a separate query.
   return JSON.stringify(query);
 }
 
 export default function SearchResults({ query, teamSlug, ...props }) {
   const jsonEncodedQuery = encodeQueryToMimicTheWayCheckApiGeneratesIds(query, teamSlug);
-  let projectId = 0;
-  const { projects } = query;
-  if (projects && projects.length === 1) {
-    [projectId] = projects;
-  }
+
   const route = React.useMemo(() => new SearchRoute({
     jsonEncodedQuery,
-    projectId,
   }), [jsonEncodedQuery]);
 
   return (

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -42,33 +42,25 @@ const OffsetButton = styled.div`
 
 const Toolbar = ({
   actions,
-  similarAction,
   title,
-  project,
   page,
   team,
   search,
   resultType,
 }) => {
-  let perms = { permissions: {}, permission: '' };
-  if (project) {
-    perms = { permissions: project.permissions, permission: 'create Media' };
-  } else if (team) {
-    perms = { permissions: team.permissions, permission: 'create ProjectMedia' };
-  }
+  const perms = { permissions: team.permissions, permission: 'create ProjectMedia' };
 
   return (
     <StyledToolbar className={`toolbar toolbar__${resultType}`}>
       <FlexRow className="toolbar__flex-row">
         <Row className="toolbar__row">
-          {similarAction}
           <span className="toolbar__title">{title}</span>
           {actions}
         </Row>
         {['trash', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published'].indexOf(page) === -1 && resultType !== 'feed' ? (
           <Can {...perms}>
             <OffsetButton>
-              <CreateProjectMedia search={search} project={project} team={team} />
+              <CreateProjectMedia search={search} team={team} />
             </OffsetButton>
           </Can>
         ) : null}
@@ -78,11 +70,11 @@ const Toolbar = ({
 };
 
 Toolbar.defaultProps = {
-  page: undefined, // FIXME find a cleaner way to render Trash differently
+  page: undefined,
 };
 
 Toolbar.propTypes = {
-  page: PropTypes.oneOf(['trash', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published']), // FIXME find a cleaner way to render Trash differently
+  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
   // FIXME: Define other PropTypes
 };
 

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -69,10 +69,6 @@ const Toolbar = ({
   );
 };
 
-Toolbar.defaultProps = {
-  page: undefined,
-};
-
 Toolbar.propTypes = {
   page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
   // FIXME: Define other PropTypes

--- a/src/app/components/search/Toolbar.js
+++ b/src/app/components/search/Toolbar.js
@@ -57,7 +57,7 @@ const Toolbar = ({
           <span className="toolbar__title">{title}</span>
           {actions}
         </Row>
-        {['trash', 'list', 'imported-reports', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published'].indexOf(page) === -1 && resultType !== 'feed' ? (
+        {['trash', 'list', 'imported-fact-checks', 'tipline-inbox', 'spam', 'suggested-matches', 'feed', 'unmatched-media', 'published'].indexOf(page) === -1 && resultType !== 'feed' ? (
           <Can {...perms}>
             <OffsetButton>
               <CreateProjectMedia search={search} team={team} />

--- a/src/app/components/team/ImportedReports.js
+++ b/src/app/components/team/ImportedReports.js
@@ -29,7 +29,7 @@ export default function ImportedReports({ routeParams }) {
         defaultQuery={defaultQuery}
         hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
         readOnlyFields={['channels']}
-        page="imported-reports"
+        page="imported-fact-checks"
       />
     </ErrorBoundary>
   );

--- a/src/app/components/team/ImportedReports.js
+++ b/src/app/components/team/ImportedReports.js
@@ -9,9 +9,12 @@ import CheckChannels from '../../CheckChannels';
 import FileDownloadIcon from '../../icons/file_download.svg';
 
 export default function ImportedReports({ routeParams }) {
+  const defaultQuery = {
+    channels: [CheckChannels.FETCH],
+  };
   const query = {
     ...safelyParseJSON(routeParams.query, {}),
-    channels: [CheckChannels.FETCH],
+    ...defaultQuery,
   };
 
   return (
@@ -23,7 +26,9 @@ export default function ImportedReports({ routeParams }) {
         icon={<FileDownloadIcon />}
         teamSlug={routeParams.team}
         query={query}
-        hideFields={['feed_fact_checked_by', 'channels', 'cluster_teams', 'cluster_published_reports']}
+        defaultQuery={defaultQuery}
+        hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+        readOnlyFields={['channels']}
         page="imported-reports"
       />
     </ErrorBoundary>

--- a/src/app/components/team/Published.js
+++ b/src/app/components/team/Published.js
@@ -21,6 +21,7 @@ const Published = ({ routeParams }) => {
       teamSlug={routeParams.team}
       query={query}
       hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+      readOnlyFields={['report_status']}
       page="published"
     />
   );

--- a/src/app/components/team/Published.js
+++ b/src/app/components/team/Published.js
@@ -6,12 +6,17 @@ import Search from '../search/Search';
 import PublishedIcon from '../../icons/playlist_add_check.svg';
 
 const Published = ({ routeParams }) => {
-  const query = {
+  const defaultQuery = {
     report_status: ['published'],
     sort: 'recent_activity',
     sort_type: 'DESC',
+  };
+
+  const query = {
+    ...defaultQuery,
     ...safelyParseJSON(routeParams.query, {}),
   };
+
   return (
     <Search
       searchUrlPrefix={`/${routeParams.team}/published`}
@@ -20,6 +25,7 @@ const Published = ({ routeParams }) => {
       icon={<PublishedIcon />}
       teamSlug={routeParams.team}
       query={query}
+      defaultQuery={defaultQuery}
       hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
       readOnlyFields={['report_status']}
       page="published"

--- a/src/app/components/team/Spam.js
+++ b/src/app/components/team/Spam.js
@@ -8,13 +8,16 @@ import Search from '../search/Search';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 
 export default function Spam({ routeParams }) {
-  const query = {
-    ...safelyParseJSON(routeParams.query, {}),
+  const defaultQuery = {
     archived: CheckArchivedFlags.SPAM,
     parent: {
       type: 'team',
       slug: routeParams.team,
     },
+  };
+  const query = {
+    ...safelyParseJSON(routeParams.query, {}),
+    ...defaultQuery,
   };
 
   return (
@@ -32,6 +35,7 @@ export default function Spam({ routeParams }) {
         icon={<SpamIcon />}
         teamSlug={routeParams.team}
         query={query}
+        defaultQuery={defaultQuery}
         hideFields={['feed_fact_checked_by', 'user', 'cluster_teams', 'cluster_published_reports', 'archived']}
         page="spam"
       />

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -53,7 +53,8 @@ const SuggestedMatches = ({ routeParams }) => (
               icon={<LightbulbIcon />}
               teamSlug={routeParams.team}
               query={query}
-              hideFields={['feed_fact_checked_by', 'suggestions_count', 'cluster_teams', 'cluster_published_reports']}
+              hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+              readOnlyFields={['suggestions_count']}
               page="suggested-matches"
             />
           );

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -1,71 +1,44 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { QueryRenderer, graphql } from 'react-relay/compat';
-import Relay from 'react-relay/classic';
 import { FormattedMessage } from 'react-intl';
 import LightbulbIcon from '../../icons/lightbulb.svg';
 import ErrorBoundary from '../error/ErrorBoundary';
 import { safelyParseJSON } from '../../helpers';
 import Search from '../search/Search';
 
-const SuggestedMatches = ({ routeParams }) => (
-  <ErrorBoundary component="SuggestedMatches">
-    <QueryRenderer
-      environment={Relay.Store}
-      query={graphql`
-        query SuggestedMatchesQuery($slug: String!) {
-          team(slug: $slug) {
-            id
-            get_suggested_matches_filters
-          }
+const SuggestedMatches = ({ routeParams }) => {
+  const defaultQuery = {
+    suggestions_count: { min: 1 },
+    sort: 'recent_added',
+    sort_type: 'DESC',
+  };
+  const query = {
+    ...defaultQuery,
+    ...safelyParseJSON(routeParams.query, {}),
+  };
+  return (
+    <ErrorBoundary component="SuggestedMatches">
+      <Search
+        searchUrlPrefix={`/${routeParams.team}/suggested-matches`}
+        mediaUrlPrefix={`/${routeParams.team}/media`}
+        title={
+          <FormattedMessage
+            id="suggestedMatches.title"
+            defaultMessage="Suggestions"
+            description="Header for suggested media page"
+          />
         }
-      `}
-      variables={{
-        slug: routeParams.team,
-      }}
-      render={({ error, props }) => {
-        if (!error && props) {
-          const { team } = props;
-          // Should we discard savedQuery already?
-          const savedQuery = team.get_suggested_matches_filters || {};
-          const defaultQuery = {
-            suggestions_count: { min: 1 },
-            sort: 'recent_added',
-            sort_type: 'DESC',
-          };
-          let query = defaultQuery;
-          if (typeof routeParams.query === 'undefined' && Object.keys(savedQuery).length > 0) {
-            query = { ...savedQuery };
-          } else if (routeParams.query) {
-            query = { ...safelyParseJSON(routeParams.query, {}) };
-          }
-          return (
-            <Search
-              searchUrlPrefix={`/${routeParams.team}/suggested-matches`}
-              mediaUrlPrefix={`/${routeParams.team}/media`}
-              title={
-                <FormattedMessage
-                  id="suggestedMatches.title"
-                  defaultMessage="Suggestions"
-                  description="Header for suggested media page"
-                />
-              }
-              icon={<LightbulbIcon />}
-              teamSlug={routeParams.team}
-              query={query}
-              defaultQuery={defaultQuery}
-              hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
-              readOnlyFields={['suggestions_count']}
-              page="suggested-matches"
-            />
-          );
-        }
-        return null;
-      }}
-    />
-  </ErrorBoundary>
-);
+        icon={<LightbulbIcon />}
+        teamSlug={routeParams.team}
+        query={query}
+        defaultQuery={defaultQuery}
+        hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+        readOnlyFields={['suggestions_count']}
+        page="suggested-matches"
+      />
+    </ErrorBoundary>
+  );
+};
 
 SuggestedMatches.propTypes = {
   routeParams: PropTypes.shape({

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -27,17 +27,18 @@ const SuggestedMatches = ({ routeParams }) => (
       render={({ error, props }) => {
         if (!error && props) {
           const { team } = props;
+          // Should we discard savedQuery already?
           const savedQuery = team.get_suggested_matches_filters || {};
-          let query = {};
+          const defaultQuery = {
+            suggestions_count: { min: 1 },
+            sort: 'recent_added',
+            sort_type: 'DESC',
+          };
+          let query = defaultQuery;
           if (typeof routeParams.query === 'undefined' && Object.keys(savedQuery).length > 0) {
             query = { ...savedQuery };
-          } else {
-            query = {
-              suggestions_count: { min: 1 },
-              sort: 'recent_added',
-              sort_type: 'DESC',
-              ...safelyParseJSON(routeParams.query, {}),
-            };
+          } else if (routeParams.query) {
+            query = { ...safelyParseJSON(routeParams.query, {}) };
           }
           return (
             <Search
@@ -53,6 +54,7 @@ const SuggestedMatches = ({ routeParams }) => (
               icon={<LightbulbIcon />}
               teamSlug={routeParams.team}
               query={query}
+              defaultQuery={defaultQuery}
               hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
               readOnlyFields={['suggestions_count']}
               page="suggested-matches"

--- a/src/app/components/team/SuggestedMatches.test.js
+++ b/src/app/components/team/SuggestedMatches.test.js
@@ -10,15 +10,6 @@ describe('<SuggestedMatches />', () => {
       routeParams={{ team }}
     />);
 
-    const renderedMockSearch = wrapper.find('ReactRelayQueryRenderer').props().render(
-      {
-        error: false,
-        props: {
-          team,
-        },
-      },
-    );
-
-    expect(renderedMockSearch.props.query.sort).toBe('recent_added');
+    expect(wrapper.find('Search').props().query.sort).toBe('recent_added');
   });
 });

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -17,7 +17,6 @@ const TiplineInbox = ({ routeParams }) => (
         query TiplineInboxQuery($slug: String!) {
           team(slug: $slug) {
             verification_statuses
-            get_tipline_inbox_filters
           }
         }
       `}
@@ -28,18 +27,14 @@ const TiplineInbox = ({ routeParams }) => (
         if (!error && props) {
           const { team } = props;
           const defaultStatusId = team.verification_statuses.default;
-          // Should we discard savedQuery already?
-          const savedQuery = team.get_tipline_inbox_filters || {};
           const defaultQuery = {
             channels: [CheckChannels.ANYTIPLINE],
             verification_status: [defaultStatusId],
           };
-          let query = defaultQuery;
-          if (typeof routeParams.query === 'undefined' && Object.keys(savedQuery).length > 0) {
-            query = { ...savedQuery };
-          } else if (routeParams.query) {
-            query = { ...safelyParseJSON(routeParams.query, query) };
-          }
+          const query = {
+            ...defaultQuery,
+            ...safelyParseJSON(routeParams.query, {}),
+          };
           return (
             <Search
               searchUrlPrefix={`/${routeParams.team}/tipline-inbox`}

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -28,6 +28,7 @@ const TiplineInbox = ({ routeParams }) => (
         if (!error && props) {
           const { team } = props;
           const defaultStatusId = team.verification_statuses.default;
+          // Should we discard savedQuery already?
           const savedQuery = team.get_tipline_inbox_filters || {};
           const defaultQuery = {
             channels: [CheckChannels.ANYTIPLINE],

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute, relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { QueryRenderer, graphql } from 'react-relay/compat';
@@ -17,7 +16,6 @@ const TiplineInbox = ({ routeParams }) => (
       query={graphql`
         query TiplineInboxQuery($slug: String!) {
           team(slug: $slug) {
-            id
             verification_statuses
             get_tipline_inbox_filters
           }
@@ -31,31 +29,26 @@ const TiplineInbox = ({ routeParams }) => (
           const { team } = props;
           const defaultStatusId = team.verification_statuses.default;
           const savedQuery = team.get_tipline_inbox_filters || {};
-          let query = {};
+          const defaultQuery = {
+            channels: [CheckChannels.ANYTIPLINE],
+            verification_status: [defaultStatusId],
+          };
+          let query = defaultQuery;
           if (typeof routeParams.query === 'undefined' && Object.keys(savedQuery).length > 0) {
             query = { ...savedQuery };
-          } else {
-            query = typeof routeParams.query === 'undefined' ?
-              {
-                read: ['0'],
-                projects: ['-1'],
-                verification_status: [defaultStatusId],
-                ...safelyParseJSON(routeParams.query, {}),
-              } :
-              {
-                ...safelyParseJSON(routeParams.query, {}),
-              };
+          } else if (routeParams.query) {
+            query = { ...safelyParseJSON(routeParams.query, query) };
           }
-          query.channels = [CheckChannels.ANYTIPLINE];
           return (
             <Search
               searchUrlPrefix={`/${routeParams.team}/tipline-inbox`}
               mediaUrlPrefix={`/${routeParams.team}/media`}
-              title={<FormattedMessage id="tiplineInbox.title" defaultMessage="Tipline inbox" />}
+              title={<FormattedMessage id="tiplineInbox.title" defaultMessage="Tipline inbox" description="Title for the tipline inbox listing of items" />}
               icon={<InboxIcon />}
               teamSlug={routeParams.team}
               query={query}
-              hideFields={['feed_fact_checked_by', 'channels', 'cluster_teams', 'cluster_published_reports']}
+              defaultQuery={defaultQuery}
+              hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
               page="tipline-inbox"
             />
           );

--- a/src/app/components/team/Trash.js
+++ b/src/app/components/team/Trash.js
@@ -1,4 +1,3 @@
-/* eslint-disable @calm/react-intl/missing-attribute */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -9,13 +8,16 @@ import Search from '../search/Search';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 
 export default function Trash({ routeParams }) {
-  const query = {
-    ...safelyParseJSON(routeParams.query, {}),
+  const defaultQuery = {
     archived: CheckArchivedFlags.TRASHED,
     parent: {
       type: 'team',
       slug: routeParams.team,
     },
+  };
+  const query = {
+    ...safelyParseJSON(routeParams.query, {}),
+    ...defaultQuery,
   };
 
   return (
@@ -23,10 +25,11 @@ export default function Trash({ routeParams }) {
       <Search
         searchUrlPrefix={`/${routeParams.team}/trash`}
         mediaUrlPrefix={`/${routeParams.team}/media`}
-        title={<FormattedMessage id="trash.title" defaultMessage="Trash" />}
+        title={<FormattedMessage id="trash.title" defaultMessage="Trash" description="Title for the trash listing of items" />}
         icon={<DeleteIcon />}
         teamSlug={routeParams.team}
         query={query}
+        defaultQuery={defaultQuery}
         hideFields={['feed_fact_checked_by', 'user', 'cluster_teams', 'cluster_published_reports', 'archived']}
         page="trash"
       />

--- a/src/app/components/team/UnmatchedMedia.js
+++ b/src/app/components/team/UnmatchedMedia.js
@@ -6,12 +6,16 @@ import Search from '../search/Search';
 import UnmatchedIcon from '../../icons/unmatched.svg';
 
 const UnmatchedMedia = ({ routeParams }) => {
-  const query = {
-    unmatched: [1],
+  const defaultQuery = {
+    unmatched: ['1'],
     sort: 'recent_activity',
     sort_type: 'DESC',
-    ...safelyParseJSON(routeParams.query, {}),
   };
+  const query = {
+    ...safelyParseJSON(routeParams.query, {}),
+    ...defaultQuery,
+  };
+
   return (
     <Search
       searchUrlPrefix={`/${routeParams.team}/unmatched-media`}
@@ -20,6 +24,7 @@ const UnmatchedMedia = ({ routeParams }) => {
       icon={<UnmatchedIcon />}
       teamSlug={routeParams.team}
       query={query}
+      defaultQuery={defaultQuery}
       hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
       readOnlyFields={['unmatched']}
       page="unmatched-media"

--- a/src/app/components/team/UnmatchedMedia.js
+++ b/src/app/components/team/UnmatchedMedia.js
@@ -21,6 +21,7 @@ const UnmatchedMedia = ({ routeParams }) => {
       teamSlug={routeParams.team}
       query={query}
       hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+      readOnlyFields={['unmatched']}
       page="unmatched-media"
     />
   );


### PR DESCRIPTION
## Description

This ticket aims to fix the filters UX and make it consistent across core and custom lists.
The main part of this approach is to code around 3 different moments of a query:

- defaultQuery: which is the definition of a list
- stateQuery: which is whatever the user is composing
- appliedQuery: which is what is actually being displayed

This way we can code the buttons behavior like this:

canApply = stateQuery != appliedQuery
canSave = appliedQuery != defaultQuery
canReset = canApply || canSave

It also includes some cleaning up, removing dead code mentioning projects, adding string descriptions, normalizing the `page` prop, removing "update core lists" logic.

Channel filter now allows for selecting a specific tipline on the Tipline inbox filter.

Added SearchFieldDummy component for action-less filter fields.

References: CV2-775

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually and with integration tests that are already in place.

## Things to pay attention to during code review

- canReset, canApply & canSave logic as mentioned above
- merging defaultQuery and appliedQuery patterns

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

