### PR TITLE
"Shared Feeds" sidebar refactoring

### DIFF
--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -350,8 +350,8 @@ const ProjectsComponent = ({
                   break;
                 // Feeds not created by the workspace, but joined upon invitation
                 case 'FeedTeam':
-                  itemProps = { routePrefix: 'feed-team' };
-                  itemType = 'feed-team';
+                  itemProps = { routePrefix: 'feed' };
+                  itemType = 'feed';
                   break;
                 // Feed invitations received but not processed yet
                 case 'FeedInvitation':

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -339,17 +339,39 @@ const ProjectsComponent = ({
               </ListItemText>
             </ListItem> :
             <>
-              {feeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map(feed => (
-                <ProjectsListItem
-                  key={feed.id}
-                  routePrefix="feed"
-                  routeSuffix="/feed"
-                  project={feed}
-                  teamSlug={team.slug}
-                  onClick={handleClick}
-                  isActive={isActive('feed', feed.dbid)}
-                />
-              ))}
+              {feeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map((feed) => {
+                let itemProps = {};
+                let itemType = null;
+                switch (feed.type) {
+                // Feeds created by the workspace
+                case 'Feed':
+                  itemProps = { routePrefix: 'feed', routeSuffix: '/feed' };
+                  itemType = 'feed';
+                  break;
+                // Feeds not created by the workspace, but joined upon invitation
+                case 'FeedTeam':
+                  itemProps = { routePrefix: 'feed-team' };
+                  itemType = 'feed-team';
+                  break;
+                // Feed invitations received but not processed yet
+                case 'FeedInvitation':
+                  itemProps = { routePrefix: 'feed-invitation' };
+                  itemType = 'feed';
+                  break;
+                default:
+                  break;
+                }
+                return (
+                  <ProjectsListItem
+                    key={feed.id}
+                    project={feed}
+                    teamSlug={team.slug}
+                    onClick={handleClick}
+                    isActive={isActive(itemType, feed.dbid)}
+                    {...itemProps}
+                  />
+                );
+              })}
             </>
           }
         </Collapse>

--- a/src/app/components/drawer/Projects/index.js
+++ b/src/app/components/drawer/Projects/index.js
@@ -6,14 +6,16 @@ import ProjectsComponent from './ProjectsComponent';
 
 const renderQuery = ({ error, props }) => {
   if (!error && props) {
+    const feedsCreated = props.team.feeds.edges.map(f => f.node).filter(f => f.team_id === props.team.dbid);
+    const feedsJoined = props.team.feed_teams.edges.map(ft => ft.node).filter(ft => !feedsCreated.find(f => f.dbid === ft.feed_id));
+    const feedsInvited = props.me.feed_invitations.edges.map(f => f.node).filter(fi => fi.state === 'invited');
+    const feeds = [].concat(feedsCreated, feedsJoined, feedsInvited);
     return (
       <ProjectsComponent
         currentUser={props.me}
         team={props.team}
-        projects={props.team.projects.edges.map(p => p.node)}
-        projectGroups={props.team.project_groups.edges.map(pg => pg.node)}
         savedSearches={props.team.saved_searches.edges.map(ss => ss.node)}
-        feeds={props.team.feeds.edges.map(f => f.node)}
+        feeds={feeds.map(f => ({ ...f, title: (f.name || f.feed?.name) }))}
       />
     );
   }
@@ -38,6 +40,19 @@ const Projects = () => {
         query ProjectsQuery($teamSlug: String!) {
           me {
             dbid
+            feed_invitations(first: 10000) {
+              edges {
+                node {
+                  id
+                  dbid
+                  state
+                  feed {
+                    name
+                  }
+                  type: __typename
+                }
+              }
+            }
           }
           team(slug: $teamSlug) {
             dbid
@@ -54,27 +69,6 @@ const Projects = () => {
             alegre_bot: team_bot_installation(bot_identifier: "alegre") {
               id
               alegre_settings
-            }
-            projects(first: 10000) {
-              edges {
-                node {
-                  id
-                  dbid
-                  title
-                  medias_count
-                  project_group_id
-                }
-              }
-            }
-            project_groups(first: 10000) {
-              edges {
-                node {
-                  id
-                  dbid
-                  title
-                  medias_count
-                }
-              }
             }
             saved_searches(first: 10000) {
               edges {
@@ -94,6 +88,21 @@ const Projects = () => {
                   id
                   dbid
                   name
+                  team_id
+                  type: __typename
+                }
+              }
+            }
+            feed_teams(first: 10000) {
+              edges {
+                node {
+                  id
+                  dbid
+                  feed_id
+                  feed {
+                    name
+                  }
+                  type: __typename
                 }
               }
             }


### PR DESCRIPTION
## Description

List three different types of objects in the "shared feeds" sections on the sidebar:

* Feeds created by the workspace (nodes of type `Feed` - route format stays as `/:workspace-slug/feed/:feed-dbid/feed`)
* Feeds not created by the workspace, but joined upon invitation (nodes of type `FeedTeam` - route format `/:workspace-slug/feed-team/:feed-team-dbid`)
* Feed invitations received by the current user that were not processed yet (nodes of type `FeedInvitation` - route format `/:workspace-slug/feed-invitation/:feed-invitation-dbid`)

Reference: CV2-3900.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

When there are feeds created, joined and invited, they should be listed in a single list, sorted alphabetically. Routes are different depending on the node type, as per GIF below.

![ezgif com-video-to-gif](https://github.com/meedan/check-web/assets/117518/05b1bdee-3126-4e38-974d-5f2a9c5727db)

## Things to pay attention to during code review

I took the opportunity to clean up some legacy stuff related to projects and project groups. I'm not implementing new design here, just implementing the minimum to unblock other work.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
