### PR TITLE
Fix parent claim banner CV2-3913

### DIFF
--- a/src/app/components/media/Similarity/MediaSuggestionReview.js
+++ b/src/app/components/media/Similarity/MediaSuggestionReview.js
@@ -4,14 +4,6 @@ import { Store } from 'react-relay/classic';
 import { browserHistory } from 'react-router';
 import { graphql, commitMutation } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
-import cx from 'classnames/bind';
-import { makeStyles } from '@material-ui/core/styles';
-import {
-  Card,
-  CardContent,
-  Grid,
-  Typography,
-} from '@material-ui/core';
 import AcceptIcon from '../../../icons/check_circle.svg';
 import RejectIcon from '../../../icons/cancel.svg';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
@@ -19,36 +11,9 @@ import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 import GenericUnknownErrorMessage from '../../GenericUnknownErrorMessage';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { can } from '../../Can';
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    background: 'var(--alertLight)',
-    borderColor: 'var(--alertLight)',
-    borderRadius: '8px',
-    marginBottom: `${theme.spacing(2)}px`,
-    fontSize: '12px',
-  },
-  title: {
-    fontSize: '16px',
-    marginBottom: `${theme.spacing(1)}px`,
-  },
-  prompt: {
-    marginBottom: `${theme.spacing(1)}px`,
-  },
-  button: {
-    borderRadius: '8px',
-    float: 'right',
-  },
-  accept: {
-    display: 'inline-flex',
-  },
-  reject: {
-    display: 'inline-flex',
-  },
-}));
+import styles from './MediaSuggestionReview.module.css';
 
 const MediaSuggestionReview = ({ projectMedia, setFlashMessage }) => {
-  const classes = useStyles();
   const [isMutationPending, setIsMutationPending] = React.useState(false);
   const disableAcceptRejectButtons = !can(projectMedia.team.permissions, 'update Relationship') || isMutationPending;
   const suggestedMainItem = projectMedia.suggested_main_item;
@@ -234,90 +199,70 @@ const MediaSuggestionReview = ({ projectMedia, setFlashMessage }) => {
   if (projectMedia.is_confirmed_similar_to_another_item) {
     const confirmedMainItemLink = `/${confirmedMainItem?.team?.slug}/media/${confirmedMainItem?.dbid}`;
     return (
-      <Card
-        variant="outlined"
-        className={classes.root}
-        elevation={0}
-      >
-        <CardContent>
-          <Typography className={classes.title} variant="h5" component="h1">
-            <FormattedMessage id="mediaSuggestionReview.matchTitle" defaultMessage="Matched claim" description="Title of a box that lets the user open a claim that this has been matched with." />
-          </Typography>
-          <Typography className={classes.prompt} variant="body1" component="p">
-            <FormattedMessage
-              id="mediaSuggestionReview.matchDescription"
-              defaultMessage="This media has been matched to the claim and fact-check below."
-              description="Hint text to tell the user what the 'Open claim' button does."
-            />
-          </Typography>
-          <Grid container direction="row" justifyContent="center" alignItems="flex-end">
-            <Grid item xs={6}>
-              <></>
-            </Grid>
-            <Grid item xs={6}>
-              <ButtonMain
-                variant="outlined"
-                theme="text"
-                size="default"
-                className={classes.button}
-                onClick={() => browserHistory.push(confirmedMainItemLink)}
-                label={<FormattedMessage id="mediaSuggestionReview.openButtonMatched" defaultMessage="Open claim" description="A label for a button that opens a claim item" />}
-              />
-            </Grid>
-          </Grid>
-        </CardContent>
-      </Card>
+      <div className={styles.MediaSuggestionReview}>
+        <div className={styles.MediaSuggestionReviewTitle}>
+          <FormattedMessage id="mediaSuggestionReview.matchTitle" defaultMessage="Matched claim" description="Title of a box that lets the user open a claim that this has been matched with." />
+        </div>
+        <FormattedMessage
+          tagName="p"
+          id="mediaSuggestionReview.matchDescription"
+          defaultMessage="This media has been matched to the claim and fact-check below."
+          description="Hint text to tell the user what the 'Open claim' button does."
+        />
+        <div className={styles.MediaSuggestionReviewActions}>
+          <ButtonMain
+            variant="outlined"
+            theme="text"
+            size="default"
+            onClick={() => browserHistory.push(confirmedMainItemLink)}
+            label={<FormattedMessage id="mediaSuggestionReview.openButtonMatched" defaultMessage="Open claim" description="A label for a button that opens a claim item" />}
+          />
+        </div>
+      </div>
     );
   }
 
   if (!getSuggestedParentRelationshipId()) return null;
 
   return (
-    <Card
-      variant="outlined"
-      className={classes.root}
-    >
-      <CardContent>
-        <Typography className={classes.title} variant="h5" component="h1">
-          <FormattedMessage id="mediaSuggestionReview.title" defaultMessage="Suggested Claim and Fact-check" description="Title of a box that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)." />
-        </Typography>
-        <p className={cx('typography-body1', classes.prompt)}>
-          <FormattedMessage id="mediaSuggestionReview.prompt" defaultMessage="Is the Claim or Fact-check below a good match for this media?" description="Text that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)." />
-        </p>
-        <Grid container direction="row" justifyContent="center" alignItems="flex-end">
-          <Grid item xs={6}>
-            <ButtonMain
-              iconCenter={<AcceptIcon />}
-              onClick={handleAccept}
-              variant="text"
-              size="large"
-              theme="validation"
-              disabled={disableAcceptRejectButtons}
-              className={classes.accept}
-            />
-            <ButtonMain
-              iconCenter={<RejectIcon />}
-              onClick={handleReject}
-              variant="text"
-              size="large"
-              theme="error"
-              disabled={disableAcceptRejectButtons}
-              className={classes.reject}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            <ButtonMain
-              variant="outlined"
-              theme="text"
-              size="default"
-              className={classes.button}
-              onClick={() => window.open(suggestedMainItemLink, '_blank')}
-              label={<FormattedMessage id="mediaSuggestionReview.openButtonMatched" defaultMessage="Open claim" description="A label for a button that opens a claim item" />}
-            />
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
+    <div className={styles.MediaSuggestionReview}>
+      <div className={styles.MediaSuggestionReviewTitle}>
+        <FormattedMessage id="mediaSuggestionReview.title" defaultMessage="Suggested Claim and Fact-check" description="Title of a box that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)." />
+      </div>
+      <FormattedMessage
+        tagName="p"
+        id="mediaSuggestionReview.prompt"
+        defaultMessage="Is the Claim or Fact-check below a good match for this media?"
+        description="Text that prompts the user to review a suggestion for a related Claim and Fact-check (technical terms from elsewhere in the app)."
+      />
+      <div className={styles.MediaSuggestionReviewActions}>
+        <div className={styles.MediaSuggestionReviewActionsConfirm}>
+          <ButtonMain
+            iconCenter={<AcceptIcon />}
+            onClick={handleAccept}
+            variant="text"
+            size="large"
+            theme="validation"
+            disabled={disableAcceptRejectButtons}
+          />
+          <ButtonMain
+            iconCenter={<RejectIcon />}
+            onClick={handleReject}
+            variant="text"
+            size="large"
+            theme="error"
+            disabled={disableAcceptRejectButtons}
+          />
+        </div>
+        <ButtonMain
+          variant="outlined"
+          theme="text"
+          size="default"
+          onClick={() => window.open(suggestedMainItemLink, '_blank')}
+          label={<FormattedMessage id="mediaSuggestionReview.openButtonMatched" defaultMessage="Open claim" description="A label for a button that opens a claim item" />}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/src/app/components/media/Similarity/MediaSuggestionReview.module.css
+++ b/src/app/components/media/Similarity/MediaSuggestionReview.module.css
@@ -1,0 +1,28 @@
+.MediaSuggestionReview {
+  background-color: var(--alertLight);
+  border-color: var(--alertLight);
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+
+  .MediaSuggestionReviewTitle {
+    @mixin typography-subtitle2;
+
+    + p {
+      @mixin typography-body2;
+    }
+  }
+
+  .MediaSuggestionReviewActions {
+    align-items: center;
+    display: flex;
+
+    .MediaSuggestionReviewActionsConfirm {
+      align-items: center;
+      display: flex;
+      flex: 1 1 auto;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fix display of parent claim banner on item page

References: [CV2-3913](https://meedan.atlassian.net/browse/CV2-3913)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

### BEFORE
<img width="453" alt="Screenshot 2023-10-31 at 11 02 39 AM" src="https://github.com/meedan/check-web/assets/418001/b89f4cd9-6c31-4470-bc26-b152836ca349">

### BEFORE
<img width="445" alt="Screenshot 2023-10-31 at 11 02 43 AM" src="https://github.com/meedan/check-web/assets/418001/e5eb3479-480e-4ea8-840c-9f98c062941e">

### AFTER
<img width="437" alt="Screenshot 2023-10-31 at 11 01 34 AM" src="https://github.com/meedan/check-web/assets/418001/102fcf41-08cb-43ab-a5b3-b6da52ec1d39">

### AFTER
<img width="421" alt="Screenshot 2023-10-31 at 11 01 37 AM" src="https://github.com/meedan/check-web/assets/418001/89f86be3-1cf7-496c-8630-d3af3fb91d3e">



## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-3913]: https://meedan.atlassian.net/browse/CV2-3913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ