### PR TITLE
CV2-3728: show assign to for unconfirmed items

### DIFF
--- a/src/app/components/media/MediaActionsMenuButton.js
+++ b/src/app/components/media/MediaActionsMenuButton.js
@@ -70,7 +70,7 @@ class MediaActionsMenuButton extends React.PureComponent {
     const menuItems = [];
 
     if (isParent) {
-      if (can(projectMedia.permissions, 'update Status') && projectMedia.archived === CheckArchivedFlags.NONE) {
+      if (can(projectMedia.permissions, 'update Status') && [CheckArchivedFlags.NONE, CheckArchivedFlags.UNCONFIRMED].includes(projectMedia.archived)) {
         menuItems.push((
           <MenuItem
             key="mediaActions.assign"


### PR DESCRIPTION
## Description

Show `Assign to ...` action for unconfirmed  items 

References: CV2-3728

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Go to unconfirmed item and check action menu item list 
Result: `Assign to ...`  should appear for unconfirmed items

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

