### PR TITLE
Parse "compound names" in tz database

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -121,7 +121,9 @@ const NewsletterComponent = ({
       // We have to do `new Date` twice here -- the `Date.parse` gives us a date object with no timezone associated. We wrap that in `new Date` to turn it from a string to a Date object. That object then uses `toLocaleString` to localize it to a string with the correct time derived from our `timezone` which is either `'Region/Zone'` or `'Region/Zone (GMT+xx:xx)'`, which we extract via regex. This gives us a second string, which we then convert back to Date object so we can compare it to the current unix epoch time. We specify 'en-US' for the localeString conversion since that is how the database is storing the datetime.
       const date = new Date(Date.parse(`${sendOn} ${time} +0000`));
       const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
-      const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone.match(/^\w*\/\w*/) && timezone.match(/^\w*\/\w*/)[0] }));
+      // Parse for `Foo/Bar` and `Foo/Bar/Baz`
+      const timeZoneRegex = /^\w*\/\w*(\/\w*)?/;
+      const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone.match(/^\w*\/\w*/) && timezone.match(timeZoneRegex)[0] }));
       const offset = utcDate.getTime() - tzDate.getTime();
       date.setTime(date.getTime() + offset);
       const scheduledDateTime = date;

--- a/src/app/components/team/Newsletter/NewsletterComponent.test.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.test.js
@@ -72,7 +72,7 @@ describe('<NewsletterComponent />', () => {
     expect(header.props().overlayText).toEqual('Some overlay');
   });
 
-  it('renders static newsletter correctly', () => {
+  it('renders rss newsletter correctly', () => {
     const newsletter = shallow(<NewsletterComponentTest
       team={teamRss}
       setFlashMessage={() => {}}


### PR DESCRIPTION
Time zones like `America/Argentina/Buenos_Aires` were being parsed incorrectly. When I wrote this code I assumed that all timezones in tzdb were formatted `Foo/Bar`. This is not true, some are formatted `Foo/Bar/Baz` and that needs to be taken into account here. For more info see "Location" here https://en.wikipedia.org/wiki/Tz_database#Location

Also fixed a unit test name

References: CV2-3854

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I tested the regexes locally, and also double checked the tzdb documentation in case there were other weird formats, and it seems there are not.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
