### PR TITLE
Display "content search field" for feeds.

### DIFF
--- a/src/app/components/search/Search.js
+++ b/src/app/components/search/Search.js
@@ -134,5 +134,5 @@ Search.propTypes = {
   defaultQuery: PropTypes.object.isRequired, // may be empty
   showExpand: PropTypes.bool,
   resultType: PropTypes.string, // 'default' or 'feed', for now
-  extra: PropTypes.node, // or null
+  extra: PropTypes.oneOfType([PropTypes.node, PropTypes.func]), // or null
 };

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -417,16 +417,15 @@ function SearchResultsComponent({
               }
             </div>
           </div>
-          { resultType !== 'factCheck' ?
-            <SearchKeyword
-              query={stateQuery}
-              setStateQuery={setStateQuery}
-              title={title}
-              team={team}
-              showExpand={showExpand}
-              cleanupQuery={cleanupQuery}
-              handleSubmit={handleSubmit}
-            /> : null }
+          <SearchKeyword
+            query={stateQuery}
+            setStateQuery={setStateQuery}
+            title={title}
+            team={team}
+            showExpand={showExpand}
+            cleanupQuery={cleanupQuery}
+            handleSubmit={handleSubmit}
+          />
         </div>
       </div>
       <div className={cx('search__results-top', styles['search-results-top'])}>


### PR DESCRIPTION
## Description

Previously, the content search field (top-right corner of the screen) was hidden for feeds. This PR displays it and also fixes a warning.

Reference: CV2-3778.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. Go to a feed page. You should see the content search field on the top-right corner.

## Things to pay attention to during code review

Hopefully this is all we need :)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
