### PR TITLE
CV2-775: Address QA feedback

### DIFF
--- a/localization/react-intl/src/app/components/search/SaveList.json
+++ b/localization/react-intl/src/app/components/search/SaveList.json
@@ -20,14 +20,19 @@
     "defaultMessage": "Save"
   },
   {
-    "id": "saveList.newList",
-    "description": "Dialog title and submit button label for saving changes to lists",
-    "defaultMessage": "Save list"
+    "id": "saveList.saveAsNewList",
+    "description": "Dialog title and submit button label for saving filters as new lists",
+    "defaultMessage": "Save as new list"
   },
   {
     "id": "saveList.title",
     "description": "Prompt for editing list name",
     "defaultMessage": "Enter new list name"
+  },
+  {
+    "id": "saveList.newList",
+    "description": "Dialog title and submit button label for saving changes to lists",
+    "defaultMessage": "Save list"
   },
   {
     "id": "saveList.cancel",

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -273,7 +273,7 @@ const SaveList = ({
       {/* Create a new list */}
       <ConfirmProceedDialog
         open={showNewDialog}
-        title={<FormattedMessage id="saveList.newList" defaultMessage="Save list" description="Dialog title and submit button label for saving changes to lists" />}
+        title={<FormattedMessage id="saveList.saveAsNewList" defaultMessage="Save as new list" description="Dialog title and submit button label for saving filters as new lists" />}
         body={
           <Box>
             <TextField
@@ -304,7 +304,11 @@ const SaveList = ({
       { savedSearch ?
         <ConfirmProceedDialog
           open={showExistingDialog}
-          title={<FormattedMessage id="saveList.newList" defaultMessage="Save list" description="Dialog title and submit button label for saving changes to lists" />}
+          title={
+            operation === 'CREATE' ?
+              <FormattedMessage id="saveList.saveAsNewList" defaultMessage="Save as new list" description="Dialog title and submit button label for saving filters as new lists" /> :
+              <FormattedMessage id="saveList.newList" defaultMessage="Save list" description="Dialog title and submit button label for saving changes to lists" />
+          }
           body={
             <FormControl fullWidth>
               <RadioGroup value={operation} onChange={(e) => { setOperation(e.target.value); }}>

--- a/src/app/components/team/Spam.js
+++ b/src/app/components/team/Spam.js
@@ -10,6 +10,8 @@ import CheckArchivedFlags from '../../CheckArchivedFlags';
 export default function Spam({ routeParams }) {
   const defaultQuery = {
     archived: CheckArchivedFlags.SPAM,
+    sort: 'recent_activity',
+    sort_type: 'DESC',
     parent: {
       type: 'team',
       slug: routeParams.team,

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -45,6 +45,7 @@ const TiplineInbox = ({ routeParams }) => (
               query={query}
               defaultQuery={defaultQuery}
               hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
+              readOnlyFields={['verification_status']}
               page="tipline-inbox"
             />
           );

--- a/src/app/components/team/Trash.js
+++ b/src/app/components/team/Trash.js
@@ -10,6 +10,8 @@ import CheckArchivedFlags from '../../CheckArchivedFlags';
 export default function Trash({ routeParams }) {
   const defaultQuery = {
     archived: CheckArchivedFlags.TRASHED,
+    sort: 'recent_activity',
+    sort_type: 'DESC',
     parent: {
       type: 'team',
       slug: routeParams.team,


### PR DESCRIPTION
## Description

Addressing feedback from QA. Couple of list sortings, one copy change and one read only filter!

References: CV2-775

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually that changes are applied:
- Tipline inbox "Rating" field is read only
- Saving new lists dialog title is "Save as new list"
- Spam and Trash are sorted by recent activity

## Things to pay attention to during code review

No big deal!

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

