### PR TITLE
remove urls to ignore from UI CV2-2223

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotSetting.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSetting.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -9,6 +8,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import TextField from '../../cds/inputs/TextField';
 import Chip from '../../cds/buttons-checkboxes-chips/Chip';
 
 const useStyles = makeStyles(theme => ({
@@ -97,7 +97,7 @@ const SmoochBotSetting = (props) => {
     inputProps.min = 1;
   }
 
-  if (field === 'smooch_urls_to_ignore' || /^smooch_template_newsletter_header_/.test(field) || field === 'turnio_cacert') {
+  if (field === /^smooch_template_newsletter_header_/.test(field) || field === 'turnio_cacert') {
     Object.assign(otherProps, {
       rows: 5,
       rowsMax: Infinity,
@@ -118,10 +118,9 @@ const SmoochBotSetting = (props) => {
         }
         handleChange(field, newValue);
       }}
-      helperText={schema.description}
+      helpContent={schema.description}
       variant="outlined"
-      fullWidth
-      inputProps={inputProps}
+      componentProps={inputProps}
       {...otherProps}
     />
   );

--- a/src/app/components/team/SmoochBot/SmoochBotSettings.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSettings.js
@@ -18,7 +18,7 @@ const SmoochBotSettings = (props) => {
         installationId={props.installationId}
       />
 
-      {['smooch_urls_to_ignore', 'smooch_time_to_send_request', 'smooch_disabled'].map(field => (
+      {['smooch_time_to_send_request', 'smooch_disabled'].map(field => (
         <SmoochBotSetting
           field={field}
           value={props.settings[field]}


### PR DESCRIPTION
## Description

While working on cleaning up layouts in the settings area I found a reference to sunsetting URLs to ignore via [CV2-2223](https://meedan.atlassian.net/browse/CV2-2223).

Also switches out the textfield component for the cds version

References: [CV2-2223](https://meedan.atlassian.net/browse/CV2-2223)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

### BEFORE
<img width="907" alt="Screenshot 2023-10-04 at 11 59 00 AM" src="https://github.com/meedan/check-web/assets/418001/3044dc3e-4567-405e-aec7-54d03c9128a7">

### AFTER
<img width="914" alt="Screenshot 2023-10-04 at 11 58 33 AM" src="https://github.com/meedan/check-web/assets/418001/cae24ba2-30fb-4c03-83d4-962056f82d61">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-2223]: https://meedan.atlassian.net/browse/CV2-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CV2-2223]: https://meedan.atlassian.net/browse/CV2-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ