### PR TITLE
Quiet down testing console

### DIFF
--- a/src/app/components/InviteNewAccount.js
+++ b/src/app/components/InviteNewAccount.js
@@ -138,10 +138,10 @@ const InviteNewAccountComponent = ({ user }) => {
                 }}
               />
             </Typography>
-            <Typography component="div" align="center" className={classes.bold} paragraph="true">
+            <Typography component="div" align="center" className={classes.bold} paragraph>
               {teamUser?.team?.name}
             </Typography>
-            <Typography component="div" align="center" paragraph="true">
+            <Typography component="div" align="center" paragraph>
               <FormattedHTMLMessage
                 id="inviteNewAccount.createMessage"
                 defaultMessage="You need to create an account for <b>{email}</b>"

--- a/src/app/components/UserTosForm.js
+++ b/src/app/components/UserTosForm.js
@@ -4,7 +4,6 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import Box from '@material-ui/core/Box';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import Typography from '@material-ui/core/Typography';
 import { units } from '../styles/js/shared';
 import { stringHelper } from '../customHelpers';
 
@@ -69,7 +68,7 @@ class UserTosForm extends Component {
               </p> : null
             }
             <Box my={4}>
-              <Typography component="div" variant="body1">
+              <div className="typography-body1">
                 <FormattedMessage
                   id="userTos.disclaimer"
                   defaultMessage="Please review our {tosLink} and our {ppLink} and consent to the following:"
@@ -79,7 +78,7 @@ class UserTosForm extends Component {
                     ppLink,
                   }}
                 />
-              </Typography>
+              </div>
             </Box>
           </div> :
           <div>

--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -4,8 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import Relay from 'react-relay/classic';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
-import Tooltip from '@material-ui/core/Tooltip';
 import styled from 'styled-components';
+import Tooltip from '../cds/alerts-and-prompts/Tooltip';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import AttachFileIcon from '../../icons/attach_file.svg';
 import CreateCommentMutation from '../../relay/mutations/CreateCommentMutation';
@@ -396,18 +396,20 @@ class AddAnnotation extends Component {
             />
           ) : null}
           <AddAnnotationButtonGroup className="add-annotation__buttons">
-            <Tooltip title={<FormattedMessage id="addAnnotation.addFile" defaultMessage="Add a file" description="Tooltip to tell the user they can add files" />} >
-              <ButtonMain
-                variant="text"
-                theme="lightText"
-                size="default"
-                iconCenter={<AttachFileIcon />}
-                className={`add-annotation__insert-photo ${this.state.fileMode ? 'add-annotation__file' : ''}`}
-                buttonProps={{
-                  id: 'add-annotation__switcher',
-                }}
-                onClick={this.switchMode.bind(this)}
-              />
+            <Tooltip arrow title={<FormattedMessage id="addAnnotation.addFile" defaultMessage="Add a file" description="Tooltip to tell the user they can add files" />}>
+              <span>
+                <ButtonMain
+                  variant="text"
+                  theme="lightText"
+                  size="default"
+                  iconCenter={<AttachFileIcon />}
+                  className={`add-annotation__insert-photo ${this.state.fileMode ? 'add-annotation__file' : ''}`}
+                  buttonProps={{
+                    id: 'add-annotation__switcher',
+                  }}
+                  onClick={this.switchMode.bind(this)}
+                />
+              </span>
             </Tooltip>
             { editMode ?
               <Button onClick={this.props.handleCloseEdit} >

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -106,8 +106,8 @@ Alert.defaultProps = {
 
 Alert.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.object,
-  content: PropTypes.object,
+  title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  content: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   floating: PropTypes.bool,
   banner: PropTypes.bool,
   icon: PropTypes.bool,

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -94,8 +94,8 @@ const Alert = ({
 Alert.defaultProps = {
   className: null,
   variant: 'info',
-  content: '',
-  title: '',
+  content: null,
+  title: null,
   buttonLabel: null,
   onButtonClick: null,
   onClose: null,

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -106,8 +106,8 @@ Alert.defaultProps = {
 
 Alert.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  content: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  title: PropTypes.node,
+  content: PropTypes.node,
   floating: PropTypes.bool,
   banner: PropTypes.bool,
   icon: PropTypes.bool,

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -278,7 +278,7 @@ const ProjectsComponent = ({
           <ListItemText disableTypography className={styles.listHeaderLabel}>
             <FormattedMessage tagName="span" id="projectsComponent.lists" defaultMessage="Custom Lists" description="List of items with some filters applied" />
             <Can permissions={team.permissions} permission="create Project">
-              <Tooltip title={<FormattedMessage id="projectsComponent.newListButton" defaultMessage="New list" description="Tooltip for button that opens list creation dialog" />}>
+              <Tooltip arrow title={<FormattedMessage id="projectsComponent.newListButton" defaultMessage="New list" description="Tooltip for button that opens list creation dialog" />}>
                 <IconButton id="projects-list__add-filtered-list" onClick={(e) => { setShowNewListDialog(true); e.stopPropagation(); }} className={styles.listHeaderLabelButton}>
                   <AddCircleIcon />
                 </IconButton>
@@ -321,7 +321,7 @@ const ProjectsComponent = ({
           <ListItemText disableTypography className={styles.listHeaderLabel}>
             <FormattedMessage tagName="span" id="projectsComponent.sharedFeeds" defaultMessage="Shared feeds" description="Feeds of content shared across workspaces" />
             <Can permissions={team.permissions} permission="create Feed">
-              <Tooltip title={<FormattedMessage id="projectsComponent.newSharedFeed" defaultMessage="New shared feed" description="Tooltip for the button that navigates to shared feed creation page" />}>
+              <Tooltip arrow title={<FormattedMessage id="projectsComponent.newSharedFeed" defaultMessage="New shared feed" description="Tooltip for the button that navigates to shared feed creation page" />}>
                 <IconButton onClick={(e) => { handleCreateFeed(); e.stopPropagation(); }} className={[styles.listHeaderLabelButton, 'projects-list__add-feed'].join(' ')}>
                   <AddCircleIcon />
                 </IconButton>

--- a/src/app/components/layout/LongShort.js
+++ b/src/app/components/layout/LongShort.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { breakWordStyles } from '../../styles/js/shared';
 
-const LongShort = styled.div`
+const LongShort = styled.p`
   ${breakWordStyles}
   overflow: hidden;
   display: -webkit-box;

--- a/src/app/components/media/MediaCardLargeFooterContent.js
+++ b/src/app/components/media/MediaCardLargeFooterContent.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import LongShort from '../layout/LongShort';
 
 const MediaCardLargeFooterContent = ({
@@ -12,7 +11,7 @@ const MediaCardLargeFooterContent = ({
 
   return (
     <div className="media-card-large-footer-content">
-      <Typography variant="body1">
+      <div className="typography-body1">
         <Box color="var(--textSecondary)">
           {title}
         </Box>
@@ -21,7 +20,7 @@ const MediaCardLargeFooterContent = ({
             {body}
           </LongShort>
         </Box>
-      </Typography>
+      </div>
     </div>
   );
 };

--- a/src/app/components/media/QuoteMediaCard.js
+++ b/src/app/components/media/QuoteMediaCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import rtlDetect from 'rtl-detect';
-import Typography from '@material-ui/core/Typography';
 import ParsedText from '../ParsedText';
 import LongShort from '../layout/LongShort';
 
@@ -11,11 +10,9 @@ const QuoteMediaCard = ({ quote, languageCode, showAll }) => (
     dir={rtlDetect.isRtlLang(languageCode) ? 'rtl' : 'ltr'}
     lang={languageCode}
   >
-    <Typography variant="body1">
-      <LongShort showAll={showAll} maxLines={6}>
-        <ParsedText text={quote} />
-      </LongShort>
-    </Typography>
+    <LongShort className="typography-body1" showAll={showAll} maxLines={6}>
+      <ParsedText text={quote} />
+    </LongShort>
   </div>
 );
 QuoteMediaCard.propTypes = {

--- a/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerFormSection.js
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import withStyles from '@material-ui/core/styles/withStyles';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import ExpandMoreIcon from '../../../icons/expand_more.svg';
 
 const useStyles = makeStyles(() => ({
-  expansionPanelDetails: {
+  accordionDetails: {
     display: 'block',
   },
   reportMessage: {
@@ -20,13 +20,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const IconLeftExpansionPanelSummary = withStyles({
+const IconLeftAccordionSummary = withStyles({
   expandIcon: {
     order: -1,
     marginLeft: 0,
     marginRight: 0,
   },
-})(ExpansionPanelSummary);
+})(AccordionSummary);
 
 const ReportDesignerFormSection = (props) => {
   const classes = useStyles();
@@ -51,12 +51,12 @@ const ReportDesignerFormSection = (props) => {
   };
 
   return (
-    <ExpansionPanel
+    <Accordion
       className={classes.reportMessage}
       TransitionProps={{ unmountOnExit: true }}
       expanded={expanded}
     >
-      <IconLeftExpansionPanelSummary
+      <IconLeftAccordionSummary
         expandIcon={<ExpandMoreIcon />}
         onClick={handleClick}
       >
@@ -71,11 +71,11 @@ const ReportDesignerFormSection = (props) => {
           }
           label={<strong>{label}</strong>}
         />
-      </IconLeftExpansionPanelSummary>
-      <ExpansionPanelDetails className={classes.expansionPanelDetails}>
+      </IconLeftAccordionSummary>
+      <AccordionDetails className={classes.accordionDetails}>
         {props.children}
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -418,7 +418,7 @@ const DateRangeFilter = ({
           value={getValueType()}
         >
           { ['created_at', 'media_published_at', 'updated_at', 'report_published_at', 'request_created_at'].filter(option => !optionsToHide.includes(option)).map(option => (
-            <option value={option}>{ intl.formatMessage(messages[option]) }</option>
+            <option key={option} value={option}>{ intl.formatMessage(messages[option]) }</option>
           ))}
         </Select>
         <Select

--- a/src/app/components/search/SearchField.js
+++ b/src/app/components/search/SearchField.js
@@ -158,7 +158,7 @@ const SearchField = ({
         >
           <TextArea
             disabled={!expand}
-            rows={5}
+            rows="5"
             onChange={(e) => {
               setParentSearchText(e.target.value);
               setLocalSearchText(e.target.value);

--- a/src/app/components/team/Statuses/EditStatusDialog.js
+++ b/src/app/components/team/Statuses/EditStatusDialog.js
@@ -185,7 +185,7 @@ const EditStatusDialog = ({
               margin="normal"
               fullWidth
               multiline
-              rows={5}
+              rows="5"
               rowsMax={Infinity}
             />
           </React.Fragment> : null }

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -26,7 +26,7 @@ StatusMessage.defaultProps = {
 };
 
 StatusMessage.propTypes = {
-  message: PropTypes.object,
+  message: PropTypes.string,
 };
 
 export default StatusMessage;

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -26,7 +26,7 @@ StatusMessage.defaultProps = {
 };
 
 StatusMessage.propTypes = {
-  message: PropTypes.string,
+  message: PropTypes.object,
 };
 
 export default StatusMessage;


### PR DESCRIPTION
## Description

While working on [1665](https://github.com/meedan/check-web/pull/1665) and trying to fix testing. I found it kinda annoying some warnings in the output of the unit test console. It makes it more tedious to find true errors. This PR makes changes to remove some of them. The biggest chunk remaining will be cleaned up when replace the autogrow textfields with our own CDS version, since the "errors" are around the mui textarea component:
`Warning: NaN is an invalid value for the `height` css style property.`

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Rerunning unit tests

## Things to pay attention to during code review

I will note in comments which errors the changes address

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
