### PR TITLE
Fix:  Large media card not displaying social media icon

### DIFF
--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -157,6 +157,7 @@ const MediaCardLargeContainer = createFragmentContainer(MediaCardLarge, graphql`
       type
       url
       quote
+      domain
       metadata
       embed_path
       file_path


### PR DESCRIPTION
## Description

get media domain on MediaCardLarg Component
Add this data to identify a YouTube link and show the icon correctly

Reference: CV2-3645

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

