### PR TITLE
Core lists counters

### DIFF
--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -25,6 +25,12 @@ import Can from '../../Can';
 import DeleteIcon from '../../../icons/delete.svg';
 import ReportIcon from '../../../icons/report.svg';
 import { withSetFlashMessage } from '../../FlashMessage';
+import { suggestedMatchesDefaultQuery } from '../../team/SuggestedMatches';
+import { importedReportsDefaultQuery } from '../../team/ImportedReports';
+import { unmatchedMediaDefaultQuery } from '../../team/UnmatchedMedia';
+import { publishedDefaultQuery } from '../../team/Published';
+import { tiplineInboxDefaultQuery } from '../../team/TiplineInbox';
+import ProjectsCoreListCounter from './ProjectsCoreListCounter';
 import styles from './Projects.module.css';
 
 const ProjectsComponent = ({
@@ -122,11 +128,6 @@ const ProjectsComponent = ({
             <ListItemText disableTypography className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.allItems" defaultMessage="All" description="Label for the 'All items' list displayed on the left sidebar" />
             </ListItemText>
-            <ListItemSecondaryAction className={styles.listItemCount}>
-              <small>
-                {team.medias_count}
-              </small>
-            </ListItemSecondaryAction>
           </ListItem>
         </Link>
 
@@ -148,7 +149,7 @@ const ProjectsComponent = ({
               <ListItemText disableTypography className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.tiplineInbox" defaultMessage="Inbox" description="Label for a list displayed on the left sidebar that includes items from is any tip line channel and the item status is unstarted" />
               </ListItemText>
-              <ListItemSecondaryAction className={styles.listItemCount} />
+              <ProjectsCoreListCounter query={{ ...tiplineInboxDefaultQuery, verification_status: [team.verification_statuses.default] }} />
             </ListItem>
           </Link>
         }
@@ -171,7 +172,7 @@ const ProjectsComponent = ({
             <ListItemText disableTypography className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.importedReports" defaultMessage="Imported" description="Label for a list displayed on the left sidebar that includes items from the 'Imported fact-checks' channel" />
             </ListItemText>
-            <ListItemSecondaryAction className={styles.listItemCount} />
+            <ProjectsCoreListCounter query={importedReportsDefaultQuery} />
           </ListItem>
         </Link>
 
@@ -195,7 +196,7 @@ const ProjectsComponent = ({
               <ListItemText disableTypography className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.suggestedMatches" defaultMessage="Suggestions" description="Label for a list displayed on the left sidebar that includes items that have a number of suggestions is more than 1" />
               </ListItemText>
-              <ListItemSecondaryAction className={styles.listItemCount} />
+              <ProjectsCoreListCounter query={suggestedMatchesDefaultQuery} />
             </ListItem>
           </Link>
         }
@@ -218,7 +219,7 @@ const ProjectsComponent = ({
               <ListItemText disableTypography className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.unmatchedMedia" defaultMessage="Unmatched media" description="Label for a list displayed on the left sidebar that includes items that were unmatched from other items (detached or rejected)" />
               </ListItemText>
-              <ListItemSecondaryAction className={styles.listItemCount} />
+              <ProjectsCoreListCounter query={unmatchedMediaDefaultQuery} />
             </ListItem>
           </Link>
         }
@@ -239,7 +240,7 @@ const ProjectsComponent = ({
             <ListItemText disableTypography className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.published" defaultMessage="Published" description="Label for a list displayed on the left sidebar that includes items that have published reports" />
             </ListItemText>
-            <ListItemSecondaryAction className={styles.listItemCount} />
+            <ProjectsCoreListCounter query={publishedDefaultQuery} />
           </ListItem>
         </Link>
 
@@ -396,6 +397,7 @@ ProjectsComponent.propTypes = {
     slug: PropTypes.string.isRequired,
     medias_count: PropTypes.number.isRequired,
     permissions: PropTypes.string.isRequired, // e.g., '{"create Media":true}'
+    verification_statuses: PropTypes.object.isRequired,
   }).isRequired,
   savedSearches: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/app/components/drawer/Projects/ProjectsCoreListCounter.js
+++ b/src/app/components/drawer/Projects/ProjectsCoreListCounter.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { QueryRenderer, graphql } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import PropTypes from 'prop-types';
+import ProjectsListCounter from './ProjectsListCounter';
+
+const ProjectsCoreListCounter = ({ query }) => (
+  <QueryRenderer
+    environment={Relay.Store}
+    query={graphql`
+      query ProjectsCoreListCounterQuery($query: String!) {
+        search(query: $query) {
+          number_of_results
+        }
+      }
+    `}
+    variables={{
+      query: JSON.stringify(query),
+    }}
+    render={({ props }) => {
+      if (props) {
+        return (<ProjectsListCounter numberOfItems={props.search.number_of_results} />);
+      }
+      return null;
+    }}
+  />
+);
+
+ProjectsCoreListCounter.propTypes = {
+  query: PropTypes.object.isRequired, // CheckSearch JSON query
+};
+
+export default ProjectsCoreListCounter;

--- a/src/app/components/drawer/Projects/ProjectsListCounter.js
+++ b/src/app/components/drawer/Projects/ProjectsListCounter.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import styles from './Projects.module.css';
+
+const ProjectsListCounter = ({ numberOfItems, intl }) => (
+  <ListItemSecondaryAction title={numberOfItems} className={styles.listItemCount}>
+    <small>
+      { !Number.isNaN(parseInt(numberOfItems, 10)) ?
+        new Intl.NumberFormat(intl.locale, { notation: 'compact', compactDisplay: 'short' }).format(numberOfItems) : null }
+    </small>
+  </ListItemSecondaryAction>
+);
+
+ProjectsListCounter.propTypes = {
+  numberOfItems: PropTypes.number.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(ProjectsListCounter);

--- a/src/app/components/drawer/Projects/ProjectsListCounter.test.js
+++ b/src/app/components/drawer/Projects/ProjectsListCounter.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import ProjectsListCounter from './ProjectsListCounter';
+
+describe('<ProjectsListCounter />', () => {
+  it('renders nothing if numberOfItems is not a number', () => {
+    const counter = mountWithIntl(<ProjectsListCounter numberOfItems="test" />);
+    expect(counter.find('small').text()).toEqual('');
+  });
+
+
+  it('renders a small number as is', () => {
+    const counter = mountWithIntl(<ProjectsListCounter numberOfItems={12} />);
+    expect(counter.find('small').text()).toEqual('12');
+  });
+
+  it('makes long numbers shorter', () => {
+    const counter = mountWithIntl(<ProjectsListCounter numberOfItems={12345} />);
+    expect(counter.find('small').text()).toEqual('12K');
+  });
+});

--- a/src/app/components/drawer/Projects/ProjectsListItem.js
+++ b/src/app/components/drawer/Projects/ProjectsListItem.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
 import { Link } from 'react-router';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ProjectsListCounter from './ProjectsListCounter';
 import styles from './Projects.module.css';
 
 const ProjectsListItem = ({
@@ -16,7 +15,6 @@ const ProjectsListItem = ({
   icon,
   routePrefix,
   routeSuffix,
-  intl,
 }) => {
   const handleClick = () => {
     if (onClick) {
@@ -55,12 +53,7 @@ const ProjectsListItem = ({
             {project.title || project.name}
           </span>
         </ListItemText>
-        <ListItemSecondaryAction title={project.medias_count} className={styles.listItemCount}>
-          <small>
-            { !Number.isNaN(parseInt(project.medias_count, 10)) ?
-              new Intl.NumberFormat(intl.locale, { notation: 'compact', compactDisplay: 'short' }).format(project.medias_count) : null }
-          </small>
-        </ListItemSecondaryAction>
+        <ProjectsListCounter numberOfItems={project.medias_count} />
       </ListItem>
     </Link>
   );
@@ -89,10 +82,9 @@ ProjectsListItem.propTypes = {
     medias_count: PropTypes.number,
     project_group_id: PropTypes.number,
   }).isRequired,
-  intl: intlShape.isRequired,
   onClick: PropTypes.func,
   isActive: PropTypes.bool,
   className: PropTypes.string,
 };
 
-export default injectIntl(ProjectsListItem);
+export default ProjectsListItem;

--- a/src/app/components/drawer/Projects/index.js
+++ b/src/app/components/drawer/Projects/index.js
@@ -40,6 +40,7 @@ const Projects = () => {
             slug
             medias_count
             permissions
+            verification_statuses
             smooch_bot: team_bot_installation(bot_identifier: "smooch") {
               id
             }

--- a/src/app/components/team/ImportedReports.js
+++ b/src/app/components/team/ImportedReports.js
@@ -8,10 +8,13 @@ import Search from '../search/Search';
 import CheckChannels from '../../CheckChannels';
 import FileDownloadIcon from '../../icons/file_download.svg';
 
+const defaultQuery = {
+  channels: [CheckChannels.FETCH],
+};
+
+export { defaultQuery as importedReportsDefaultQuery };
+
 export default function ImportedReports({ routeParams }) {
-  const defaultQuery = {
-    channels: [CheckChannels.FETCH],
-  };
   const query = {
     ...safelyParseJSON(routeParams.query, {}),
     ...defaultQuery,
@@ -34,6 +37,7 @@ export default function ImportedReports({ routeParams }) {
     </ErrorBoundary>
   );
 }
+
 ImportedReports.propTypes = {
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired,

--- a/src/app/components/team/Published.js
+++ b/src/app/components/team/Published.js
@@ -5,9 +5,13 @@ import { safelyParseJSON } from '../../helpers';
 import Search from '../search/Search';
 import PublishedIcon from '../../icons/playlist_add_check.svg';
 
+const defaultFilters = {
+  report_status: ['published'],
+};
+
 const Published = ({ routeParams }) => {
   const defaultQuery = {
-    report_status: ['published'],
+    ...defaultFilters,
     sort: 'recent_activity',
     sort_type: 'DESC',
   };
@@ -40,4 +44,5 @@ Published.propTypes = {
   }).isRequired,
 };
 
+export { defaultFilters as publishedDefaultQuery };
 export default Published;

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -6,9 +6,13 @@ import ErrorBoundary from '../error/ErrorBoundary';
 import { safelyParseJSON } from '../../helpers';
 import Search from '../search/Search';
 
+const defaultFilters = {
+  suggestions_count: { min: 1 },
+};
+
 const SuggestedMatches = ({ routeParams }) => {
   const defaultQuery = {
-    suggestions_count: { min: 1 },
+    ...defaultFilters,
     sort: 'recent_added',
     sort_type: 'DESC',
   };
@@ -47,4 +51,5 @@ SuggestedMatches.propTypes = {
   }).isRequired,
 };
 
+export { defaultFilters as suggestedMatchesDefaultQuery };
 export default SuggestedMatches;

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -9,6 +9,11 @@ import Search from '../search/Search';
 import CheckChannels from '../../CheckChannels';
 import InboxIcon from '../../icons/inbox.svg';
 
+const defaultQuery = {
+  channels: [CheckChannels.ANYTIPLINE],
+  verification_status: [], // To be set to the value returned by the backend
+};
+
 const TiplineInbox = ({ routeParams }) => (
   <ErrorBoundary component="TiplineInbox">
     <QueryRenderer
@@ -27,10 +32,7 @@ const TiplineInbox = ({ routeParams }) => (
         if (!error && props) {
           const { team } = props;
           const defaultStatusId = team.verification_statuses.default;
-          const defaultQuery = {
-            channels: [CheckChannels.ANYTIPLINE],
-            verification_status: [defaultStatusId],
-          };
+          defaultQuery.verification_status = [defaultStatusId];
           const query = {
             ...defaultQuery,
             ...safelyParseJSON(routeParams.query, {}),
@@ -63,4 +65,5 @@ TiplineInbox.propTypes = {
   }).isRequired,
 };
 
+export { defaultQuery as tiplineInboxDefaultQuery };
 export default TiplineInbox;

--- a/src/app/components/team/UnmatchedMedia.js
+++ b/src/app/components/team/UnmatchedMedia.js
@@ -5,9 +5,13 @@ import { safelyParseJSON } from '../../helpers';
 import Search from '../search/Search';
 import UnmatchedIcon from '../../icons/unmatched.svg';
 
+const defaultFilters = {
+  unmatched: ['1'],
+};
+
 const UnmatchedMedia = ({ routeParams }) => {
   const defaultQuery = {
-    unmatched: ['1'],
+    ...defaultFilters,
     sort: 'recent_activity',
     sort_type: 'DESC',
   };
@@ -38,5 +42,7 @@ UnmatchedMedia.propTypes = {
     query: PropTypes.string, // JSON-encoded value; can be empty/null/invalid
   }).isRequired,
 };
+
+export { defaultFilters as unmatchedMediaDefaultQuery };
 
 export default UnmatchedMedia;


### PR DESCRIPTION
## Description

Adding counters to core lists on the left sidebar. Includes a refactoring that extracts the counter as its own component.

Reference: CV2-3720.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

All core lists links on the left sidebar (inbox, imported, unmatched, suggestions and published) should show a counter next to them.

## Things to pay attention to during code review

At this point there is too much logic shared by all core lists. I would like to rethink their architecture on the frontend.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

