### PR TITLE
Hotfix: initial height of pre-populated TextArea

### DIFF
--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -51,10 +51,10 @@ const SandboxComponent = ({ admin }) => {
   const [switchesDisabled, setSwitchesDisabled] = React.useState(Boolean(false));
   const [switchesHelp, setSwitchesHelp] = React.useState(Boolean(false));
   const [switched, setSwitchExample] = React.useState(Boolean(false));
-  const [limitedText, setLimitedText] = React.useState('Hello this is the initial limited text state');
+  const [limitedText, setLimitedText] = React.useState('Hello this is the initial limited text state. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. This is very very long. ');
   const [textareaHelp, setTextareaHelp] = React.useState(Boolean(true));
   const [textareaAutogrow, setTextareaAutogrow] = React.useState(Boolean(true));
-  const [textareaLimited, setTextareaLimited] = React.useState(Boolean(false));
+  const [textareaLimited, setTextareaLimited] = React.useState(Boolean(true));
   const [textareaDisabled, setTextareaDisabled] = React.useState(Boolean(false));
   const [textareaRequired, setTextareaRequired] = React.useState(Boolean(true));
 

--- a/src/app/components/cds/inputs/TextArea.js
+++ b/src/app/components/cds/inputs/TextArea.js
@@ -9,6 +9,12 @@ const TextArea = React.forwardRef(({
   rows,
   ...inputProps
 }, ref) => {
+  React.useEffect(() => {
+    if (ref?.current) {
+      ref.current.parentNode.setAttribute('data-replicated-value', ref.current.value);
+    }
+  }, []);
+
   const handleChange = (event) => {
     event.target.parentNode.setAttribute('data-replicated-value', event.target.value);
     if (inputProps.onInput) {


### PR DESCRIPTION
We need to set the height of `TextArea` to the correct value if it has text already in it. What I do here is repeat what we normally do to get the correct height but make sure to do it on initial render using the `forwardRef` to access the element instead of via `event`.

I saved a long newsletter item and reloaded the page and this is what the initial render looks like (correct height):

![image](https://github.com/meedan/check-web/assets/266454/2cbecb30-9906-48c2-9672-b4a773723ce4)

I also added a long text to the limited textarea in the sandbox that is easy to see as well.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Things to pay attention to during code review

Notice that the new code is copying [what we already do](https://github.com/meedan/check-web/blob/47a846cca1cfbe4bba13cff935c497465b729f1c/src/app/components/cds/inputs/TextArea.js#L18-L23), just using the `ref` to access the DOM element instead of `event` (since this is not triggered on an event, just initial render).

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] I have removed the /* eslint-disable @calm/react-intl/missing-attribute */ from any files I've worked on and added a `description` prop to all `<FormattedMessage />` components that were missing it.
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)