### PR TITLE
Sentry quick fix: Switching to arrow-function

### DIFF
--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -389,6 +389,7 @@ class AddAnnotation extends Component {
           />
           {this.state.fileMode ? (
             <UploadFile
+              className="int-note-annotation__upload-file-drop-zone"
               type="file"
               value={this.state.file}
               onChange={this.onFileChange}

--- a/src/app/components/annotations/AddAnnotation.js
+++ b/src/app/components/annotations/AddAnnotation.js
@@ -71,7 +71,7 @@ class AddAnnotation extends Component {
     this.setState({ file, message: null, canSubmit });
   }
 
-  onFileError(file, message) {
+  onFileError = (file, message) => {
     this.setState({ file: null, message });
   }
 


### PR DESCRIPTION
There was a bug in sentry where the `onFileError` event that occurs when someone attaches an invalid item (like wrong file type) to a Note would silently trigger an error about a missing `this`. It also meant that the error message was never correctly displayed on a note attachment file error.

Using an arrow function causes `this` to bind correctly, which means we actually update the state with the error message when an unsupported file is uploaded as seen here:

![image](https://github.com/meedan/check-web/assets/266454/d693dbdd-6726-4d07-9a99-64a8e304fd5e)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Reproduced the bug locally, manually tested that the feature works now.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [X] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
