### PR TITLE
Hide "Link preview" option for newsletters

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -68,7 +68,7 @@ const NewsletterComponent = ({
   const [introductionText, setIntroductionText] = React.useState(introduction || '');
   const [articleNum, setArticleNum] = React.useState(number_of_articles || 0);
   const [articles, setArticles] = React.useState([first_article || '', second_article || '', third_article || '']);
-  const [headerType, setHeaderType] = React.useState(header_type || 'link_preview');
+  const [headerType, setHeaderType] = React.useState(header_type || 'none');
   const fileNameFromUrl = new RegExp(/[^/\\&?]+\.\w{3,4}(?=([?&].*$|$))/);
   const [fileName, setFileName] = React.useState((header_file_url && header_file_url.match(fileNameFromUrl) && header_file_url.match(fileNameFromUrl)[0]) || '');
   const [rssFeedUrl, setRssFeedUrl] = React.useState(rss_feed_url || '');
@@ -468,6 +468,7 @@ const NewsletterComponent = ({
               handleFileChange={handleFileChange}
               setFile={setFile}
               setFileName={setFileName}
+              hideOptions={['link_preview']}
               availableHeaderTypes={team.available_newsletter_header_types || []}
               headerType={headerType}
               fileName={fileName}

--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -468,8 +468,7 @@ const NewsletterComponent = ({
               handleFileChange={handleFileChange}
               setFile={setFile}
               setFileName={setFileName}
-              hideOptions={['link_preview']}
-              availableHeaderTypes={team.available_newsletter_header_types || []}
+              availableHeaderTypes={team.available_newsletter_header_types ? team.available_newsletter_header_types.filter(type => type !== 'link_preview') : []}
               headerType={headerType}
               fileName={fileName}
               overlayText={overlayText}

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -34,6 +34,14 @@ const messages = defineMessages({
   },
 });
 
+const headerTypes = {
+  none: messages.headerTypeNone,
+  link_preview: messages.headerTypeLinkPreview,
+  image: messages.headerTypeImage,
+  video: messages.headerTypeVideo,
+  audio: messages.headerTypeAudio,
+};
+
 const NewsletterHeader = ({
   disabled,
   availableHeaderTypes,
@@ -47,6 +55,7 @@ const NewsletterHeader = ({
   setFileName,
   overlayText,
   onUpdateField,
+  hideOptions,
   intl,
 }) => (
   <div>
@@ -59,11 +68,13 @@ const NewsletterHeader = ({
       error={parentErrors.header_type || error}
       helpContent={parentErrors.header_type}
     >
-      <option disabled={!availableHeaderTypes.includes('none')} value="none">{intl.formatMessage(messages.headerTypeNone)}</option>
-      <option disabled={!availableHeaderTypes.includes('link_preview')} value="link_preview">{intl.formatMessage(messages.headerTypeLinkPreview)}</option>
-      <option disabled={!availableHeaderTypes.includes('image')} value="image">{intl.formatMessage(messages.headerTypeImage)}</option>
-      <option disabled={!availableHeaderTypes.includes('video')} value="video">{intl.formatMessage(messages.headerTypeVideo)}</option>
-      <option disabled={!availableHeaderTypes.includes('audio')} value="audio">{intl.formatMessage(messages.headerTypeAudio)}</option>
+      {Object.keys(headerTypes).map(type => (
+        !hideOptions.includes(type) && (
+          <option key={type} value={type} disabled={!availableHeaderTypes.includes(type)}>
+            {intl.formatMessage(headerTypes[type])}
+          </option>
+        )
+      ))}
     </Select>
 
     { (headerType === 'image' || headerType === 'video' || headerType === 'audio') ?
@@ -109,7 +120,8 @@ const NewsletterHeader = ({
 NewsletterHeader.defaultProps = {
   disabled: false,
   availableHeaderTypes: [],
-  headerType: 'link_preview',
+  hideOptions: [],
+  headerType: 'none',
   overlayText: null,
   fileName: '',
   error: false,
@@ -118,6 +130,7 @@ NewsletterHeader.defaultProps = {
 NewsletterHeader.propTypes = {
   disabled: PropTypes.bool,
   availableHeaderTypes: PropTypes.arrayOf(PropTypes.string),
+  hideOptions: PropTypes.arrayOf(PropTypes.string),
   headerType: PropTypes.oneOf(['', 'none', 'link_preview', 'image', 'video', 'audio']),
   setFile: PropTypes.func.isRequired,
   setFileName: PropTypes.func.isRequired,

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -55,7 +55,6 @@ const NewsletterHeader = ({
   setFileName,
   overlayText,
   onUpdateField,
-  hideOptions,
   intl,
 }) => (
   <div>
@@ -69,11 +68,9 @@ const NewsletterHeader = ({
       helpContent={parentErrors.header_type}
     >
       {Object.keys(headerTypes).map(type => (
-        !hideOptions.includes(type) && (
-          <option key={type} value={type} disabled={!availableHeaderTypes.includes(type)}>
-            {intl.formatMessage(headerTypes[type])}
-          </option>
-        )
+        <option key={type} value={type} disabled={!availableHeaderTypes.includes(type)}>
+          {intl.formatMessage(headerTypes[type])}
+        </option>
       ))}
     </Select>
 
@@ -120,7 +117,6 @@ const NewsletterHeader = ({
 NewsletterHeader.defaultProps = {
   disabled: false,
   availableHeaderTypes: [],
-  hideOptions: [],
   headerType: 'none',
   overlayText: null,
   fileName: '',
@@ -130,7 +126,6 @@ NewsletterHeader.defaultProps = {
 NewsletterHeader.propTypes = {
   disabled: PropTypes.bool,
   availableHeaderTypes: PropTypes.arrayOf(PropTypes.string),
-  hideOptions: PropTypes.arrayOf(PropTypes.string),
   headerType: PropTypes.oneOf(['', 'none', 'link_preview', 'image', 'video', 'audio']),
   setFile: PropTypes.func.isRequired,
   setFileName: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
add a hideOptions prop to Newsletter component to hide the chosen fields

Reference: CV2-3736

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Go to the Newsletter settings page and check that the option "Link Preview" is not being displayed
- Go to the Tipline settings page 
- Click on the "Resources" tab and check that the option "Link Preview" is being displayed

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
