### PR TITLE
Fix: Shrink  text area when deleting text

### DIFF
--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -88,6 +88,16 @@ const SandboxComponent = ({ admin }) => {
     setButtonVariant(event.target.value);
   };
 
+  const [textareaRows, setTextareaRows] = React.useState('none');
+  const onChangeTextareaRows = (event) => {
+    setTextareaRows(event.target.value);
+  };
+
+  const [textareaMaxHeight, setTextareaMaxHeight] = React.useState('none');
+  const onChangeTextareaMaxHeight = (event) => {
+    setTextareaMaxHeight(event.target.value);
+  };
+
   const [buttonSize, setButtonSize] = React.useState('default');
   const onChangeButtonSize = (event) => {
     setButtonSize(event.target.value);
@@ -345,6 +355,28 @@ const SandboxComponent = ({ admin }) => {
             </div>
             <ul>
               <li>
+                <Select
+                  label="Row Count"
+                  onChange={onChangeTextareaRows}
+                >
+                  <option value="none">none</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="4">4</option>
+                  <option value="8">8</option>
+                </Select>
+              </li>
+              <li>
+                <Select
+                  label="Max height"
+                  onChange={onChangeTextareaMaxHeight}
+                >
+                  <option value="none">none</option>
+                  <option value="48px">48px</option>
+                  <option value="96px">96px</option>
+                </Select>
+              </li>
+              <li>
                 <SwitchComponent
                   label="AutoGrow"
                   labelPlacement="top"
@@ -391,12 +423,18 @@ const SandboxComponent = ({ admin }) => {
               <LimitedTextArea
                 maxChars={500}
                 setValue={setLimitedText}
+                placeholder="I am a placeholder for limited textarea"
                 label="I am a limited textarea title"
                 value={limitedText}
                 helpContent={textareaHelp ? 'I can be of help to limited textarea' : null}
                 autoGrow={textareaAutogrow}
+                rows={textareaRows === 'none' ? undefined : textareaRows}
                 required={textareaRequired}
                 disabled={textareaDisabled}
+                style={{
+                  maxHeight: textareaMaxHeight,
+                  overflowY: textareaMaxHeight === 'none' ? 'hidden' : 'scroll',
+                }}
               />
               :
               <TextArea
@@ -404,8 +442,13 @@ const SandboxComponent = ({ admin }) => {
                 label="I am a textarea title"
                 helpContent={textareaHelp ? 'I can be of help to textarea' : null}
                 autoGrow={textareaAutogrow}
+                rows={textareaRows === 'none' ? undefined : textareaRows}
                 required={textareaRequired}
                 disabled={textareaDisabled}
+                style={{
+                  maxHeight: textareaMaxHeight,
+                  overflowY: textareaMaxHeight === 'none' ? 'hidden' : 'scroll',
+                }}
               />
             }
           </div>

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -52,6 +52,11 @@ const SandboxComponent = ({ admin }) => {
   const [switchesHelp, setSwitchesHelp] = React.useState(Boolean(false));
   const [switched, setSwitchExample] = React.useState(Boolean(false));
   const [limitedText, setLimitedText] = React.useState('Hello this is the initial limited text state');
+  const [textareaHelp, setTextareaHelp] = React.useState(Boolean(true));
+  const [textareaAutogrow, setTextareaAutogrow] = React.useState(Boolean(true));
+  const [textareaLimited, setTextareaLimited] = React.useState(Boolean(false));
+  const [textareaDisabled, setTextareaDisabled] = React.useState(Boolean(false));
+  const [textareaRequired, setTextareaRequired] = React.useState(Boolean(true));
 
   const [switchLabelPlacement, setSwitchLabelPlacement] = React.useState('top');
   const onChangeSwitchLabelPlacement = (event) => {
@@ -300,46 +305,6 @@ const SandboxComponent = ({ admin }) => {
         </div>
         <div className={styles.componentWrapper}>
           <div className={cx('typography-subtitle2', [styles.componentName])}>
-            TextArea
-            <a
-              href="https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=3606-26274&mode=design&t=ZVq51pKdIKdWZicO-4"
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Figma Designs"
-              className={styles.figmaLink}
-            >
-              <FigmaColorLogo />
-            </a>
-          </div>
-          <TextArea
-            placeholder="I am a placeholder for textarea"
-            label="I am a textarea title"
-            helpContent="I can be of help to textarea"
-            required
-          />
-        </div>
-        <div className={styles.componentWrapper}>
-          <div className={cx('typography-subtitle2', [styles.componentName])}>
-            LimitedTextArea
-            <a
-              href="https://www.figma.com/file/bQWUXJItRRX8xO3uQ9FWdg/Multimedia-Newsletter-%2B-Report?type=design&node-id=656-50446&mode=design&t=PjtorENpol0lp5QG-4"
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Figma Designs"
-              className={styles.figmaLink}
-            >
-              <FigmaColorLogo />
-            </a>
-          </div>
-          <LimitedTextArea
-            maxChars={500}
-            label="Limited text area"
-            value={limitedText}
-            setValue={setLimitedText}
-          />
-        </div>
-        <div className={styles.componentWrapper}>
-          <div className={cx('typography-subtitle2', [styles.componentName])}>
             Select
             <a
               href="https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=34-5720&mode=design&t=ZVq51pKdIKdWZicO-4"
@@ -363,6 +328,87 @@ const SandboxComponent = ({ admin }) => {
             <option value="2">two</option>
             <option value="3">three</option>
           </Select>
+        </div>
+        <div className={styles.componentWrapper}>
+          <div className={styles.componentControls}>
+            <div className={cx('typography-subtitle2', [styles.componentName])}>
+              TextArea
+              <a
+                href="https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=3606-26274&mode=design&t=ZVq51pKdIKdWZicO-4"
+                rel="noopener noreferrer"
+                target="_blank"
+                title="Figma Designs"
+                className={styles.figmaLink}
+              >
+                <FigmaColorLogo />
+              </a>
+            </div>
+            <ul>
+              <li>
+                <SwitchComponent
+                  label="AutoGrow"
+                  labelPlacement="top"
+                  checked={textareaAutogrow}
+                  onChange={() => setTextareaAutogrow(!textareaAutogrow)}
+                />
+              </li>
+              <li>
+                <SwitchComponent
+                  label="Limit Character Count"
+                  labelPlacement="top"
+                  checked={textareaLimited}
+                  onChange={() => setTextareaLimited(!textareaLimited)}
+                />
+              </li>
+              <li>
+                <SwitchComponent
+                  label="Show Help"
+                  labelPlacement="top"
+                  checked={textareaHelp}
+                  onChange={() => setTextareaHelp(!textareaHelp)}
+                />
+              </li>
+              <li>
+                <SwitchComponent
+                  label="Disabled"
+                  labelPlacement="top"
+                  checked={textareaDisabled}
+                  onChange={() => setTextareaDisabled(!textareaDisabled)}
+                />
+              </li>
+              <li>
+                <SwitchComponent
+                  label="Required"
+                  labelPlacement="top"
+                  checked={textareaRequired}
+                  onChange={() => setTextareaRequired(!textareaRequired)}
+                />
+              </li>
+            </ul>
+          </div>
+          <div className={styles.componentBlockVariants}>
+            { textareaLimited ?
+              <LimitedTextArea
+                maxChars={500}
+                setValue={setLimitedText}
+                label="I am a limited textarea title"
+                value={limitedText}
+                helpContent={textareaHelp ? 'I can be of help to limited textarea' : null}
+                autoGrow={textareaAutogrow}
+                required={textareaRequired}
+                disabled={textareaDisabled}
+              />
+              :
+              <TextArea
+                placeholder="I am a placeholder for textarea"
+                label="I am a textarea title"
+                helpContent={textareaHelp ? 'I can be of help to textarea' : null}
+                autoGrow={textareaAutogrow}
+                required={textareaRequired}
+                disabled={textareaDisabled}
+              />
+            }
+          </div>
         </div>
         <div className={styles.componentWrapper}>
           <div className={styles.componentControls}>

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -1,43 +1,32 @@
 // DESIGNS: https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=3606-26274&mode=design&t=ZVq51pKdIKdWZicO-4
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import TextField from './TextField';
 
 const TextArea = React.forwardRef(({
   autoGrow,
-  maxHeight,
-  minHeight: minHeightProp,
+  rows,
   ...inputProps
 }, ref) => {
-  const [height, setHeight] = useState('auto');
-
   const handleChange = (event) => {
-    const minHeight = minHeightProp || 0;
-    const newHeight = `${event.target.scrollHeight}px`;
-    // if the input is empty reset the height
-    if (event.target.value === '') {
-      setHeight('auto');
-    } else if ((autoGrow && event.target.scrollHeight >= minHeight) && (!maxHeight || event.target.scrollHeight <= maxHeight)) {
-      setHeight(newHeight);
-    }
-    if (inputProps.onChange) {
-      inputProps.onChange(event);
+    event.target.parentNode.setAttribute('data-replicated-value', event.target.value);
+    if (inputProps.onInput) {
+      inputProps.onInput(event);
     }
   };
 
   const customStyle = inputProps.style || {};
-  return <TextField textArea autoGrow={autoGrow} ref={ref} {...inputProps} style={{ ...customStyle, height }} onChange={handleChange} />;
+  return <TextField textArea autoGrow={autoGrow} ref={ref} {...inputProps} style={{ ...customStyle }} rows={rows} onInput={handleChange} />;
 });
 
 TextArea.defaultProps = {
   autoGrow: true,
-  maxHeight: null,
+  rows: '1',
 };
 
 TextArea.propTypes = {
   autoGrow: PropTypes.bool,
-  maxHeight: PropTypes.number,
-  minHeight: PropTypes.number.isRequired,
+  rows: PropTypes.string,
 };
 
 export default TextArea;

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -10,20 +10,14 @@ const TextArea = React.forwardRef(({
   ...inputProps
 }, ref) => {
   const [height, setHeight] = useState('auto');
-  const [initialHeight, setInitialHeight] = useState('auto');
-
-  React.useEffect(() => {
-    // Get the initial height when the component mounts
-    setInitialHeight(minHeightProp || ref?.current?.offsetHeight);
-  }, []);
 
   const handleChange = (event) => {
-    const minHeight = minHeightProp || event.target.offsetHeight;
+    const minHeight = minHeightProp || 0;
     const newHeight = `${event.target.scrollHeight}px`;
-    // if the input is empty reset the height to minHeight
+    // if the input is empty reset the height
     if (event.target.value === '') {
-      setHeight(initialHeight);
-    } else if (autoGrow && event.target.scrollHeight >= minHeight && (!maxHeight || event.target.scrollHeight <= maxHeight)) {
+      setHeight('auto');
+    } else if ((autoGrow && event.target.scrollHeight >= minHeight) && (!maxHeight || event.target.scrollHeight <= maxHeight)) {
       setHeight(newHeight);
     }
     if (inputProps.onChange) {

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -63,6 +63,7 @@ const TextField = React.forwardRef(({
         inputStyles['input-container'],
         {
           [styles['textarea-container']]: textArea,
+          [styles['textarea-autoGrow']]: autoGrow,
         })
       }
       >
@@ -82,7 +83,6 @@ const TextField = React.forwardRef(({
                 [styles.outlined]: variant === 'outlined',
                 [styles['input-icon-left']]: iconLeft,
                 [styles['input-icon-right']]: iconRight,
-                [styles['textarea-autoGrow']]: autoGrow,
               })
             }
             ref={ref}

--- a/src/app/components/cds/inputs/TextField.module.css
+++ b/src/app/components/cds/inputs/TextField.module.css
@@ -69,7 +69,7 @@
   &.textarea-container {
     textarea {
       max-width: 100%;
-      min-height: 3.5em;
+      min-height: 5em;
 
       &.textarea-autoGrow {
         overflow-y: hidden;

--- a/src/app/components/cds/inputs/TextField.module.css
+++ b/src/app/components/cds/inputs/TextField.module.css
@@ -1,10 +1,11 @@
+/* stylelint-disable no-descending-specificity */
 .textfield-container {
   .input {
     background-color: var(--otherWhite);
     border: 2px solid var(--grayBorderMain);
     border-radius: 8px;
     color: var(--textPrimary);
-    font: 400 14px var(--fontStackSans);
+    font: inherit;
     height: 100%;
     letter-spacing: .15px;
     line-height: 20px;
@@ -67,14 +68,47 @@
   }
 
   &.textarea-container {
-    textarea {
-      max-width: 100%;
-      min-height: 5em;
+    &.textarea-autoGrow {
+      display: grid;
 
-      &.textarea-autoGrow {
-        overflow-y: hidden;
+      &::after {
+
+        /* Note the weird space! Needed to preventy jumpy behavior */
+        content: attr(data-replicated-value) ' ';
+
+        /* Hidden from view, clicks, and screen readers */
+        visibility: hidden;
+
+        /* This is how textarea text behaves */
+        white-space: pre-wrap;
+      }
+
+      > textarea {
+        height: auto;
+
+        /* Firefox shows scrollbar on growth, you can hide like this. */
+        overflow: hidden;
+
+        /* You could leave this, but after a user resizes, then it ruins the auto sizing */
         resize: none;
       }
+
+      > textarea,
+      &::after {
+
+        /* Identical styling required!! */
+        border: 1px solid inherit;
+        font: inherit;
+
+        /* Place on top of each other */
+        grid-area: 1 / 1 / 2 / 2;
+        line-height: 20px;
+        padding: .5rem;
+      }
+    }
+
+    textarea {
+      max-width: 100%;
     }
   }
 }

--- a/src/app/components/sandbox.module.css
+++ b/src/app/components/sandbox.module.css
@@ -42,7 +42,8 @@
         }
       }
 
-      .componentInlineVariants {
+      .componentInlineVariants,
+      .componentBlockVariants {
         display: inline-flex;
         flex-direction: row;
         gap: 32px;
@@ -51,6 +52,10 @@
         &.componentInlineGreyVariants {
           background-color: var(--grayBackground);
         }
+      }
+
+      .componentBlockVariants {
+        display: block;
       }
 
       .componentControls {
@@ -69,7 +74,8 @@
           }
         }
 
-        + .componentInlineVariants {
+        + .componentInlineVariants,
+        + .componentBlockVariants {
           border: solid 4px var(--brandBackground);
           border-radius: 0 0 5px 5px;
           padding: 20px;


### PR DESCRIPTION
## Description

update min-heigt on CSS file and remove the attempt to get the initial height, as we are getting the undefined value for ref.
obs: It is reduced when you use the backspace but not immediately if we select and delete part of the text
Reference: CV2-3180

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

