### PR TITLE
Block updating NLU settings if there are unsaved changes to tipline settings

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.json
@@ -17,6 +17,11 @@
   {
     "id": "smoochBotMenuKeywords.helperText",
     "description": "Helper text for tags component on tipline menu option editing screen.",
-    "defaultMessage": "Keywords and phrases that should match this menu item for NLU. This feature is still experimental, and changes take effect immediately. Be sure to Publish your changes before setting keywords, otherwise they can get associated with the wrong menu option."
+    "defaultMessage": "Keywords and phrases that should match this menu item for NLU. Changes take effect immediately."
+  },
+  {
+    "id": "smoochBotMenuKeywords.helperTextUnsavedChanges",
+    "description": "Helper text for tags component on tipline menu option editing screen when there are unsaved changes.",
+    "defaultMessage": "There are unsaved changes to tipline settings. Please 'Publish' the tipline or reload the page and then try again."
   }
 ]

--- a/src/app/components/team/SmoochBot/SmoochBotComponent.js
+++ b/src/app/components/team/SmoochBot/SmoochBotComponent.js
@@ -39,6 +39,17 @@ const SmoochBotComponent = ({
 
   const [settings, setSettings] = React.useState(installation ? JSON.parse(installation.json_settings) : {});
 
+  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);
+
+  React.useEffect(() => {
+    setHasUnsavedChanges(false);
+  }, [installation.lock_version]);
+
+  const updateSettings = (newSettings) => {
+    setSettings(newSettings);
+    setHasUnsavedChanges(true);
+  };
+
   const userRole = UserUtil.myRole(currentUser, team.slug);
 
   const handleEditingResource = (value) => {
@@ -136,7 +147,7 @@ const SmoochBotComponent = ({
           smooch_menu_options: [],
         },
       });
-      setSettings(updatedValue);
+      updateSettings(updatedValue);
     }
     setCurrentLanguage(newValue);
   };
@@ -198,7 +209,7 @@ const SmoochBotComponent = ({
               schema={JSON.parse(bot.settings_as_json_schema)}
               uiSchema={JSON.parse(bot.settings_ui_schema)}
               value={settings}
-              onChange={setSettings}
+              onChange={updateSettings}
               currentUser={currentUser}
               userRole={userRole}
               currentLanguage={currentLanguage}
@@ -206,6 +217,7 @@ const SmoochBotComponent = ({
               enabledIntegrations={installation.smooch_enabled_integrations}
               resources={team.tipline_resources.edges.map(edge => edge.node).filter(node => node.language === currentLanguage)}
               onEditingResource={handleEditingResource}
+              hasUnsavedChanges={hasUnsavedChanges}
             /> :
             <Box display="flex" alignItems="center" justifyContent="center" mt={30} mb={30}>
               { currentUser.is_admin ?

--- a/src/app/components/team/SmoochBot/SmoochBotConfig.js
+++ b/src/app/components/team/SmoochBot/SmoochBotConfig.js
@@ -23,6 +23,7 @@ const SmoochBotConfig = (props) => {
     userRole,
     value,
     resources,
+    hasUnsavedChanges,
     onEditingResource,
   } = props;
   const [currentTab, setCurrentTab] = React.useState(0);
@@ -245,6 +246,7 @@ const SmoochBotConfig = (props) => {
                   onChange={handleChangeMenu}
                   resources={resources}
                   currentUser={props.currentUser}
+                  hasUnsavedChanges={hasUnsavedChanges}
                 /> : null }
             </div>
           </div>
@@ -276,6 +278,7 @@ SmoochBotConfig.propTypes = {
   enabledIntegrations: PropTypes.object.isRequired,
   resources: PropTypes.arrayOf(PropTypes.object),
   onEditingResource: PropTypes.func.isRequired,
+  hasUnsavedChanges: PropTypes.bool.isRequired,
 };
 
 export default SmoochBotConfig;

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -33,6 +33,7 @@ const SmoochBotMainMenu = ({
   resources,
   enabledIntegrations,
   currentUser,
+  hasUnsavedChanges,
   intl,
   onChange,
 }) => {
@@ -134,6 +135,7 @@ const SmoochBotMainMenu = ({
         canCreate={canCreateNewOption}
         currentUser={currentUser}
         currentLanguage={currentLanguage}
+        hasUnsavedChanges={hasUnsavedChanges}
         onChangeTitle={(newValue) => { handleChangeTitle(newValue, 'smooch_state_main'); }}
         onChangeMenuOptions={(newOptions) => { handleChangeMenuOptions(newOptions, 'smooch_state_main'); }}
       />
@@ -146,6 +148,7 @@ const SmoochBotMainMenu = ({
           canCreate={canCreateNewOption}
           currentUser={currentUser}
           currentLanguage={currentLanguage}
+          hasUnsavedChanges={hasUnsavedChanges}
           onChangeTitle={(newValue) => { handleChangeTitle(newValue, 'smooch_state_secondary'); }}
           onChangeMenuOptions={(newOptions) => { handleChangeMenuOptions(newOptions, 'smooch_state_secondary'); }}
           optional
@@ -185,6 +188,7 @@ SmoochBotMainMenu.propTypes = {
   intl: intlShape.isRequired,
   enabledIntegrations: PropTypes.object.isRequired,
   currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }).isRequired,
+  hasUnsavedChanges: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   resources: PropTypes.arrayOf(PropTypes.object),
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -16,6 +16,7 @@ const SmoochBotMainMenuOption = ({
   menu,
   index,
   resources,
+  hasUnsavedChanges,
   onSave,
   onCancel,
   intl,
@@ -98,6 +99,7 @@ const SmoochBotMainMenuOption = ({
             menu={menu}
             currentLanguage={currentLanguage}
             index={index}
+            hasUnsavedChanges={hasUnsavedChanges}
             onUpdateKeywords={() => { setKeywordsUpdated(true); }}
           />
           <br />
@@ -190,6 +192,7 @@ SmoochBotMainMenuOption.defaultProps = {
   currentLanguage: null,
   currentKeywords: [],
   index: null,
+  hasUnsavedChanges: false,
 };
 
 SmoochBotMainMenuOption.propTypes = {
@@ -202,6 +205,7 @@ SmoochBotMainMenuOption.propTypes = {
   currentLanguage: PropTypes.string,
   menu: PropTypes.oneOf(['main', 'secondary']).isRequired,
   index: PropTypes.number,
+  hasUnsavedChanges: PropTypes.bool,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -22,6 +22,7 @@ const SmoochBotMainMenuSection = ({
   currentUser,
   currentLanguage,
   canCreate,
+  hasUnsavedChanges,
   onChangeTitle,
   onChangeMenuOptions,
 }) => {
@@ -288,6 +289,7 @@ const SmoochBotMainMenuSection = ({
           currentValue={options[editingOptionIndex].smooch_menu_option_value === 'custom_resource' ? options[editingOptionIndex].smooch_menu_custom_resource_id : options[editingOptionIndex].smooch_menu_option_value}
           currentUser={currentUser}
           currentKeywords={options[editingOptionIndex].smooch_menu_option_nlu_keywords}
+          hasUnsavedChanges={hasUnsavedChanges}
           index={editingOptionIndex}
           currentLanguage={currentLanguage}
         /> : null }
@@ -332,6 +334,7 @@ SmoochBotMainMenuSection.defaultProps = {
   resources: [],
   readOnly: false,
   optional: false,
+  hasUnsavedChanges: false,
   noTitleNoDescription: false,
   canCreate: true,
 };
@@ -346,6 +349,7 @@ SmoochBotMainMenuSection.propTypes = {
   canCreate: PropTypes.bool,
   currentUser: PropTypes.shape({ is_admin: PropTypes.bool.isRequired }).isRequired,
   currentLanguage: PropTypes.string.isRequired,
+  hasUnsavedChanges: PropTypes.bool,
   onChangeTitle: PropTypes.func.isRequired,
   onChangeMenuOptions: PropTypes.func.isRequired,
 };

--- a/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMenuKeywords.js
@@ -14,6 +14,7 @@ const SmoochBotMenuKeywords = ({
   currentLanguage,
   currentUser,
   keywords: savedKeywords,
+  hasUnsavedChanges,
   onUpdateKeywords,
   setFlashMessage,
 }) => {
@@ -126,12 +127,23 @@ const SmoochBotMenuKeywords = ({
         <FormattedMessage
           tagName="small"
           id="smoochBotMenuKeywords.helperText"
-          defaultMessage="Keywords and phrases that should match this menu item for NLU. This feature is still experimental, and changes take effect immediately. Be sure to Publish your changes before setting keywords, otherwise they can get associated with the wrong menu option."
+          defaultMessage="Keywords and phrases that should match this menu item for NLU. Changes take effect immediately."
           description="Helper text for tags component on tipline menu option editing screen."
         />
+        { hasUnsavedChanges ?
+          <span style={{ color: 'var(--alertMain)' }}>
+            <br />
+            <FormattedMessage
+              tagName="small"
+              id="smoochBotMenuKeywords.helperTextUnsavedChanges"
+              defaultMessage="There are unsaved changes to tipline settings. Please 'Publish' the tipline or reload the page and then try again."
+              description="Helper text for tags component on tipline menu option editing screen when there are unsaved changes."
+            />
+          </span> : null
+        }
       </p>
       <TagList
-        readOnly={saving}
+        readOnly={saving || hasUnsavedChanges}
         setTags={handleSetTags}
         onClickTag={() => {}}
         options={[]}
@@ -155,6 +167,7 @@ SmoochBotMenuKeywords.propTypes = {
   currentLanguage: PropTypes.string,
   index: PropTypes.number,
   keywords: PropTypes.arrayOf(PropTypes.string),
+  hasUnsavedChanges: PropTypes.bool.isRequired,
   onUpdateKeywords: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
## Description

If there are unsaved changes to tipline settings, don't allow NLU keywords to be changed until "Publish" is clicked or the page is reloaded. This is to avoid a situation where NLU keywords can get associated with the wrong menu item.

Reference: CV2-3709.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. For example: as a super-admin, make changes to tipline settings (for example, change the order of items in a menu). Click to edit an item. The keywords component should be read-only and you should see a warning message.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
