### PR TITLE
Fix: only render RestoreProjectMedia button if flag is Trashed or Spam

### DIFF
--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -269,17 +269,14 @@ class MediaActionsBarComponent extends Component {
 
     const context = this.getContext();
 
-    let restorProjectMedia = '';
-    if (media.archived !== CheckArchivedFlags.NONE) {
-      restorProjectMedia = (
-        <RestoreProjectMedia
-          team={this.props.media.team}
-          projectMedia={this.props.media}
-          context={context}
-          className={classes.spacedButton}
-        />
-      );
-    }
+    const restorProjectMedia = (
+      <RestoreProjectMedia
+        team={this.props.media.team}
+        projectMedia={this.props.media}
+        context={context}
+        className={classes.spacedButton}
+      />
+    );
 
     return (
       <div className={styles['media-actions']}>

--- a/src/app/components/media/RestoreProjectMedia.js
+++ b/src/app/components/media/RestoreProjectMedia.js
@@ -115,7 +115,7 @@ function RestoreProjectMedia({
     );
   }
 
-  if (projectMedia.archived === CheckArchivedFlags.NONE) {
+  if (projectMedia.archived !== CheckArchivedFlags.TRASHED && projectMedia.archived !== CheckArchivedFlags.SPAM) {
     return null;
   }
 


### PR DESCRIPTION

## Description

Previously, the RestoreProjectMedia button was rendering conditionally based on whether the flag was different from "none." This resulted in the button being rendered without a label in certain cases. Fixed by updating the code to check specific flags (Trashed or Spam) before rendering the RestoreProjectMedia button

Reference: CV2-3693

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
