### PR TITLE
Display Tagger bot in Integrations tab only when Paraphrase Multilingual text similarity model is in use

### DIFF
--- a/src/app/components/team/TeamBots.js
+++ b/src/app/components/team/TeamBots.js
@@ -109,6 +109,15 @@ class TeamBots extends Component {
             return null;
           }
 
+          // The Tagger bot just works well with the Paraphrase Multilingual model, so let's display it only when that model is in use
+          if (bot.identifier === 'tagger') {
+            const PARAPHRASE_MULTILINGUAL_MODEL = 'paraphrase-multilingual-mpnet-base-v2';
+            const textModel = team?.alegre_bot?.alegre_settings?.text_similarity_model;
+            if (!textModel || (typeof textModel === 'string' && textModel !== PARAPHRASE_MULTILINGUAL_MODEL) || (!textModel.includes(PARAPHRASE_MULTILINGUAL_MODEL))) {
+              return null;
+            }
+          }
+
           const botExpanded = installation && this.state.expanded === bot.dbid;
           return (
             <div key={`bot-${bot.dbid}`} className={cx(settingsStyles['setting-content-container'], styles['integration-bot'])}>

--- a/src/app/components/team/TeamIntegrations.js
+++ b/src/app/components/team/TeamIntegrations.js
@@ -38,6 +38,9 @@ const TeamIntegrations = () => (<QueryRenderer
               }
             }
           }
+          alegre_bot: team_bot_installation(bot_identifier: "alegre") {
+            alegre_settings
+          }
           ...SlackConfig_team
         }
         team_bots_listed(first: 10000) {


### PR DESCRIPTION
## Description

The Tagger bot doesn't work well with other models, so, let's display the Tagger bot in Integrations tab only when Paraphrase Multilingual text similarity model is in use.

Reference: CV2-3877.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- If "paraphrase multilingual" text vector model is enabled under "Similarity" tab, the Tagger bot should be visible in the "Integrations" tab
- Otherwise, the Tagger bot should not be visible in the "Integrations" tab

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
