### PR TITLE
Hide tipline setting "smooch_time_to_send_request"

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotSettings.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSettings.js
@@ -18,14 +18,12 @@ const SmoochBotSettings = (props) => {
         installationId={props.installationId}
       />
 
-      {['smooch_time_to_send_request', 'smooch_disabled'].map(field => (
-        <SmoochBotSetting
-          field={field}
-          value={props.settings[field]}
-          schema={fields[field]}
-          onChange={props.onChange}
-        />
-      ))}
+      <SmoochBotSetting
+        field="smooch_disabled"
+        value={props.settings.smooch_disabled}
+        schema={fields.smooch_disabled}
+        onChange={props.onChange}
+      />
 
       { props.currentUser.is_admin ?
         <Box mt={2}>


### PR DESCRIPTION
## Description

Hide tipline setting "smooch_time_to_send_request", since we don't use it in backend anymore.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Load the tipline settings page, click on the tab "Settings" and "Pause the bot" should be the first setting. There shouldn't be a "Time to send request" setting field anymore.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
