### PR TITLE
UI component to manage NLU keywords.

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "smoochBotMenuKeywords.errorMessage",
+    "description": "Error message displayed when NLU keywords for a given tipline menu item can't be updated. NLU stands for Natural Language Understanding.",
+    "defaultMessage": "Could not update NLU keywords"
+  },
+  {
+    "id": "smoochBotMenuKeywords.successMessage",
+    "description": "Success message displayed when NLU keywords for a given tipline menu item are updated successfully. NLU stands for Natural Language Understanding.",
+    "defaultMessage": "NLU keywords updated successfully"
+  },
+  {
+    "id": "smoochBotMenuKeywords.title",
+    "description": "Label for tags component on tipline menu option editing screen.",
+    "defaultMessage": "Keywords (super-admin only)"
+  },
+  {
+    "id": "smoochBotMenuKeywords.helperText",
+    "description": "Helper text for tags component on tipline menu option editing screen.",
+    "defaultMessage": "Keywords and phrases  that should match this menu item for NLU."
+  }
+]

--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
@@ -17,6 +17,6 @@
   {
     "id": "smoochBotMenuKeywords.helperText",
     "description": "Helper text for tags component on tipline menu option editing screen.",
-    "defaultMessage": "Keywords and phrases  that should match this menu item for NLU."
+    "defaultMessage": "Keywords and phrases that should match this menu item for NLU. This feature is still experimental, and changes take effect immediately. Be sure to Publish your changes before setting keywords, otherwise they can get associated with the wrong menu option."
   }
 ]

--- a/src/app/components/cds/menus-lists-dialogs/TagList.js
+++ b/src/app/components/cds/menus-lists-dialogs/TagList.js
@@ -11,6 +11,7 @@ import Chip from '../buttons-checkboxes-chips/Chip';
 import Tooltip from '../alerts-and-prompts/Tooltip';
 import LocalOfferIcon from '../../../icons/local_offer.svg';
 import AddCircleIcon from '../../../icons/add_circle.svg';
+import MediasLoading from '../../media/MediasLoading';
 
 const TagList = ({
   readOnly,
@@ -19,6 +20,7 @@ const TagList = ({
   setTags,
   maxTags,
   onClickTag,
+  saving,
 }) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -98,7 +100,7 @@ const TagList = ({
             variant="text"
             theme="text"
             size="small"
-            disabled={readOnly}
+            disabled={readOnly || saving}
             className={`int-tag-list__button--manage ${styles['tag-icon']}`}
             onClick={readOnly ? undefined : handleOpenMenu}
           />
@@ -207,6 +209,7 @@ const TagList = ({
           </span>
         </Tooltip>
       }
+      { saving && <MediasLoading theme="grey" variant="icon" size="icon" /> }
     </div>
   );
 };
@@ -216,6 +219,7 @@ TagList.defaultProps = {
   maxTags: Infinity,
   onClickTag: null,
   options: null,
+  saving: false,
 };
 
 TagList.propTypes = {
@@ -225,6 +229,7 @@ TagList.propTypes = {
   tags: PropTypes.array.isRequired,
   maxTags: PropTypes.number,
   onClickTag: PropTypes.func,
+  saving: PropTypes.bool,
 };
 
 export default TagList;

--- a/src/app/components/cds/menus-lists-dialogs/TagList.module.css
+++ b/src/app/components/cds/menus-lists-dialogs/TagList.module.css
@@ -1,7 +1,7 @@
 .grid-wrapper {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: 1fr auto 1fr auto;
   grid-template-rows: 1fr;
   width: fit-content;
 }

--- a/src/app/components/team/SmoochBot/SmoochBotConfig.js
+++ b/src/app/components/team/SmoochBot/SmoochBotConfig.js
@@ -239,10 +239,12 @@ const SmoochBotConfig = (props) => {
                 <SmoochBotMainMenu
                   key={currentLanguage}
                   languages={languages.filter(f => f !== currentLanguage)}
+                  currentLanguage={currentLanguage}
                   value={value.smooch_workflows[currentWorkflowIndex]}
                   enabledIntegrations={props.enabledIntegrations}
                   onChange={handleChangeMenu}
                   resources={resources}
+                  currentUser={props.currentUser}
                 /> : null }
             </div>
           </div>

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -29,8 +29,10 @@ const messages = defineMessages({
 const SmoochBotMainMenu = ({
   value,
   languages,
+  currentLanguage,
   resources,
   enabledIntegrations,
+  currentUser,
   intl,
   onChange,
 }) => {
@@ -130,6 +132,8 @@ const SmoochBotMainMenu = ({
         resources={resources}
         noTitleNoDescription={!whatsAppEnabled}
         canCreate={canCreateNewOption}
+        currentUser={currentUser}
+        currentLanguage={currentLanguage}
         onChangeTitle={(newValue) => { handleChangeTitle(newValue, 'smooch_state_main'); }}
         onChangeMenuOptions={(newOptions) => { handleChangeMenuOptions(newOptions, 'smooch_state_main'); }}
       />
@@ -140,6 +144,8 @@ const SmoochBotMainMenu = ({
           value={value.smooch_state_secondary}
           resources={resources}
           canCreate={canCreateNewOption}
+          currentUser={currentUser}
+          currentLanguage={currentLanguage}
           onChangeTitle={(newValue) => { handleChangeTitle(newValue, 'smooch_state_secondary'); }}
           onChangeMenuOptions={(newOptions) => { handleChangeMenuOptions(newOptions, 'smooch_state_secondary'); }}
           optional
@@ -175,8 +181,10 @@ SmoochBotMainMenu.defaultProps = {
 SmoochBotMainMenu.propTypes = {
   value: PropTypes.object,
   languages: PropTypes.arrayOf(PropTypes.string),
+  currentLanguage: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
   enabledIntegrations: PropTypes.object.isRequired,
+  currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }).isRequired,
   onChange: PropTypes.func.isRequired,
   resources: PropTypes.arrayOf(PropTypes.object),
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -4,11 +4,17 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import Select from '../../cds/inputs/Select';
 import LimitedTextArea from '../../layout/inputs/LimitedTextArea';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
+import SmoochBotMenuKeywords from './SmoochBotMenuKeywords';
 
 const SmoochBotMainMenuOption = ({
   currentTitle,
   currentDescription,
   currentValue,
+  currentUser,
+  currentKeywords,
+  currentLanguage,
+  menu,
+  index,
   resources,
   onSave,
   onCancel,
@@ -78,6 +84,14 @@ const SmoochBotMainMenuOption = ({
             onBlur={(e) => { setDescription(e.target.value); }}
             maxChars={72}
             variant="contained"
+          />
+          <br />
+          <SmoochBotMenuKeywords
+            keywords={currentKeywords}
+            currentUser={currentUser}
+            menu={menu}
+            currentLanguage={currentLanguage}
+            index={index}
           />
           <br />
           <FormattedMessage
@@ -161,17 +175,26 @@ const SmoochBotMainMenuOption = ({
 };
 
 SmoochBotMainMenuOption.defaultProps = {
+  resources: [],
   currentTitle: '',
   currentDescription: '',
   currentValue: null,
-  resources: [],
+  currentUser: null,
+  currentLanguage: null,
+  currentKeywords: [],
+  index: null,
 };
 
 SmoochBotMainMenuOption.propTypes = {
+  resources: PropTypes.arrayOf(PropTypes.object),
   currentTitle: PropTypes.string,
   currentDescription: PropTypes.string,
   currentValue: PropTypes.string,
-  resources: PropTypes.arrayOf(PropTypes.object),
+  currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }),
+  currentKeywords: PropTypes.arrayOf(PropTypes.string),
+  currentLanguage: PropTypes.string,
+  menu: PropTypes.oneOf(['main', 'secondary']).isRequired,
+  index: PropTypes.number,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -24,11 +24,17 @@ const SmoochBotMainMenuOption = ({
   const [description, setDescription] = React.useState(currentDescription);
   const [value, setValue] = React.useState(currentValue);
   const [submitted, setSubmitted] = React.useState(false);
+  const [keywordsUpdated, setKeywordsUpdated] = React.useState(false);
 
   const handleSave = () => {
     setSubmitted(true);
     if (text && value) {
       onSave(text, description, value);
+    }
+    if (keywordsUpdated) {
+      // Reload the page so settings are refreshed
+      // This is necessary because keywords are updated using Relay Modern and tipline settings are still using Relay classic, so they don't share the same store
+      window.location.reload();
     }
   };
 
@@ -92,6 +98,7 @@ const SmoochBotMainMenuOption = ({
             menu={menu}
             currentLanguage={currentLanguage}
             index={index}
+            onUpdateKeywords={() => { setKeywordsUpdated(true); }}
           />
           <br />
           <FormattedMessage

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -19,6 +19,8 @@ const SmoochBotMainMenuSection = ({
   readOnly,
   optional,
   noTitleNoDescription,
+  currentUser,
+  currentLanguage,
   canCreate,
   onChangeTitle,
   onChangeMenuOptions,
@@ -28,6 +30,7 @@ const SmoochBotMainMenuSection = ({
   const [showErrorDialog, setShowErrorDialog] = React.useState(false);
 
   const options = value.smooch_menu_options || [];
+  const menu = { 1: 'main', 2: 'secondary' }[number];
 
   const handleAddNewOption = () => {
     if (canCreate) {
@@ -266,17 +269,27 @@ const SmoochBotMainMenuSection = ({
 
       {/* Dialog: Add new option */}
       { showNewOptionDialog ?
-        <SmoochBotMainMenuOption resources={resources} onSave={handleSaveNewOption} onCancel={handleCancel} /> : null }
+        <SmoochBotMainMenuOption
+          menu={menu}
+          resources={resources}
+          onSave={handleSaveNewOption}
+          onCancel={handleCancel}
+        /> : null }
 
       {/* Dialog: Edit option */}
       { editingOptionIndex > -1 ?
         <SmoochBotMainMenuOption
+          menu={menu}
           resources={resources}
+          onSave={handleSaveOption}
+          onCancel={handleCancel}
           currentTitle={options[editingOptionIndex].smooch_menu_option_label}
           currentDescription={options[editingOptionIndex].smooch_menu_option_description}
           currentValue={options[editingOptionIndex].smooch_menu_option_value === 'custom_resource' ? options[editingOptionIndex].smooch_menu_custom_resource_id : options[editingOptionIndex].smooch_menu_option_value}
-          onSave={handleSaveOption}
-          onCancel={handleCancel}
+          currentUser={currentUser}
+          currentKeywords={options[editingOptionIndex].smooch_menu_option_nlu_keywords}
+          index={editingOptionIndex}
+          currentLanguage={currentLanguage}
         /> : null }
 
       {/* Dialog: Can't add more menu options */}
@@ -331,6 +344,8 @@ SmoochBotMainMenuSection.propTypes = {
   optional: PropTypes.bool,
   noTitleNoDescription: PropTypes.bool,
   canCreate: PropTypes.bool,
+  currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }).isRequired,
+  currentLanguage: PropTypes.string.isRequired,
   onChangeTitle: PropTypes.func.isRequired,
   onChangeMenuOptions: PropTypes.func.isRequired,
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { commitMutation, graphql } from 'react-relay/compat';
+import { Store } from 'react-relay/classic';
+import TagList from '../../cds/menus-lists-dialogs/TagList';
+import { withSetFlashMessage } from '../../FlashMessage';
+
+// This is used for the NLU integration
+
+const SmoochBotMenuKeywords = ({
+  menu,
+  index,
+  currentLanguage,
+  currentUser,
+  keywords: savedKeywords,
+  setFlashMessage,
+}) => {
+  const [keywords, setKeywords] = React.useState(savedKeywords);
+  const [saving, setSaving] = React.useState(false);
+
+  // This feature is enabled only for super-admins and only when editing options
+  if (!currentUser?.is_admin) {
+    return null;
+  }
+
+  const handleError = () => {
+    const message = (
+      <FormattedMessage
+        id="smoochBotMenuKeywords.errorMessage"
+        defaultMessage="Could not update NLU keywords"
+        description="Error message displayed when NLU keywords for a given tipline menu item can't be updated. NLU stands for Natural Language Understanding."
+      />
+    );
+    setFlashMessage(message, 'error');
+    setSaving(false);
+  };
+
+  const handleSuccess = () => {
+    const message = (
+      <FormattedMessage
+        id="smoochBotMenuKeywords.successMessage"
+        defaultMessage="NLU keywords updated successfully"
+        description="Success message displayed when NLU keywords for a given tipline menu item are updated successfully. NLU stands for Natural Language Understanding."
+      />
+    );
+    setFlashMessage(message, 'success');
+    setSaving(false);
+  };
+
+  const handleToggleKeyword = (keyword, mutation) => {
+    setSaving(true);
+
+    commitMutation(Store, {
+      mutation,
+      variables: {
+        input: {
+          menu,
+          keyword,
+          menuOptionIndex: index,
+          language: currentLanguage,
+        },
+      },
+      onCompleted: (response, error) => {
+        if (!error && (response.addNluKeywordToTiplineMenu?.success || response.removeNluKeywordFromTiplineMenu?.success)) {
+          handleSuccess();
+        } else {
+          handleError();
+        }
+      },
+      onError: () => {
+        handleError();
+      },
+    });
+  };
+
+  const handleAddKeyword = (keyword) => {
+    const mutation = graphql`
+      mutation SmoochBotMenuKeywordsAddNluKeywordToTiplineMenuMutation($input: AddKeywordToTiplineMenuInput!) {
+        addNluKeywordToTiplineMenu(input: $input) {
+          success
+        }
+      }
+    `;
+    handleToggleKeyword(keyword, mutation);
+  };
+
+  const handleRemoveKeyword = (keyword) => {
+    const mutation = graphql`
+      mutation SmoochBotMenuKeywordsRemoveNluKeywordFromTiplineMenuMutation($input: RemoveKeywordFromTiplineMenuInput!) {
+        removeNluKeywordFromTiplineMenu(input: $input) {
+          success
+        }
+      }
+    `;
+    handleToggleKeyword(keyword, mutation);
+  };
+
+  const handleSetTags = (newKeywords) => {
+    // Adding tag
+    if (newKeywords.length > keywords.length) {
+      const difference = newKeywords.filter(x => !keywords.includes(x));
+      const keyword = difference[0];
+      handleAddKeyword(keyword);
+    // Deleting tag
+    } else if (newKeywords.length < keywords.length) {
+      const difference = keywords.filter(x => !newKeywords.includes(x));
+      const keyword = difference[0];
+      handleRemoveKeyword(keyword);
+    }
+    setKeywords(newKeywords);
+  };
+
+  return (
+    <div>
+      <p>
+        <FormattedMessage
+          tagName="span"
+          id="smoochBotMenuKeywords.title"
+          defaultMessage="Keywords (super-admin only)"
+          description="Label for tags component on tipline menu option editing screen."
+        />
+        <br />
+        <FormattedMessage
+          tagName="small"
+          id="smoochBotMenuKeywords.helperText"
+          defaultMessage="Keywords and phrases  that should match this menu item for NLU."
+          description="Helper text for tags component on tipline menu option editing screen."
+        />
+      </p>
+      <TagList
+        readOnly={saving}
+        setTags={handleSetTags}
+        onClickTag={() => {}}
+        options={[]}
+        tags={keywords}
+      />
+    </div>
+  );
+};
+
+SmoochBotMenuKeywords.defaultProps = {
+  currentUser: null,
+  currentLanguage: null,
+  index: null,
+  keywords: [],
+};
+
+SmoochBotMenuKeywords.propTypes = {
+  menu: PropTypes.oneOf(['main', 'secondary']).isRequired,
+  currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }),
+  currentLanguage: PropTypes.string,
+  index: PropTypes.number,
+  keywords: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default withSetFlashMessage(SmoochBotMenuKeywords);

--- a/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
@@ -14,6 +14,7 @@ const SmoochBotMenuKeywords = ({
   currentLanguage,
   currentUser,
   keywords: savedKeywords,
+  onUpdateKeywords,
   setFlashMessage,
 }) => {
   const [keywords, setKeywords] = React.useState(savedKeywords);
@@ -46,6 +47,7 @@ const SmoochBotMenuKeywords = ({
     );
     setFlashMessage(message, 'success');
     setSaving(false);
+    onUpdateKeywords();
   };
 
   const handleToggleKeyword = (keyword, mutation) => {
@@ -124,7 +126,7 @@ const SmoochBotMenuKeywords = ({
         <FormattedMessage
           tagName="small"
           id="smoochBotMenuKeywords.helperText"
-          defaultMessage="Keywords and phrases  that should match this menu item for NLU."
+          defaultMessage="Keywords and phrases that should match this menu item for NLU. This feature is still experimental, and changes take effect immediately. Be sure to Publish your changes before setting keywords, otherwise they can get associated with the wrong menu option."
           description="Helper text for tags component on tipline menu option editing screen."
         />
       </p>
@@ -153,6 +155,7 @@ SmoochBotMenuKeywords.propTypes = {
   currentLanguage: PropTypes.string,
   index: PropTypes.number,
   keywords: PropTypes.arrayOf(PropTypes.string),
+  onUpdateKeywords: PropTypes.func.isRequired,
 };
 
 export default withSetFlashMessage(SmoochBotMenuKeywords);

--- a/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
@@ -134,6 +134,7 @@ const SmoochBotMenuKeywords = ({
         onClickTag={() => {}}
         options={[]}
         tags={keywords}
+        saving={saving}
       />
     </div>
   );


### PR DESCRIPTION
## Description

Super-admins see the tags component on the dialog that opens when they try to edit a tipline menu option. They can use that component to add and remove keywords for the NLU feature.

When a tipline menu option is associated with a keyword or phrase, any message sent to the tipline that matches that keyword will have the same effect as if that menu option was clicked.

Reference: CV2-3709.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I'm still going to add unit tests for the keywords component.

## Things to pay attention to during code review

This feature is still in beta, so I tried to isolate it as much as possible in one single self-contained new component.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
