### PR TITLE
On media page, "Suggestions" tab should be the default when there are requests and suggestions

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -35,6 +35,9 @@ class MediaComponent extends Component {
     let initialTab = 'metadata';
     if (showRequests && this.props.view !== 'similarMedia') {
       initialTab = 'requests';
+      if (this.props.projectMedia.suggested_similar_items_count > 0) {
+        initialTab = 'suggestedMedia';
+      }
     } else if (this.props.view === 'similarMedia') {
       initialTab = 'suggestedMedia';
     }
@@ -268,6 +271,7 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
     creator_name
     user_id
     channel
+    suggested_similar_items_count
     suggested_similar_relationships(first: 10000) {
       edges {
         node {


### PR DESCRIPTION
## Description

Currently, the default tab on the media page is "Requests". This PR changes it to "Suggestions", when there are both suggestions and requests associated with that item.

Reference: CV2-765.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- Open an item that has requests but no suggestions: the default tab should be Requests
- Open an item that has suggestions and requests: the default tab should be Suggestions

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
