### PR TITLE
Allow textfields to have a removable button

### DIFF
--- a/localization/react-intl/src/app/components/cds/inputs/TextField.json
+++ b/localization/react-intl/src/app/components/cds/inputs/TextField.json
@@ -3,5 +3,10 @@
     "id": "textfield.required",
     "description": "A label to indicate that a form field must be filled out",
     "defaultMessage": "Required"
+  },
+  {
+    "id": "textfield.removeSelection",
+    "description": "Tooltip for button on Textfield component to remove current text of the input",
+    "defaultMessage": "Clear text"
   }
 ]

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -66,6 +66,7 @@ const SandboxComponent = ({ admin }) => {
   const [textfieldError, setTextfieldError] = React.useState(Boolean(false));
   const [textfieldDisabled, setTextfieldDisabled] = React.useState(Boolean(false));
   const [textfieldRequired, setTextfieldRequired] = React.useState(Boolean(true));
+  const [textfieldRemovable, setTextfieldRemovable] = React.useState(Boolean(true));
 
 
   const [selectLabel, setSelectLabel] = React.useState(Boolean(true));
@@ -473,6 +474,14 @@ const SandboxComponent = ({ admin }) => {
                   onChange={() => setTextfieldError(!textfieldError)}
                 />
               </li>
+              <li>
+                <SwitchComponent
+                  label="Removable"
+                  labelPlacement="top"
+                  checked={textfieldRemovable}
+                  onChange={() => setTextfieldRemovable(!textfieldRemovable)}
+                />
+              </li>
             </ul>
           </div>
           <div className={styles.componentBlockVariants}>
@@ -485,6 +494,7 @@ const SandboxComponent = ({ admin }) => {
               helpContent={textfieldHelp ? 'I can be of help to textfield' : null}
               disabled={textfieldDisabled}
               error={textfieldError}
+              onRemove={textfieldRemovable ? () => {} : null}
             />
           </div>
         </div>

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -67,6 +67,7 @@ const SandboxComponent = ({ admin }) => {
   const [textfieldDisabled, setTextfieldDisabled] = React.useState(Boolean(false));
   const [textfieldRequired, setTextfieldRequired] = React.useState(Boolean(true));
   const [textfieldRemovable, setTextfieldRemovable] = React.useState(Boolean(true));
+  const [textfieldContent, setTextfieldContent] = React.useState('');
 
 
   const [selectLabel, setSelectLabel] = React.useState(Boolean(true));
@@ -494,7 +495,9 @@ const SandboxComponent = ({ admin }) => {
               helpContent={textfieldHelp ? 'I can be of help to textfield' : null}
               disabled={textfieldDisabled}
               error={textfieldError}
-              onRemove={textfieldRemovable ? () => {} : null}
+              value={textfieldContent}
+              onChange={e => setTextfieldContent(e.target.value)}
+              onRemove={textfieldRemovable ? () => { setTextfieldContent(''); } : null}
             />
           </div>
         </div>

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -146,14 +146,14 @@ const TextField = React.forwardRef(({
           )}
         </div>
         { onRemove ?
-          <Tooltip arrow title={<FormattedMessage id="textfield.removeSelection" defaultMessage="Clear text" description="Tooltip for button on Select component to remove current text input" />}>
+          <Tooltip arrow title={<FormattedMessage id="textfield.removeSelection" defaultMessage="Clear text" description="Tooltip for button on Textfield component to remove current text of the input" />}>
             <span>
               <ButtonMain
                 iconCenter={<ClearIcon />}
                 variant="contained"
                 size="default"
                 theme="lightText"
-                className="select__clear-button"
+                className="int-clear-input__button--textfield"
                 onClick={() => { onRemove(); }}
               />
             </span>

--- a/src/app/components/cds/inputs/TextField.js
+++ b/src/app/components/cds/inputs/TextField.js
@@ -3,6 +3,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';
+import ButtonMain from '../buttons-checkboxes-chips/ButtonMain';
+import ClearIcon from '../../../icons/clear.svg';
+import Tooltip from '../alerts-and-prompts/Tooltip';
 import ErrorIcon from '../../../icons/error.svg';
 import inputStyles from '../../../styles/css/inputs.module.css';
 import styles from './TextField.module.css';
@@ -37,6 +40,7 @@ const TextField = React.forwardRef(({
   autoGrow,
   maxHeight,
   componentProps,
+  onRemove,
   ...inputProps
 }, ref) => {
   const [internalError, setInternalError] = React.useState(suppressInitialError ? false : error);
@@ -66,6 +70,7 @@ const TextField = React.forwardRef(({
           [inputStyles['label-container']],
           {
             [inputStyles['error-label']]: internalError,
+            [styles['textfield-removeable']]: onRemove,
           })
         }
         >
@@ -73,71 +78,87 @@ const TextField = React.forwardRef(({
           { required && <span className={inputStyles.required}>*<FormattedMessage id="textfield.required" defaultMessage="Required" description="A label to indicate that a form field must be filled out" /></span>}
         </div>
       )}
-      <div
-        className={cx(
-          styles['textfield-container'],
-          inputStyles['input-container'],
-          {
-            [styles.disabled]: disabled,
-            [styles['textarea-container']]: textArea,
-            [styles['textarea-autoGrow']]: autoGrow,
-            [styles['textarea-maxHeight']]: maxHeight,
-          })
-        }
-        style={{
-          maxHeight,
-        }}
-      >
-        { iconLeft && (
-          <div className={inputStyles['input-icon-left-icon']}>
-            {iconLeft}
-          </div>
-        )}
-        { textArea ? (
-          <textarea
-            className={cx(
-              'typography-body1',
-              [styles.input],
-              {
-                [styles.error]: internalError,
-                [styles.outlined]: variant === 'outlined',
-                [styles['input-icon-left']]: iconLeft,
-                [styles['input-icon-right']]: iconRight,
-              })
-            }
-            ref={ref}
-            disabled={disabled}
-            error={internalError}
-            placeholder={placeholder}
-            {...componentProps}
-            {...inputProps}
-          />
-        ) : (
-          <input
-            className={cx(
-              'typography-body1',
-              [styles.input],
-              {
-                [styles.error]: internalError,
-                [styles.outlined]: variant === 'outlined',
-                [styles['input-icon-left']]: iconLeft,
-                [styles['input-icon-right']]: iconRight,
-              })
-            }
-            ref={ref}
-            type="text"
-            disabled={disabled}
-            error={internalError}
-            placeholder={placeholder}
-            {...componentProps}
-            {...inputProps}
-          />
-        )}
-        { iconRight && (
-          <div className={inputStyles['input-icon-right-icon']}>
-            {iconRight}
-          </div>
-        )}
+      <div className={styles['textfield-wrapper']}>
+        <div
+          className={cx(
+            styles['textfield-container'],
+            inputStyles['input-container'],
+            {
+              [styles.disabled]: disabled,
+              [styles['textarea-container']]: textArea,
+              [styles['textarea-autoGrow']]: autoGrow,
+              [styles['textarea-maxHeight']]: maxHeight,
+            })
+          }
+          style={{
+            maxHeight,
+          }}
+        >
+          { iconLeft && (
+            <div className={inputStyles['input-icon-left-icon']}>
+              {iconLeft}
+            </div>
+          )}
+          { textArea ? (
+            <textarea
+              className={cx(
+                'typography-body1',
+                [styles.input],
+                {
+                  [styles.error]: internalError,
+                  [styles.outlined]: variant === 'outlined',
+                  [styles['input-icon-left']]: iconLeft,
+                  [styles['input-icon-right']]: iconRight,
+                })
+              }
+              ref={ref}
+              disabled={disabled}
+              error={internalError}
+              placeholder={placeholder}
+              {...componentProps}
+              {...inputProps}
+            />
+          ) : (
+            <input
+              className={cx(
+                'typography-body1',
+                [styles.input],
+                {
+                  [styles.error]: internalError,
+                  [styles.outlined]: variant === 'outlined',
+                  [styles['input-icon-left']]: iconLeft,
+                  [styles['input-icon-right']]: iconRight,
+                })
+              }
+              ref={ref}
+              type="text"
+              disabled={disabled}
+              error={internalError}
+              placeholder={placeholder}
+              {...componentProps}
+              {...inputProps}
+            />
+          )}
+          { iconRight && (
+            <div className={inputStyles['input-icon-right-icon']}>
+              {iconRight}
+            </div>
+          )}
+        </div>
+        { onRemove ?
+          <Tooltip arrow title={<FormattedMessage id="textfield.removeSelection" defaultMessage="Clear text" description="Tooltip for button on Select component to remove current text input" />}>
+            <span>
+              <ButtonMain
+                iconCenter={<ClearIcon />}
+                variant="contained"
+                size="default"
+                theme="lightText"
+                className="select__clear-button"
+                onClick={() => { onRemove(); }}
+              />
+            </span>
+          </Tooltip>
+          : null }
       </div>
       { helpContent && (
         <div className={cx(
@@ -163,6 +184,7 @@ TextField.defaultProps = {
   iconLeft: null,
   iconRight: null,
   label: null,
+  onRemove: null,
   placeholder: null,
   required: false,
   suppressInitialError: false,
@@ -188,6 +210,7 @@ TextField.propTypes = {
   autoGrow: PropTypes.bool,
   maxHeight: PropTypes.string,
   componentProps: PropTypes.object,
+  onRemove: PropTypes.func,
   variant: PropTypes.oneOf(['contained', 'outlined']),
 };
 

--- a/src/app/components/cds/inputs/TextField.module.css
+++ b/src/app/components/cds/inputs/TextField.module.css
@@ -1,129 +1,141 @@
 /* stylelint-disable no-descending-specificity */
-.textfield-container {
-  .input {
-    background-color: var(--otherWhite);
-    border: 2px solid var(--grayBorderMain);
-    border-radius: 8px;
-    color: var(--textPrimary);
-    font: inherit;
-    height: 100%;
-    letter-spacing: .15px;
-    line-height: 20px;
-    min-height: 48px;
-    padding: .75rem .625rem .625rem;
+.textfield-wrapper {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+
+  .textfield-container {
     width: 100%;
 
-    &.input-icon-left {
-      padding-left: 38px;
-    }
-
-    &.input-icon-right {
-      padding-right: 34px;
-    }
-
-    &:hover {
-      border-color: var(--grayBorderAccent);
-    }
-
-    &::placeholder {
-      color: var(--textPlaceholder);
-      font: 400 14px var(--fontStackSans);
+    .input {
+      background-color: var(--otherWhite);
+      border: 2px solid var(--grayBorderMain);
+      border-radius: 8px;
+      color: var(--textPrimary);
+      font: inherit;
+      height: 100%;
       letter-spacing: .15px;
       line-height: 20px;
-    }
+      min-height: 48px;
+      padding: .75rem .625rem .625rem;
+      width: 100%;
 
-    &:focus {
-      border-color: var(--brandMain);
-      outline: none;
-
-      &::placeholder {
-        color: transparent;
+      &.input-icon-left {
+        padding-left: 38px;
       }
-    }
 
-    &.outlined {
-      background-color: transparent;
-    }
-
-    &.error {
-      border-color: var(--errorMain) !important;
+      &.input-icon-right {
+        padding-right: 34px;
+      }
 
       &:hover {
-        border-color: var(--errorSecondary) !important;
+        border-color: var(--grayBorderAccent);
+      }
+
+      &::placeholder {
+        color: var(--textPlaceholder);
+        font: 400 14px var(--fontStackSans);
+        letter-spacing: .15px;
+        line-height: 20px;
       }
 
       &:focus {
+        border-color: var(--brandMain);
+        outline: none;
+
+        &::placeholder {
+          color: transparent;
+        }
+      }
+
+      &.outlined {
+        background-color: transparent;
+      }
+
+      &.error {
         border-color: var(--errorMain) !important;
+
+        &:hover {
+          border-color: var(--errorSecondary) !important;
+        }
+
+        &:focus {
+          border-color: var(--errorMain) !important;
+        }
+      }
+    }
+
+    &.textarea-container {
+      &.textarea-autoGrow {
+        display: grid;
+
+        &::after {
+          border: 2px solid transparent;
+
+          /* Note the weird space! Needed to preventy jumpy behavior */
+          content: attr(data-replicated-value) ' ';
+          margin-top: 1px;
+          max-height: inherit;
+          overflow-wrap: anywhere;
+
+          /* Hidden from view, clicks, and screen readers */
+          visibility: hidden;
+
+          /* This is how textarea text behaves */
+          white-space: pre-wrap;
+        }
+
+        > textarea {
+          height: auto;
+
+          /* Firefox shows scrollbar on growth, you can hide like this. */
+          overflow: hidden;
+          overflow-wrap: anywhere;
+
+          /* You could leave this, but after a user resizes, then it ruins the auto sizing */
+          resize: none;
+        }
+
+        > textarea,
+        &::after {
+          font: inherit;
+
+          /* Place on top of each other */
+          grid-area: 1 / 1 / 2 / 2;
+          letter-spacing: .15px;
+          line-height: 20px;
+          margin: 1px 0;
+          padding: .75rem .625rem .625rem;
+        }
+      }
+
+      &.textarea-maxHeight {
+        > textarea,
+        &::after {
+          max-height: inherit;
+          overflow-y: auto;
+        }
+      }
+
+      textarea {
+        max-width: 100%;
+      }
+    }
+
+    &.disabled {
+      .input {
+        background-color: var(--grayDisabledBackground);
+        color: var(--textDisabledInput);
+        cursor: not-allowed;
+
+        &:hover {
+          border-color: var(--grayBorderMain);
+        }
       }
     }
   }
+}
 
-  &.textarea-container {
-    &.textarea-autoGrow {
-      display: grid;
-
-      &::after {
-        border: 2px solid transparent;
-
-        /* Note the weird space! Needed to preventy jumpy behavior */
-        content: attr(data-replicated-value) ' ';
-        margin-top: 1px;
-        max-height: inherit;
-        overflow-wrap: anywhere;
-
-        /* Hidden from view, clicks, and screen readers */
-        visibility: hidden;
-
-        /* This is how textarea text behaves */
-        white-space: pre-wrap;
-      }
-
-      > textarea {
-        height: auto;
-
-        /* Firefox shows scrollbar on growth, you can hide like this. */
-        overflow: hidden;
-        overflow-wrap: anywhere;
-
-        /* You could leave this, but after a user resizes, then it ruins the auto sizing */
-        resize: none;
-      }
-
-      > textarea,
-      &::after {
-        font: inherit;
-
-        /* Place on top of each other */
-        grid-area: 1 / 1 / 2 / 2;
-        letter-spacing: .15px;
-        line-height: 20px;
-        margin: 1px 0;
-        padding: .75rem .625rem .625rem;
-      }
-    }
-
-    &.textarea-maxHeight {
-      > textarea,
-      &::after {
-        max-height: inherit;
-        overflow-y: auto;
-      }
-    }
-
-    textarea {
-      max-width: 100%;
-    }
-  }
-
-  &.disabled {
-    .input {
-      background-color: var(--grayDisabledBackground);
-      color: var(--textDisabledInput);
-      cursor: not-allowed;
-
-      &:hover {
-        border-color: var(--grayBorderMain);
-      }
-    }
-  }
+.textfield-removeable {
+  padding: 0 46px 0 0;
 }


### PR DESCRIPTION
## Description

In order to make [this WIP PR](https://github.com/meedan/check-web/pull/1710) easier to review, I have broken off this funtionality into a separate PR.

- Adds the ability to add a "remove" button to the textfield component. This is in support of the work in that PR
- This works just like the `<Select...` component's remove button
- Updates to the sandbox show functionality

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Sandbox

## Things to pay attention to during code review

### AFTER - Remove function provided:
<img width="1055" alt="Screenshot 2023-11-01 at 9 46 58 AM" src="https://github.com/meedan/check-web/assets/418001/97f3ff8e-4f63-439d-afd2-a7116662af3a">

### AFTER - no remove function
<img width="1060" alt="Screenshot 2023-11-01 at 9 46 17 AM" src="https://github.com/meedan/check-web/assets/418001/72821420-3cb7-417f-a994-5a583b2b0d8f">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [x] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
