### PR TITLE
Update Reorder component CV2-3552

### DIFF
--- a/localization/react-intl/src/app/components/layout/Reorder.json
+++ b/localization/react-intl/src/app/components/layout/Reorder.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "reorder.moveUp",
+    "description": "Tooltip for control that moves an item higher up in a list",
+    "defaultMessage": "Move item up"
+  },
+  {
+    "id": "reorder.moveDown",
+    "description": "Tooltip for control that moves an item lower in a list",
+    "defaultMessage": "Move item down"
+  }
+]

--- a/localization/react-intl/src/app/components/team/TeamLists/TeamListsColumn.json
+++ b/localization/react-intl/src/app/components/team/TeamLists/TeamListsColumn.json
@@ -2,6 +2,6 @@
   {
     "id": "teamListsColumn.none",
     "description": "Placeholder text when there are no columns left for selection when the user is customizing which ones they want to show or hide",
-    "defaultMessage": "None available"
+    "defaultMessage": "No columns available"
   }
 ]

--- a/localization/react-intl/src/app/components/team/TeamLists/TeamListsComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamLists/TeamListsComponent.json
@@ -22,17 +22,17 @@
   {
     "id": "teamListsComponent.displayedColumns",
     "description": "Columns that are displayed for users in lists.",
-    "defaultMessage": "Displayed columns"
+    "defaultMessage": "Displayed"
   },
   {
     "id": "teamListsComponent.generalColumns",
     "description": "Columns not currently displayed for users in lists.",
-    "defaultMessage": "General"
+    "defaultMessage": "General (hidden)"
   },
   {
     "id": "teamListsComponent.metadataColumns",
     "description": "Subtitle for Column settings page, where users can configure the visibility of annotations columns in lists.",
-    "defaultMessage": "Annotation"
+    "defaultMessage": "Annotations (hidden)"
   },
   {
     "id": "teamListsComponent.createMetadata",

--- a/localization/react-intl/src/app/components/team/TeamLists/TeamListsItem.json
+++ b/localization/react-intl/src/app/components/team/TeamLists/TeamListsItem.json
@@ -17,6 +17,6 @@
   {
     "id": "teamListsItem.show",
     "description": "Button label to show this item in the list",
-    "defaultMessage": "Show"
+    "defaultMessage": "Display"
   }
 ]

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -14,6 +14,7 @@ import { ToggleButton, ToggleButtonGroup } from './cds/inputs/ToggleButtonGroup'
 import Select from './cds/inputs/Select';
 import SwitchComponent from './cds/inputs/SwitchComponent';
 import ButtonMain from './cds/buttons-checkboxes-chips/ButtonMain';
+import Reorder from './layout/Reorder';
 import AddIcon from '../icons/settings.svg';
 import ListIcon from '../icons/list.svg';
 import FigmaColorLogo from '../icons/figma_color.svg';
@@ -49,6 +50,8 @@ const SandboxComponent = ({ admin }) => {
   const [tagsReadOnly, setTagsReadOnly] = React.useState(Boolean(false));
   const [chipRemovable, setChipRemovable] = React.useState(Boolean(false));
   const [buttonDisabled, setMainButtonDisabled] = React.useState(Boolean(false));
+  const [reorderFirst, setReorderFirst] = React.useState(Boolean(false));
+  const [reorderLast, setReorderLast] = React.useState(Boolean(false));
   const [switchesDisabled, setSwitchesDisabled] = React.useState(Boolean(false));
   const [switchesHelp, setSwitchesHelp] = React.useState(Boolean(false));
   const [switched, setSwitchExample] = React.useState(Boolean(false));
@@ -89,6 +92,11 @@ const SandboxComponent = ({ admin }) => {
     setButtonVariant(event.target.value);
   };
 
+  const [reorderVariant, setReorderVariant] = React.useState('vertical');
+  const onChangeReorderVariant = (event) => {
+    setReorderVariant(event.target.value);
+  };
+
   const [textareaRows, setTextareaRows] = React.useState('none');
   const onChangeTextareaRows = (event) => {
     setTextareaRows(event.target.value);
@@ -107,6 +115,11 @@ const SandboxComponent = ({ admin }) => {
   const [buttonTheme, setButtonTheme] = React.useState('brand');
   const onChangeButtonTheme = (event) => {
     setButtonTheme(event.target.value);
+  };
+
+  const [reorderTheme, setReorderTheme] = React.useState('gray');
+  const onChangeReorderTheme = (event) => {
+    setReorderTheme(event.target.value);
   };
 
   const generateUncaughtError = () => {
@@ -252,6 +265,66 @@ const SandboxComponent = ({ admin }) => {
             <ButtonMain iconLeft={<AddIcon />} label="Left" variant={buttonVariant} size={buttonSize} theme={buttonTheme} disabled={buttonDisabled} />
             <ButtonMain iconRight={<AddIcon />} label="Right" variant={buttonVariant} size={buttonSize} theme={buttonTheme} disabled={buttonDisabled} />
             <ButtonMain iconCenter={<AddIcon />} label="Center" variant={buttonVariant} size={buttonSize} theme={buttonTheme} disabled={buttonDisabled} />
+          </div>
+        </div>
+        <div className={styles.componentWrapper}>
+          <div className={styles.componentControls}>
+            <div className={cx('typography-subtitle2', [styles.componentName])}>
+              Reorder
+              <a
+                href="https://www.figma.com/file/7ZlvdotCAzeIQcbIKxOB65/Components?type=design&node-id=2142-47843&mode=design&t=Xk5LFyi7pmsXEX1T-4"
+                rel="noopener noreferrer"
+                target="_blank"
+                title="Figma Designs"
+                className={styles.figmaLink}
+              >
+                <FigmaColorLogo />
+              </a>
+            </div>
+            <ul>
+              <li>
+                <Select
+                  label="Variant"
+                  onChange={onChangeReorderVariant}
+                >
+                  <option value="vertical">vertical (default)</option>
+                  <option value="horizontal">horizontal</option>
+                </Select>
+              </li>
+              <li>
+                <Select
+                  label="Theme"
+                  onChange={onChangeReorderTheme}
+                >
+                  <option value="gray">gray (default)</option>
+                  <option value="white">white</option>
+                </Select>
+              </li>
+              <li>
+                <SwitchComponent
+                  label="First"
+                  labelPlacement="top"
+                  checked={reorderFirst}
+                  onChange={() => setReorderFirst(!reorderFirst)}
+                />
+              </li>
+              <li>
+                <SwitchComponent
+                  label="Last"
+                  labelPlacement="top"
+                  checked={reorderLast}
+                  onChange={() => setReorderLast(!reorderLast)}
+                />
+              </li>
+            </ul>
+          </div>
+          <div className={styles.componentInlineVariants} style={{ backgroundColor: reorderTheme === 'white' ? 'var(--grayBackground)' : 'var(--otherWhite' }}>
+            <Reorder
+              variant={reorderVariant}
+              theme={reorderTheme}
+              disableUp={reorderFirst}
+              disableDown={reorderLast}
+            />
           </div>
         </div>
         <div className={styles.componentWrapper}>

--- a/src/app/components/layout/Reorder.js
+++ b/src/app/components/layout/Reorder.js
@@ -1,51 +1,102 @@
+// DESIGNS: https://www.figma.com/file/7ZlvdotCAzeIQcbIKxOB65/Components?type=design&node-id=2142-47843&mode=design&t=Xk5LFyi7pmsXEX1T-4
 import React from 'react';
 import PropTypes from 'prop-types';
-import Box from '@material-ui/core/Box';
-import IconButton from '@material-ui/core/IconButton';
-import { makeStyles } from '@material-ui/core/styles';
-import ArrowUpwardIcon from '../../icons/arrow_upward.svg';
-import ArrowDownwardIcon from '../../icons/arrow_downward.svg';
-
-const useStyles = makeStyles(() => ({
-  reorderArrow: {
-    paddingTop: 2,
-    paddingBottom: 2,
-  },
-}));
+import { FormattedMessage } from 'react-intl';
+import cx from 'classnames/bind';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
+import Tooltip from '../cds/alerts-and-prompts/Tooltip';
+import ArrowDropUpIcon from '../../icons/arrow_drop_up.svg';
+import ArrowDropDownIcon from '../../icons/arrow_drop_down.svg';
+import styles from './Reorder.module.css';
 
 const Reorder = ({
+  className,
+  customStyle,
   onMoveDown,
   onMoveUp,
   disableUp,
   disableDown,
-}) => {
-  const classes = useStyles();
-  return (
-    <Box display="flex" flexDirection="column" width="fit-content">
-      <IconButton
-        className={['reorder__button-up', classes.reorderArrow].join(' ')}
-        onClick={onMoveUp}
-        disabled={disableUp}
-      >
-        <ArrowUpwardIcon style={{ fontSize: '20px' }} />
-      </IconButton>
-      <IconButton
-        className={['reorder__button-down', classes.reorderArrow].join(' ')}
-        onClick={onMoveDown}
-        disabled={disableDown}
-      >
-        <ArrowDownwardIcon style={{ fontSize: '20px' }} />
-      </IconButton>
-    </Box>
-  );
-};
+  theme,
+  variant,
+}) => (
+  <div
+    className={cx(
+      [styles.reorder],
+      styles[`theme-${theme}`],
+      {
+        [className]: true,
+        [styles.horizontal]: variant === 'horizontal',
+        [styles.vertical]: variant === 'vertical',
+      })
+    }
+    style={customStyle}
+  >
+    <Tooltip
+      disableHoverListener={disableUp}
+      placement="top"
+      arrow
+      title={
+        <FormattedMessage
+          id="reorder.moveUp"
+          defaultMessage="Move item up"
+          description="Tooltip for control that moves an item higher up in a list"
+        />
+      }
+    >
+      <span>
+        <ButtonMain
+          className="int-reorder__button-up"
+          size="small"
+          variant="text"
+          theme="brand"
+          iconCenter={<ArrowDropUpIcon />}
+          onClick={onMoveUp}
+          disabled={disableUp}
+        />
+      </span>
+    </Tooltip>
+    <hr />
+    <Tooltip
+      disableHoverListener={disableDown}
+      placement="bottom"
+      arrow
+      title={
+        <FormattedMessage
+          id="reorder.moveDown"
+          defaultMessage="Move item down"
+          description="Tooltip for control that moves an item lower in a list"
+        />
+      }
+    >
+      <span>
+        <ButtonMain
+          className="int-reorder__button-down"
+          size="small"
+          variant="text"
+          theme="brand"
+          iconCenter={<ArrowDropDownIcon />}
+          onClick={onMoveDown}
+          disabled={disableDown}
+        />
+      </span>
+    </Tooltip>
+  </div>
+);
 
 Reorder.defaultProps = {
   disableUp: false,
   disableDown: false,
+  theme: 'gray',
+  variant: 'vertical',
+  className: '',
+  customStyle: {},
 };
 
 Reorder.propTypes = {
+  className: PropTypes.string,
+  customStyle: PropTypes.object,
+  theme: PropTypes.oneOf(['gray', 'white']),
+  variant: PropTypes.oneOf(['vertical', 'horizontal']),
   onMoveUp: PropTypes.func.isRequired,
   onMoveDown: PropTypes.func.isRequired,
   disableUp: PropTypes.bool,

--- a/src/app/components/layout/Reorder.module.css
+++ b/src/app/components/layout/Reorder.module.css
@@ -1,0 +1,42 @@
+.reorder {
+  background-color: var(--grayBackground);
+  border-radius: 8px;
+  display: flex;
+
+  span {
+    margin: 2px;
+  }
+
+  &.vertical {
+    flex-direction: column;
+    height: 68px;
+    width: 34px;
+  }
+
+  &.horizontal {
+    flex-direction: row;
+    height: 34px;
+    width: 68px;
+
+    hr {
+      height: auto;
+      width: 1px;
+    }
+  }
+
+  &.theme-gray {
+    background-color: var(--grayBackground);
+
+    hr {
+      background-color: var(--otherWhite);
+    }
+  }
+
+  &.theme-white {
+    background-color: var(--otherWhite);
+
+    hr {
+      background-color: var(--grayBackground);
+    }
+  }
+}

--- a/src/app/components/layout/Reorder.test.js
+++ b/src/app/components/layout/Reorder.test.js
@@ -9,7 +9,7 @@ describe('<Reorder />', () => {
       onMoveUp={() => {}}
     />);
     expect(wrapper.find('button').hostNodes()).toHaveLength(2);
-    expect(wrapper.find('.reorder__button-up').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('.reorder__button-down').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.int-reorder__button-up').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.int-reorder__button-down').hostNodes()).toHaveLength(1);
   });
 });

--- a/src/app/components/team/Settings.module.css
+++ b/src/app/components/team/Settings.module.css
@@ -63,12 +63,6 @@
           }
         }
       }
-
-      .settings-columns {
-        display: flex;
-        gap: 16px;
-        justify-content: space-between;
-      }
     }
   }
 }

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -12,15 +12,13 @@ import LockIcon from '../../../icons/lock.svg';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import SmoochBotMainMenuOption from './SmoochBotMainMenuOption';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
+import Reorder from '../../layout/Reorder';
 import AddIcon from '../../../icons/add.svg';
-import ArrowUpwardIcon from '../../../icons/arrow_upward.svg';
-import ArrowDownwardIcon from '../../../icons/arrow_downward.svg';
 
 const useStyles = makeStyles(theme => ({
   box: {
-    background: 'var(--grayBackground)',
-    border: '1px solid var(--textPlaceholder)',
-    borderRadius: theme.spacing(2),
+    background: 'var(--brandBackground)',
+    borderRadius: theme.spacing(1),
   },
   textField: {
     background: 'var(--otherWhite)',
@@ -30,13 +28,6 @@ const useStyles = makeStyles(theme => ({
   title: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
-  },
-  arrows: {
-    flexDirection: 'column',
-  },
-  arrow: {
-    margin: 0,
-    padding: theme.spacing(0.25),
   },
   lock: {
     color: 'var(--textSecondary)',
@@ -249,34 +240,18 @@ const SmoochBotMainMenuSection = ({
         { options.map((option, i) => (
           <Box display="flex" alignItems="center" justifyContent="space-between" my={1} key={formatOptionLabel(option)}>
 
-            {/* Menu option label and arrows */}
-            <Box display="flex" alignItems="center">
-
-              {/* Arrows */}
-              { readOnly ?
-                null :
-                <Box display="flex" className={classes.arrows}>
-                  <ButtonMain
-                    iconCenter={<ArrowUpwardIcon />}
-                    variant="text"
-                    theme="text"
-                    size="small"
-                    onClick={() => { handleMoveUp(i); }}
-                    disabled={i === 0}
-                    className={classes.arrow}
-                  />
-                  <ButtonMain
-                    iconCenter={<ArrowDownwardIcon />}
-                    variant="text"
-                    theme="text"
-                    size="small"
-                    onClick={() => { handleMoveDown(i); }}
-                    disabled={i === options.length - 1}
-                    className={classes.arrow}
-                  />
-                </Box> }
-              {' '}
-
+            {/* Menu option label and reordering */}
+            <Box display="flex" alignItems="center" style={{ gap: '10px' }}>
+              { !readOnly &&
+                <Reorder
+                  variant="horizontal"
+                  theme="white"
+                  onMoveUp={() => { handleMoveUp(i); }}
+                  onMoveDown={() => { handleMoveDown(i); }}
+                  disableUp={i === 0}
+                  disableDown={i === options.length - 1}
+                />
+              }
               <Box m={readOnly ? 1 : 0}>
                 {/* Menu option label */}
                 <div className="typography-body1">

--- a/src/app/components/team/TeamLists/TeamLists.module.css
+++ b/src/app/components/team/TeamLists/TeamLists.module.css
@@ -1,0 +1,79 @@
+.teamlist-columns {
+  display: grid;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  margin: 0 auto;
+
+  .teamlist-column {
+    .teamlist-column-items {
+      border-radius: 5px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin: 8px 0;
+      padding: 8px;
+
+      .teamlist-column-item {
+        align-items: center;
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 8px;
+
+        .item-details {
+          align-items: center;
+          background-color: var(--otherWhite);
+          border: solid 2px var(--grayBorderMain);
+          border-radius: 5px;
+          display: grid;
+          gap: 0 4px;
+          grid-template-columns: 1fr max-content;
+          padding: 8px;
+          width: 100%;
+
+          .item-content {
+            .item-label {
+              @mixin typography-body1;
+            }
+
+            small {
+              color: var(--textSecondary);
+              display: none;
+            }
+          }
+
+          &.item-visible {
+            min-height: 68px;
+
+            .item-content {
+              small {
+                display: block;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    &.teamlist-column-selected {
+      .teamlist-column-items {
+        background-color: var(--brandBackground);
+      }
+    }
+
+    .teamlist-placeholder {
+      align-items: center;
+      background-color: var(--grayBackground);
+      border-radius: 5px;
+      color: var(--textSecondary);
+      display: flex;
+      justify-content: center;
+      min-height: 80px;
+      padding: 8px;
+      text-align: center;
+
+      a {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/src/app/components/team/TeamLists/TeamListsColumn.js
+++ b/src/app/components/team/TeamLists/TeamListsColumn.js
@@ -1,19 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Box from '@material-ui/core/Box';
-import { makeStyles } from '@material-ui/core/styles';
+import cx from 'classnames/bind';
 import TeamListsItem from './TeamListsItem';
-
-const useStyles = makeStyles({
-  innerColumn: {
-    margin: '22px 0 0',
-  },
-  placeholder: {
-    color: 'var(--textSecondary)',
-    textAlign: 'center',
-  },
-});
+import styles from './TeamLists.module.css';
 
 const TeamListsColumn = ({
   columns,
@@ -21,46 +11,49 @@ const TeamListsColumn = ({
   onToggle,
   onMoveUp,
   onMoveDown,
-  style,
+  className,
   placeholder,
-}) => {
-  const classes = useStyles();
-
-  return (
-    <Box width="1">
-      <span className="typography-subtitle2">
-        {title}
-      </span>
-      <Box className={classes.innerColumn} style={style}>
-        {columns.map((column, i) => (
-          <TeamListsItem
-            key={column.key}
-            column={column}
-            onToggle={onToggle}
-            onMoveUp={onMoveUp}
-            onMoveDown={onMoveDown}
-            isFirst={i === 0}
-            isLast={i === columns.length - 1}
-            isRequired={column.key === 'created_at_timestamp'}
-          />
-        ))}
-        { columns.length === 0 ?
-          <Box className={classes.placeholder}>
-            {placeholder}
-          </Box> : null }
-      </Box>
-    </Box>
-  );
-};
+}) => (
+  <div
+    className={cx(
+      styles['teamlist-column'],
+      {
+        [className]: true,
+      })
+    }
+  >
+    <span className="typography-subtitle2">
+      {title}
+    </span>
+    <div className={styles['teamlist-column-items']}>
+      {columns.map((column, i) => (
+        <TeamListsItem
+          key={column.key}
+          column={column}
+          onToggle={onToggle}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          isFirst={i === 0}
+          isLast={i === columns.length - 1}
+          isRequired={column.key === 'created_at_timestamp'}
+        />
+      ))}
+      { columns.length === 0 ?
+        <div className={styles['teamlist-placeholder']}>
+          {placeholder}
+        </div> : null }
+    </div>
+  </div>
+);
 
 TeamListsColumn.defaultProps = {
   onMoveUp: null,
   onMoveDown: null,
-  style: {},
+  className: null,
   placeholder: (
     <FormattedMessage
       id="teamListsColumn.none"
-      defaultMessage="None available"
+      defaultMessage="No columns available"
       description="Placeholder text when there are no columns left for selection when the user is customizing which ones they want to show or hide"
     />
   ),
@@ -77,7 +70,7 @@ TeamListsColumn.propTypes = {
   onToggle: PropTypes.func.isRequired,
   onMoveUp: PropTypes.func,
   onMoveDown: PropTypes.func,
-  style: PropTypes.object,
+  className: PropTypes.string,
   placeholder: PropTypes.node,
 };
 

--- a/src/app/components/team/TeamLists/TeamListsColumn.test.js
+++ b/src/app/components/team/TeamLists/TeamListsColumn.test.js
@@ -33,7 +33,7 @@ describe('<TeamListsColumn />', () => {
     expect(wrapper.html()).toMatch('label-content-1');
     expect(wrapper.html()).toMatch('label-content-2');
     expect(wrapper.html()).toMatch('label-content-3');
-    expect(wrapper.html()).not.toMatch('None available');
+    expect(wrapper.html()).not.toMatch('No columns available');
   });
 
   it('should render team list column title and the placeholder when there are no items in the list', () => {
@@ -45,6 +45,6 @@ describe('<TeamListsColumn />', () => {
     />);
     expect(wrapper.find('.typography-subtitle2').hostNodes()).toHaveLength(1);
     expect(wrapper.html()).toMatch('Column title');
-    expect(wrapper.html()).toMatch('None available');
+    expect(wrapper.html()).toMatch('No columns available');
   });
 });

--- a/src/app/components/team/TeamLists/TeamListsComponent.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.js
@@ -201,7 +201,7 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
               background: 'var(--brandBackground)',
               borderRadius: '5px',
               margin: '16px 0 0',
-              padding: '.3rem 1rem .5rem 0',
+              padding: '.3rem .5rem .5rem .5rem',
             }}
           />
           <TeamListsColumn

--- a/src/app/components/team/TeamLists/TeamListsComponent.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.js
@@ -4,35 +4,20 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router';
 import { graphql, commitMutation } from 'react-relay/compat';
 import { Store } from 'react-relay/classic';
-import { makeStyles } from '@material-ui/core/styles';
 import cx from 'classnames/bind';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import TeamListsColumn from './TeamListsColumn';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmDialog from '../../layout/ConfirmDialog';
 import { withSetFlashMessage } from '../../FlashMessage';
+import styles from './TeamLists.module.css';
 import settingsStyles from '../Settings.module.css';
-
-const useStyles = makeStyles(theme => ({
-  link: {
-    textDecoration: 'underline',
-    background: 'var(--grayBackground)',
-    padding: theme.spacing(1),
-    margin: theme.spacing(1),
-    minHeight: theme.spacing(10),
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 5,
-  },
-}));
 
 function clone(arrayOfObjects) {
   return JSON.parse(JSON.stringify(arrayOfObjects));
 }
 
 const TeamListsComponent = ({ team, setFlashMessage }) => {
-  const classes = useStyles();
   const [columns, setColumns] = React.useState(clone(team.list_columns || []));
   const [saving, setSaving] = React.useState(false);
   const [showConfirmSaveDialog, setShowConfirmSaveDialog] = React.useState(false);
@@ -184,32 +169,27 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
         }
       />
       <div className={cx(settingsStyles['setting-details-wrapper'])}>
-        <div className={cx(settingsStyles['setting-content-container'], settingsStyles['settings-columns'])}>
+        <div className={cx(settingsStyles['setting-content-container'], styles['teamlist-columns'])}>
           <TeamListsColumn
             columns={selectedColumns}
             title={
               <FormattedMessage
                 id="teamListsComponent.displayedColumns"
-                defaultMessage="Displayed columns"
+                defaultMessage="Displayed"
                 description="Columns that are displayed for users in lists."
               />
             }
             onToggle={handleToggle}
             onMoveUp={handleMoveUp}
             onMoveDown={handleMoveDown}
-            style={{
-              background: 'var(--brandBackground)',
-              borderRadius: '5px',
-              margin: '16px 0 0',
-              padding: '.3rem .5rem .5rem .5rem',
-            }}
+            className={styles['teamlist-column-selected']}
           />
           <TeamListsColumn
             columns={availableColumns.filter(c => !/^task_value_/.test(c.key))}
             title={
               <FormattedMessage
                 id="teamListsComponent.generalColumns"
-                defaultMessage="General"
+                defaultMessage="General (hidden)"
                 description="Columns not currently displayed for users in lists."
               />
             }
@@ -220,13 +200,13 @@ const TeamListsComponent = ({ team, setFlashMessage }) => {
             title={
               <FormattedMessage
                 id="teamListsComponent.metadataColumns"
-                defaultMessage="Annotation"
+                defaultMessage="Annotations (hidden)"
                 description="Subtitle for Column settings page, where users can configure the visibility of annotations columns in lists."
               />
             }
             onToggle={handleToggle}
             placeholder={
-              <Link to={`/${team.slug}/settings/annotation`} className={classes.link} id="create-metadata__add-button" >
+              <Link to={`/${team.slug}/settings/annotation`} id="create-metadata__add-button" >
                 <FormattedMessage
                   id="teamListsComponent.createMetadata"
                   defaultMessage="Create new annotation field"

--- a/src/app/components/team/TeamLists/TeamListsComponent.test.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.test.js
@@ -59,7 +59,7 @@ describe('<TeamListsComponent />', () => {
     const wrapper = mountWithIntl(<TeamListsComponent team={team2} />);
     expect(wrapper.html()).toMatch('Hide');
     expect(wrapper.html()).not.toMatch('Show');
-    wrapper.find('.test__list-toggle').hostNodes().simulate('click');
+    wrapper.find('.int-list-toggle__button').hostNodes().simulate('click');
     expect(wrapper.html()).toMatch('Show');
     expect(wrapper.html()).not.toMatch('Hide');
   });

--- a/src/app/components/team/TeamLists/TeamListsComponent.test.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.test.js
@@ -57,7 +57,7 @@ describe('<TeamListsComponent />', () => {
 
   it('should hide item column', () => {
     const wrapper = mountWithIntl(<TeamListsComponent team={team2} />);
-    const button =  wrapper.find('.int-list-toggle__button').at(0);
+    const button = wrapper.find('.int-list-toggle__button').at(0);
     expect(button.html()).toMatch('Hide');
     expect(button.html()).not.toMatch('Display');
     button.simulate('click');

--- a/src/app/components/team/TeamLists/TeamListsComponent.test.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.test.js
@@ -36,9 +36,9 @@ describe('<TeamListsComponent />', () => {
   it('should render all list columns', () => {
     const wrapper = mountWithIntl(<TeamListsComponent team={team} />);
     expect(wrapper.find('.typography-subtitle2').hostNodes()).toHaveLength(3);
-    expect(wrapper.html()).toMatch('Displayed columns');
-    expect(wrapper.html()).toMatch('General');
-    expect(wrapper.html()).toMatch('Annotation');
+    expect(wrapper.html()).toMatch('Displayed');
+    expect(wrapper.html()).toMatch('General (hidden)');
+    expect(wrapper.html()).toMatch('Annotations (hidden)');
   });
 
   it('should render create metadata button', () => {
@@ -52,15 +52,16 @@ describe('<TeamListsComponent />', () => {
     expect(wrapper.html()).toMatch('team-lists__item-0-key-content1');
     expect(wrapper.html()).toMatch('team-lists__item-1-key-content2');
     expect(wrapper.html()).toMatch('team-lists__item-2-key-content3');
-    wrapper.find('.MuiButton-text').at(0).simulate('click');
+    wrapper.find('.int-list-toggle__button').at(0).simulate('click');
   });
 
   it('should hide item column', () => {
     const wrapper = mountWithIntl(<TeamListsComponent team={team2} />);
-    expect(wrapper.html()).toMatch('Hide');
-    expect(wrapper.html()).not.toMatch('Show');
-    wrapper.find('.int-list-toggle__button').hostNodes().simulate('click');
-    expect(wrapper.html()).toMatch('Show');
+    const button =  wrapper.find('.int-list-toggle__button').at(0);
+    expect(button.html()).toMatch('Hide');
+    expect(button.html()).not.toMatch('Display');
+    button.simulate('click');
+    expect(wrapper.html()).toMatch('Display');
     expect(wrapper.html()).not.toMatch('Hide');
   });
 

--- a/src/app/components/team/TeamLists/TeamListsComponent.test.js
+++ b/src/app/components/team/TeamLists/TeamListsComponent.test.js
@@ -66,7 +66,7 @@ describe('<TeamListsComponent />', () => {
 
   it('should render reorder buttons', () => {
     const wrapper = mountWithIntl(<TeamListsComponent team={team} />);
-    expect(wrapper.find('.reorder__button-up').hostNodes()).toHaveLength(2);
-    expect(wrapper.find('.reorder__button-down').hostNodes()).toHaveLength(2);
+    expect(wrapper.find('.int-reorder__button-up').hostNodes()).toHaveLength(2);
+    expect(wrapper.find('.int-reorder__button-down').hostNodes()).toHaveLength(2);
   });
 });

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -1,35 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
-import { makeStyles } from '@material-ui/core/styles';
+import cx from 'classnames/bind';
+import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import Reorder from '../../layout/Reorder';
-
-const useStyles = makeStyles(theme => ({
-  box: {
-    border: '2px solid var(--grayBorderMain)',
-    borderRadius: '5px',
-    padding: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    marginTop: theme.spacing(1),
-    minHeight: theme.spacing(10),
-    background: 'var(--otherWhite)',
-  },
-  label: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    width: '10rem',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-  },
-  button: {
-    fontSize: 12,
-    fontWeight: 'normal',
-  },
-}));
+import styles from './TeamLists.module.css';
 
 const TeamListsItem = ({
   column,
@@ -46,8 +21,6 @@ const TeamListsItem = ({
     label,
     show,
   } = column;
-  const classes = useStyles();
-
   const handleToggle = () => {
     onToggle(key, index);
   };
@@ -61,7 +34,7 @@ const TeamListsItem = ({
   };
 
   return (
-    <Box display="flex" flexWrap="nowrap" alignItems="center" style={{ gap: '4px', padding: '2px' }}>
+    <div className={styles['teamlist-column-item']}>
       { onMoveUp && onMoveDown ?
         <Reorder
           variant="vertical"
@@ -71,51 +44,61 @@ const TeamListsItem = ({
           disableUp={isFirst}
           disableDown={isLast}
         /> : null }
-      <Box
+      <div
         id={`team-lists__item-${index}-${key}`}
-        className={classes.box}
-        display="flex"
-        width="1"
-        alignItems="center"
-        justifyContent="space-between"
+        className={cx(
+          styles['item-details'],
+          {
+            [styles['item-visible']]: show,
+          })
+        }
       >
-        <Box>
-          <Typography title={label} variant="body1" className={classes.label}>
+        <div className={styles['item-content']}>
+          <span title={label} className={styles['item-label']}>
             {label}
-          </Typography>
-          <Typography variant="caption">
-            { /^task_value_/.test(key) ?
-              <FormattedMessage
-                id="teamListsItem.metadata"
-                defaultMessage="Annotation"
-                description="label to show that this type of task is an annotation"
-              /> :
-              <FormattedMessage
-                id="teamListsItem.general"
-                defaultMessage="General"
-                description="label to show that this type of task is a general task"
-              /> }
-          </Typography>
-        </Box>
+          </span>
+          { /^task_value_/.test(key) ?
+            <FormattedMessage
+              tagName="small"
+              id="teamListsItem.metadata"
+              defaultMessage="Annotation"
+              description="label to show that this type of task is an annotation"
+            /> :
+            <FormattedMessage
+              tagName="small"
+              id="teamListsItem.general"
+              defaultMessage="General"
+              description="label to show that this type of task is a general task"
+            />
+          }
+        </div>
         {
           isRequired ?
             null :
-            <Button color="primary" size="small" onClick={handleToggle} className={['test__list-toggle', classes.button].join(' ')}>
-              { show ?
-                <FormattedMessage
-                  id="teamListsItem.hide"
-                  defaultMessage="Hide"
-                  description="Button label to hide this item from the list"
-                /> :
-                <FormattedMessage
-                  id="teamListsItem.show"
-                  defaultMessage="Show"
-                  description="Button label to show this item in the list"
-                /> }
-            </Button>
+            <div className={styles['item-actions']}>
+              <ButtonMain
+                theme="lightBrand"
+                variant="contained"
+                size="small"
+                onClick={handleToggle}
+                className="int-list-toggle__button"
+                label={show ?
+                  <FormattedMessage
+                    id="teamListsItem.hide"
+                    defaultMessage="Hide"
+                    description="Button label to hide this item from the list"
+                  /> :
+                  <FormattedMessage
+                    id="teamListsItem.show"
+                    defaultMessage="Display"
+                    description="Button label to show this item in the list"
+                  />
+                }
+              />
+            </div>
         }
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 };
 

--- a/src/app/components/team/TeamLists/TeamListsItem.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),
-    Minheight: theme.spacing(10),
+    minHeight: theme.spacing(10),
     background: 'var(--otherWhite)',
   },
   label: {
@@ -61,9 +61,11 @@ const TeamListsItem = ({
   };
 
   return (
-    <Box display="flex" flexWrap="nowrap" alignItems="center">
+    <Box display="flex" flexWrap="nowrap" alignItems="center" style={{ gap: '4px', padding: '2px' }}>
       { onMoveUp && onMoveDown ?
         <Reorder
+          variant="vertical"
+          theme="white"
           onMoveUp={handleMoveUp}
           onMoveDown={handleMoveDown}
           disableUp={isFirst}

--- a/src/app/components/team/TeamLists/TeamListsItem.test.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.test.js
@@ -36,7 +36,7 @@ describe('<TeamListsItem />', () => {
       onToggle={() => {}}
     />);
     expect(wrapper.html()).toMatch('Hide');
-    expect(wrapper.html()).not.toMatch('Show');
+    expect(wrapper.html()).not.toMatch('Display');
     expect(wrapper.html()).toMatch('label-content');
     expect(wrapper.html()).toMatch('General');
     expect(wrapper.find('#team-lists__item-1-key-content').hostNodes()).toHaveLength(1);
@@ -50,7 +50,7 @@ describe('<TeamListsItem />', () => {
       isRequired
     />);
     expect(wrapper.html()).not.toMatch('Hide');
-    expect(wrapper.html()).not.toMatch('Show');
+    expect(wrapper.html()).not.toMatch('Display');
     expect(wrapper.html()).toMatch('label-content');
     expect(wrapper.html()).toMatch('General');
     expect(wrapper.find('#team-lists__item-1-key-content').hostNodes()).toHaveLength(1);
@@ -63,7 +63,7 @@ describe('<TeamListsItem />', () => {
       onToggle={() => {}}
     />);
     expect(wrapper.html()).not.toMatch('Hide');
-    expect(wrapper.html()).toMatch('Show');
+    expect(wrapper.html()).toMatch('Display');
     expect(wrapper.html()).toMatch('label-content');
     expect(wrapper.html()).toMatch('General');
     expect(wrapper.find('#team-lists__item-2-key-content').hostNodes()).toHaveLength(1);

--- a/src/app/components/team/TeamLists/TeamListsItem.test.js
+++ b/src/app/components/team/TeamLists/TeamListsItem.test.js
@@ -79,8 +79,8 @@ describe('<TeamListsItem />', () => {
     />);
     expect(wrapper.html()).toMatch('label-content');
     expect(wrapper.find('#team-lists__item-1-key-content').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('.reorder__button-up').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('.reorder__button-down').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.int-reorder__button-up').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.int-reorder__button-down').hostNodes()).toHaveLength(1);
   });
 
   it('should not render reorder buttons', () => {
@@ -91,8 +91,8 @@ describe('<TeamListsItem />', () => {
     />);
     expect(wrapper.html()).toMatch('label-content');
     expect(wrapper.find('#team-lists__item-1-key-content').hostNodes()).toHaveLength(1);
-    expect(wrapper.find('.reorder__button-up').hostNodes()).toHaveLength(0);
-    expect(wrapper.find('.reorder__button-down').hostNodes()).toHaveLength(0);
+    expect(wrapper.find('.int-reorder__button-up').hostNodes()).toHaveLength(0);
+    expect(wrapper.find('.int-reorder__button-down').hostNodes()).toHaveLength(0);
   });
 
   it('should display Annotation label', () => {

--- a/src/app/components/team/TeamTasksListItem.js
+++ b/src/app/components/team/TeamTasksListItem.js
@@ -302,7 +302,14 @@ class TeamTasksListItem extends React.Component {
     return (
       <React.Fragment>
         <Box display="flex" alignItems="center" className="team-tasks__list-item">
-          <Reorder onMoveUp={this.handleMoveTaskUp} onMoveDown={this.handleMoveTaskDown} />
+          <Reorder
+            onMoveUp={this.handleMoveTaskUp}
+            onMoveDown={this.handleMoveTaskDown}
+            disableUp={this.props.isFirst}
+            disableDown={this.props.isLast}
+            variant="vertical"
+            theme="gray"
+          />
           <TeamTaskCard
             icon={icon[task.type]}
             task={this.props.task}

--- a/src/app/components/team/TeamTasksListItem.js
+++ b/src/app/components/team/TeamTasksListItem.js
@@ -301,7 +301,7 @@ class TeamTasksListItem extends React.Component {
 
     return (
       <React.Fragment>
-        <Box display="flex" alignItems="center" className="team-tasks__list-item">
+        <Box display="flex" alignItems="center" className="team-tasks__list-item" style={{ gap: '10px' }}>
           <Reorder
             onMoveUp={this.handleMoveTaskUp}
             onMoveDown={this.handleMoveTaskDown}

--- a/src/app/components/team/TeamTasksProject.js
+++ b/src/app/components/team/TeamTasksProject.js
@@ -22,6 +22,8 @@ const TeamTasksProject = props => props.project.teamTasks.length ? (
           tasks={props.project.teamTasks}
           team={props.team}
           about={props.about}
+          isFirst={index === 0}
+          isLast={index === props.project.teamTasks.length - 1}
         />))}
     </List>
   </div>


### PR DESCRIPTION
## Description

- Update to the reorder component to match cds designs
- Add Reorder to the tipline menu creator interface
- Add Reorder to the ui sandbox
- Update the layouts where its used to account for new designs
- Updates some mat buttons for CDS buttons per [CV2-3360](https://meedan.atlassian.net/browse/CV2-3360)

References: [CV2-3552](https://meedan.atlassian.net/browse/CV2-3552), [CV2-3360](https://meedan.atlassian.net/browse/CV2-3360)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

### SANDBOX
<img width="1605" alt="Screenshot 2023-10-06 at 9 48 02 AM" src="https://github.com/meedan/check-web/assets/418001/59c12b84-96b5-4506-a7cc-a3743ad64cf6">

### BEFORE - menu options
<img width="197" alt="Screenshot 2023-10-06 at 9 44 47 AM" src="https://github.com/meedan/check-web/assets/418001/30872aa9-ba46-4c3b-ae9b-23af5832538b">

### AFTER - menu options
<img width="364" alt="Screenshot 2023-10-06 at 9 45 39 AM" src="https://github.com/meedan/check-web/assets/418001/faea28ea-8741-446a-a738-5c863e0c586c">

### BEFORE - annotations
<img width="282" alt="Screenshot 2023-10-06 at 9 45 00 AM" src="https://github.com/meedan/check-web/assets/418001/40ead222-6fa6-4969-b4c8-5d2ef550e098">

### AFTER - annotations
<img width="267" alt="Screenshot 2023-10-06 at 9 45 55 AM" src="https://github.com/meedan/check-web/assets/418001/0aaa67f4-b864-4758-bc93-80dede76a36d">

### BEFORE - columns
<img width="221" alt="Screenshot 2023-10-06 at 9 45 13 AM" src="https://github.com/meedan/check-web/assets/418001/16301e71-f1cd-4d7c-b5ec-1ca3350a1ae5">

### AFTER - columns
<img width="206" alt="Screenshot 2023-10-06 at 9 45 27 AM" src="https://github.com/meedan/check-web/assets/418001/19c8485b-d16b-4b3c-b42d-5e969397ff8e">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-3552]: https://meedan.atlassian.net/browse/CV2-3552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CV2-3360]: https://meedan.atlassian.net/browse/CV2-3360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CV2-3360]: https://meedan.atlassian.net/browse/CV2-3360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ