### PR TITLE
Quick fix: tags column crashing on initial load

### DIFF
--- a/src/app/components/search/SearchResultsTable/TagsCell.js
+++ b/src/app/components/search/SearchResultsTable/TagsCell.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import ValueListCell from './ValueListCell';
 
 export default function TagsCell({ projectMedia }) {
-  const tags = projectMedia.list_columns_values.tags_as_sentence
-    .split(',').map(t => t.trim()).filter(t => t !== '');
+  const tags = projectMedia.list_columns_values?.tags_as_sentence
+    ?.split(',').map(t => t.trim()).filter(t => t !== '');
 
   return (<ValueListCell values={tags} noValueLabel="-" />);
 }

--- a/src/app/components/search/SearchResultsTable/ValueListCell.js
+++ b/src/app/components/search/SearchResultsTable/ValueListCell.js
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
   chip: {
     color: 'var(--otherWhite)',
     fontSize: 12,
+    marginTop: '2px',
   },
   noFactCheck: {
     background: 'var(--alertMain)',


### PR DESCRIPTION
When we change the column settings so that the Tags column is in there, and then navigate to All Items, there is an initial render of the component where `tags_as_sentence` is undefined that throws an error, followed by the actual updated render. This commit briefly renders an empty tags column until the the data is available shortly after.

Also a minor CSS fix to how the tags are displayed.

![image](https://github.com/meedan/check-web/assets/266454/b9507251-adcf-4f52-bb0e-80f19a64dd58)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I reproduced the issue reported in Slack by going to my local environment, changing column settings so the Tags column is displayed, then clicking "All Items" in the left side menu, and observing a crash. The crash doesn't happen after this first load, but if you move the Tags column back, hard reload the page, and repeat, it is repeatable. After applying this patch, I was unable to reproduce it at all.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
