### PR TITLE
Use correct requests count for new tab counter

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -265,6 +265,7 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
     pusher_channel
     project_id
     last_seen
+    demand
     requests_count
     picture
     show_warning_cover

--- a/src/app/components/media/MediaComponentRightPanel.js
+++ b/src/app/components/media/MediaComponentRightPanel.js
@@ -41,7 +41,7 @@ const MediaComponentRightPanel = ({
                   defaultMessage="Requests"
                   description="Label for the Requests tab, as in requests from users"
                 />
-                {projectMedia.requests_count > 0 && ` [${projectMedia.requests_count}]`}
+                {projectMedia.demand > 0 && ` [${projectMedia.demand}]`}
               </span>
             }
             value="requests"


### PR DESCRIPTION
## Description

In this previous PR [1713](https://github.com/meedan/check-web/pull/1713)
I used the incorrect total count of requests to put in the tab. Some times it was correct, but others not.
This PR changes to the correct count.

Example of incorrect:
[https://qa.checkmedia.org/check-message-demo/media/23126?listIndex=29](https://qa.checkmedia.org/check-message-demo/media/23126?listIndex=29)
<img width="298" alt="Screenshot 2023-11-06 at 10 23 30 AM" src="https://github.com/meedan/check-web/assets/418001/e5e7921b-008c-4ab7-b54d-4c1141ddb147">



## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

qa


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
