### PR TITLE
Bugfix on conversation history: Display messages related to media submission without caption.

### DIFF
--- a/src/app/components/layout/ChatHistory.js
+++ b/src/app/components/layout/ChatHistory.js
@@ -112,7 +112,7 @@ const ChatHistory = ({
 
     // Concatenate with a media URL if there is one
     if (mediaUrl) {
-      preParsedText = `${mediaUrl}\n\n${preParsedText}`;
+      preParsedText = [mediaUrl, preParsedText].filter(contentSection => !!contentSection).join('\n\n');
     }
 
     // Return a proper icon for the message event type
@@ -145,7 +145,7 @@ const ChatHistory = ({
           { [styles['bot-message']]: !userMessage },
         )}
       >
-        { content ?
+        { preParsedText ?
           <div className={cx(
             'typography-body1',
             styles[`message-event-${messageEvent ? messageEvent.replaceAll('_', '-') : 'default'}`],


### PR DESCRIPTION
## Description

There was a bug that was not displaying in the conversation history messages related to media submissions when there was no caption (so, cases where the message had only the media file attachment without text). This PR fixes this case.

Reference: CV2-3853.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- Submit a media file to a tipline, without any text
- Go to the conversation history
- The history should show an entry for that message, with just a link to the file

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
