### PR TITLE
Re-adding @material-ui/icons to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,6 +2861,32 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "5.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-5.0.0-beta.5.tgz",
+      "integrity": "sha512-C2KHSf8mvDn22rzsV0UfsJyBYI3Nt/LItcKPJBAG9kgqdBHAuLMH2lfKmdMuX55qd8O+NO5rM7aIHdYQRjfcMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.14.8"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.23.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+          "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+          "dev": true
+        }
+      }
+    },
     "@material-ui/lab": {
       "version": "4.0.0-alpha.52",
       "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.52.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     ]
   },
   "devDependencies": {
+    "@material-ui/icons": "^5.0.0-beta.5",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.2",
     "enzyme": "^3.3.0",
     "jest": "^25.4.0"


### PR DESCRIPTION
This fixes the issue where `check-ui` dev integration complains due to lack of the `@material-ui/icons` package, but at the same time doesn't include the package in our production distribution.

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
