### PR TITLE
Fixing unsafe property access

### DIFF
--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -249,7 +249,7 @@ class MediaActionsBarComponent extends Component {
 
     const isParent = !(media?.suggested_main_item || media?.is_confirmed_similar_to_another_item);
 
-    const published = (media.dynamic_annotation_report_design && media.dynamic_annotation_report_design?.data && media?.dynamic_annotation_report_design?.data?.state === 'published');
+    const published = media?.dynamic_annotation_report_design?.data?.state === 'published';
 
     const options = [];
     media.team.team_users?.edges.forEach((teamUser) => {


### PR DESCRIPTION
From error screening on Sentry: When `media` is null we were throwing exceptions, this now safely accesses all properties.
