### PR TITLE
Fix integration tests

### DIFF
--- a/src/app/components/cds/menus-lists-dialogs/TagList.js
+++ b/src/app/components/cds/menus-lists-dialogs/TagList.js
@@ -114,6 +114,7 @@ const TagList = ({
         { tags.length > 0 && tags.map(tag => (
           <Chip
             label={tag}
+            className="tag-list__chip"
             key={tag}
             onClick={onClickTag ? () => onClickTag(tag) : null}
             onRemove={!readOnly ? () => {

--- a/test/spec/source_spec.rb
+++ b/test/spec/source_spec.rb
@@ -4,7 +4,6 @@ shared_examples 'source' do
   it 'should check, edit and remove source info', bin2: true do
     api_create_team_and_bot_and_link_and_redirect_to_media_page({ url: 'https://g1.globo.com/' })
     wait_for_selector('.media')
-    wait_for_selector('.tag-menu__icon')
     wait_for_selector('.media-tab__source').click
     wait_for_selector("//span[contains(text(), 'Go to settings')]", :xpath)
     wait_for_selector('#media__source')

--- a/test/spec/tag_spec.rb
+++ b/test/spec/tag_spec.rb
@@ -61,8 +61,8 @@ shared_examples 'tag' do
     create_media('new media')
     sleep 30 # wait for the items to be indexed in the Elasticsearch
     wait_for_selector('.media__heading').click
-    wait_for_selector('.media-tags__tag')
-    expect(@driver.page_source.include?('tag added automatically')).to be(true)
+    wait_for_selector('.media-card-large')
+    @wait.until { @driver.page_source.include?('tag added automatically') }
   end
 
   it 'should add a tag, reject duplicated tag', bin3: true, quick: true do
@@ -71,11 +71,10 @@ shared_examples 'tag' do
     wait_for_selector('.media__heading').click
     wait_for_selector('.media-card-large')
     # Try to add duplicate
-    wait_for_selector('.tag-menu__icon').click
+    wait_for_selector('#tag-list__add-icon').click
     fill_field('.multiselector__search-input input', 'TAG')
     wait_for_selector('#tag-menu__create-button').click
     @driver.action.send_keys(:enter).perform
-    # Verify that 'Tag already exists' message is displayed
-    @wait.until { @driver.page_source.include?('Tag already exists') }
+    expect(@driver.find_elements(:css, '.tag-list__chip').length == 1).to be(true)
   end
 end


### PR DESCRIPTION
## Description

Fix integration tests that are failing due to UI changes in the Tags feature.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

