### PR TITLE
Resubmit query on search pages when an image search is cleared CV2-103

### DIFF
--- a/src/app/components/search/SearchKeyword.js
+++ b/src/app/components/search/SearchKeyword.js
@@ -155,7 +155,7 @@ class SearchKeyword extends React.Component {
 
   /*
   check that the sort parameter is the default, if it is, set the parameter to "clear"
-  to identify that no other sort filter is applied and the search query should be reseted
+  to identify that no other sort filter is applied and the search query should be reset
   */
   handleClickClear = () => {
     const newQuery = { ...this.props.query };
@@ -179,6 +179,7 @@ class SearchKeyword extends React.Component {
       },
     });
     this.props.setStateQuery(cleanQuery);
+    this.props.handleSubmit(null, cleanQuery);
   };
 
   subscribe() {


### PR DESCRIPTION
## Description

When searching with a file, clearing the file did not reset the search. This PR fixes the bug and resubmits the cleaned query, without the file.
See video below

References: [CV2-103](https://meedan.atlassian.net/browse/CV2-103)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review


https://github.com/meedan/check-web/assets/418001/9f20f4ba-030d-4135-a37e-77fb0c163770


- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-103]: https://meedan.atlassian.net/browse/CV2-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ