### PR TITLE
move setting maxheight on the textarea component CV2-3180

### DIFF
--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -374,6 +374,7 @@ const SandboxComponent = ({ admin }) => {
                   <option value="none">none</option>
                   <option value="48px">48px</option>
                   <option value="96px">96px</option>
+                  <option value="180px">180px</option>
                 </Select>
               </li>
               <li>
@@ -431,10 +432,7 @@ const SandboxComponent = ({ admin }) => {
                 rows={textareaRows === 'none' ? undefined : textareaRows}
                 required={textareaRequired}
                 disabled={textareaDisabled}
-                style={{
-                  maxHeight: textareaMaxHeight,
-                  overflowY: textareaMaxHeight === 'none' ? 'hidden' : 'scroll',
-                }}
+                maxHeight={textareaMaxHeight === 'none' ? undefined : textareaMaxHeight}
               />
               :
               <TextArea
@@ -445,10 +443,7 @@ const SandboxComponent = ({ admin }) => {
                 rows={textareaRows === 'none' ? undefined : textareaRows}
                 required={textareaRequired}
                 disabled={textareaDisabled}
-                style={{
-                  maxHeight: textareaMaxHeight,
-                  overflowY: textareaMaxHeight === 'none' ? 'hidden' : 'scroll',
-                }}
+                maxHeight={textareaMaxHeight === 'none' ? undefined : textareaMaxHeight}
               />
             }
           </div>

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -5,6 +5,7 @@ import TextField from './TextField';
 
 const TextArea = React.forwardRef(({
   autoGrow,
+  maxHeight,
   rows,
   ...inputProps
 }, ref) => {
@@ -16,16 +17,18 @@ const TextArea = React.forwardRef(({
   };
 
   const customStyle = inputProps.style || {};
-  return <TextField textArea autoGrow={autoGrow} ref={ref} {...inputProps} style={{ ...customStyle }} rows={rows} onInput={handleChange} />;
+  return <TextField textArea autoGrow={autoGrow} maxHeight={maxHeight} ref={ref} {...inputProps} style={{ ...customStyle }} rows={rows} onInput={handleChange} />;
 });
 
 TextArea.defaultProps = {
   autoGrow: true,
+  maxHeight: null,
   rows: '1',
 };
 
 TextArea.propTypes = {
   autoGrow: PropTypes.bool,
+  maxHeight: PropTypes.string,
   rows: PropTypes.string,
 };
 

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -35,6 +35,7 @@ const TextField = React.forwardRef(({
   variant,
   textArea,
   autoGrow,
+  maxHeight,
   componentProps,
   ...inputProps
 }, ref) => {
@@ -58,14 +59,19 @@ const TextField = React.forwardRef(({
           { required && <span className={inputStyles.required}>*<FormattedMessage id="textfield.required" defaultMessage="Required" description="A label to indicate that a form field must be filled out" /></span>}
         </div>
       )}
-      <div className={cx(
-        styles['textfield-container'],
-        inputStyles['input-container'],
-        {
-          [styles['textarea-container']]: textArea,
-          [styles['textarea-autoGrow']]: autoGrow,
-        })
-      }
+      <div
+        className={cx(
+          styles['textfield-container'],
+          inputStyles['input-container'],
+          {
+            [styles['textarea-container']]: textArea,
+            [styles['textarea-autoGrow']]: autoGrow,
+            [styles['textarea-maxHeight']]: maxHeight,
+          })
+        }
+        style={{
+          maxHeight,
+        }}
       >
         { iconLeft && (
           <div className={inputStyles['input-icon-left-icon']}>
@@ -149,6 +155,7 @@ TextField.defaultProps = {
   suppressInitialError: false,
   textArea: false,
   autoGrow: true,
+  maxHeight: null,
   variant: 'contained',
   componentProps: {},
 };
@@ -166,6 +173,7 @@ TextField.propTypes = {
   suppressInitialError: PropTypes.bool,
   textArea: PropTypes.bool,
   autoGrow: PropTypes.bool,
+  maxHeight: PropTypes.string,
   componentProps: PropTypes.object,
   variant: PropTypes.oneOf(['contained', 'outlined']),
 };

--- a/src/app/components/cds/inputs/TextField.module.css
+++ b/src/app/components/cds/inputs/TextField.module.css
@@ -75,6 +75,7 @@
 
         /* Note the weird space! Needed to preventy jumpy behavior */
         content: attr(data-replicated-value) ' ';
+        max-height: inherit;
 
         /* Hidden from view, clicks, and screen readers */
         visibility: hidden;
@@ -104,6 +105,13 @@
         grid-area: 1 / 1 / 2 / 2;
         line-height: 20px;
         padding: .5rem;
+      }
+    }
+
+    &.textarea-maxHeight {
+      > textarea {
+        max-height: inherit;
+        overflow: auto;
       }
     }
 


### PR DESCRIPTION
## Description

Setting of the maxheight option on the text area component resulted in the ghost element to continue to grow. This PR moves the logic to the wrapper div in order for everything to change height at the same time.

References: CV2-3180

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual sandbox testing

## Things to pay attention to during code review

### BEFORE
<img width="764" alt="Screenshot 2023-09-13 at 2 55 04 PM" src="https://github.com/meedan/check-web/assets/418001/585ddd2d-77be-4515-a53c-8e4355b3ceed">

### AFTER
<img width="690" alt="Screenshot 2023-09-13 at 3 24 35 PM" src="https://github.com/meedan/check-web/assets/418001/534611fa-29a3-43f5-a60a-c12213e7a704">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)

