### PR TITLE
Minor fix to timezone parsing safety check

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.js
+++ b/src/app/components/team/Newsletter/NewsletterComponent.js
@@ -123,7 +123,7 @@ const NewsletterComponent = ({
       const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
       // Parse for `Foo/Bar` and `Foo/Bar/Baz`
       const timeZoneRegex = /^\w*\/\w*(\/\w*)?/;
-      const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone.match(/^\w*\/\w*/) && timezone.match(timeZoneRegex)[0] }));
+      const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone.match(timeZoneRegex) && timezone.match(timeZoneRegex)[0] }));
       const offset = utcDate.getTime() - tzDate.getTime();
       date.setTime(date.getTime() + offset);
       const scheduledDateTime = date;


### PR DESCRIPTION
Just a quick fix to a safety check -- technically it isn't even a bug because the `()` clause in the regexp is by definition optional, but it makes the code clearer.

References: CV2-3854

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
