### PR TITLE
Feature/cv2-3180: Text areas component

### DIFF
--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -3,12 +3,15 @@ import React, { useState } from 'react';
 import TextField from './TextField';
 
 const TextArea = React.forwardRef(({
+  autoGrow = true,
   ...inputProps
 }, ref) => {
   const [height, setHeight] = useState('auto');
 
   const handleChange = (event) => {
-    setHeight(`${event.target.scrollHeight}px`);
+    if (autoGrow) {
+      setHeight(`${event.target.scrollHeight}px`);
+    }
   };
 
   return <TextField textArea ref={ref} {...inputProps} style={{ height }} onChange={handleChange} />;

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -1,12 +1,17 @@
 // DESIGNS: https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=3606-26274&mode=design&t=ZVq51pKdIKdWZicO-4
-import React from 'react';
+import React, { useState } from 'react';
 import TextField from './TextField';
 
 const TextArea = React.forwardRef(({
   ...inputProps
-}, ref) => (
-  <TextField textArea ref={ref} {...inputProps} />
-));
+}, ref) => {
+  const [height, setHeight] = useState('auto');
 
-// eslint-disable-next-line import/no-unused-modules
+  const handleChange = (event) => {
+    setHeight(`${event.target.scrollHeight}px`);
+  };
+
+  return <TextField textArea ref={ref} {...inputProps} style={{ height }} onChange={handleChange} />;
+});
+
 export default TextArea;

--- a/src/app/components/cds/inputs/TextField.module.css
+++ b/src/app/components/cds/inputs/TextField.module.css
@@ -70,6 +70,8 @@
     textarea {
       max-width: 100%;
       min-height: 3.5em;
+      overflow-y: hidden;
+      resize: none;
     }
   }
 }


### PR DESCRIPTION
## Description

- Hide the browser resizable icon when it auto-grows and hide the scroll
- and add auto grow prop, that is true by default and controls the text area that should grow automatically (height) as the user types

Reference-CV2-3180

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)


## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

