### PR TITLE
Adding a "clean" step to the dev build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { spawn } = require('child_process');
+const { spawn, exec } = require('child_process');
 const request = require('sync-request');
 const gulp = require('gulp');
 const gutil = require('gulp-util');
@@ -103,6 +103,12 @@ gulp.task('build:web', gulp.series('relay:copy', 'react-relay:build', 'webpack:b
 
 gulp.task('react-relay:build:watch', () => spawnPromise([...RelayCommand, '--watch']));
 
+gulp.task('clean:build:web', (cb) => {
+  exec('rm -rf build/web/*', (err, stdout, stderr) => {
+    cb();
+  });
+});
+
 // Dev mode — with 'watch' enabled for faster builds
 // Webpack only — without the rest of the web build steps.
 gulp.task('webpack:build:web:dev', (callback) => {
@@ -142,6 +148,7 @@ gulp.task('webpack:build:web:dev', (callback) => {
 gulp.task(
   'build:web:dev',
   gulp.series(
+    'clean:build:web',
     'relay:copy',
     'copy:build:web',
     'react-relay:build', // before Webpack -- for first run to succeed and not race


### PR DESCRIPTION
Based on discussions about our rapidly ballooning `build/web` directories, it makes sense to add a `clean` step to the build process. `spawnPromise` wasn't working with `rm` for whatever reason so I use `exec` here instead to shell out.

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
