### PR TITLE
Parse CAPI templates from WhatsApp

### DIFF
--- a/src/app/components/layout/ChatHistory.js
+++ b/src/app/components/layout/ChatHistory.js
@@ -55,6 +55,18 @@ const ChatHistory = ({
 
   const convertSentAtToLocaleDateString = sent_at => new Date(+sent_at * 1000).toLocaleDateString();
 
+  const parseWhatsApp = (content) => {
+    // eslint-disable-next-line
+    console.log('~~~',content);
+    return content.components.map(
+      item => item.parameters.map(
+        innerItem => (innerItem.type === 'text' && innerItem.text)
+          || (innerItem.type === 'video' && innerItem.video.link)
+          || (innerItem.type === 'image' && innerItem.image.link),
+      ),
+    ).flat().join('\n\n');
+  };
+
   const Message = ({
     content,
     dateTime,
@@ -79,7 +91,7 @@ const ChatHistory = ({
         >
           {
             typeof content === 'object' ? // It's probably a WhatsApp Cloud API template message, which is an object
-              JSON.stringify(content.template) :
+              parseWhatsApp(content.template) :
               content
           }
         </Linkify>


### PR DESCRIPTION
Fix to rendering WhatsApp CAPI templates:

BEFORE:

![image](https://github.com/meedan/check-web/assets/266454/a7a48d7f-6edc-4779-b309-7bd19a8b6bba)

AFTER (something like this text):

![image](https://github.com/meedan/check-web/assets/266454/538b346e-b559-4298-996f-a87fabf6f3a3)

..not perfect but a good start.
