### PR TITLE
Run the CloudFlare cache clear script in verbose mode for debugging purposes

### DIFF
--- a/scripts/clear-cf-cache.sh
+++ b/scripts/clear-cf-cache.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Clearing check-web cache at CloudFlare..."
-curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+curl -v --output "/dev/null" --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
         -H "Authorization: Bearer ${CF_CACHE_TOKEN}" -H "Content-Type: application/json" \
         --data '{"purge_everything":true}'
 


### PR DESCRIPTION
## Description

This change runs the CloudFlare cache clear script in debug mode for more information to resolve this issue.

References: https://meedan.atlassian.net/browse/DEVOPS-389

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I ran the script locally and it output request and response headers as expected.

## Things to pay attention to during code review

N/A.