### PR TITLE
Shared feed invitation accept interface

### DIFF
--- a/localization/react-intl/src/app/components/feed/FeedInvitation.json
+++ b/localization/react-intl/src/app/components/feed/FeedInvitation.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "feedInvitation.invited",
+    "description": "This is a fragment of text that appears after the name of a person and email address, like: '[[Bob Smith, bob@example.com]] has invited your organization to...'. The name appears above the text and this part of the sentence continues on the second row of text. The two messages combined should read like a grammatically correct sentence.",
+    "defaultMessage": "has invited your organization to contribute to a Check Shared Feed"
+  },
+  {
+    "id": "feedInvitation.prompt",
+    "description": "A question prompting the user to pick one of several workspaces from a list, reminding them that this will contribute data to a shared feed.",
+    "defaultMessage": "Which workspace will you use to contribute fact-checks to this shared feed?"
+  },
+  {
+    "id": "feedInvitation.alreadyAccepted",
+    "description": "An informational message that appears if the user tries to accept an invitation that they have already accepted.",
+    "defaultMessage": "You have already accepted this invitation."
+  },
+  {
+    "id": "feedInvitation.noWorkspaces",
+    "description": "An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page.",
+    "defaultMessage": "You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error."
+  },
+  {
+    "id": "feedInvitation.viewButton",
+    "description": "Label for a button that the user presses to view an invitation that they are going to accept or reject",
+    "defaultMessage": "View invitation"
+  }
+]

--- a/localization/react-intl/src/app/components/feed/FeedInvitationRespond.json
+++ b/localization/react-intl/src/app/components/feed/FeedInvitationRespond.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "feedInvitation.invited",
+    "description": "This is a fragment of text that appears after the name of a person and email address, like: '[[Bob Smith, bob@example.com]] has invited your organization to...'. The name appears above the text and this part of the sentence continues on the second row of text. The two messages combined should read like a grammatically correct sentence.",
+    "defaultMessage": "has invited your organization to contribute to a Check Shared Feed"
+  },
+  {
+    "id": "feedInvitation.notAdmin",
+    "description": "An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page.",
+    "defaultMessage": "You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error."
+  },
+  {
+    "id": "feedInvitation.alreadyAccepted",
+    "description": "An informational message that appears if the user tries to accept an invitation that they have already accepted.",
+    "defaultMessage": "You have already accepted this invitation."
+  },
+  {
+    "id": "feedInvitation.accept",
+    "description": "Label for a button that the user presses to accept an invitation they have received to collaborate with another organization",
+    "defaultMessage": "Accept Invitation"
+  },
+  {
+    "id": "feedInvitation.decline",
+    "description": "Label for a button that the user presses to decline an invitation they have received to collaborate with another organization",
+    "defaultMessage": "Decline Invitation"
+  },
+  {
+    "id": "feedItem.importTitle",
+    "description": "Dialog title when importing a claim from feed page.",
+    "defaultMessage": "Import data to workspace"
+  },
+  {
+    "id": "feedItem.importDescription",
+    "description": "Dialog description when importing a claim from feed page.",
+    "defaultMessage": "A new claim will be created in your workspace with media."
+  },
+  {
+    "id": "feedItem.proceedImport",
+    "description": "Button label to confirm importing claim from feed page",
+    "defaultMessage": "Import"
+  }
+]

--- a/src/app/components/Home.js
+++ b/src/app/components/Home.js
@@ -232,6 +232,7 @@ class HomeComponent extends Component {
     const routeSlug = HomeComponent.routeSlug(children);
 
     const routeIsPublic = children && children.props.route.public;
+    const routeIsSplash = children && children.props.route.splash;
 
     if (!routeIsPublic && !this.state.token) {
       if (this.state.error) {
@@ -308,7 +309,7 @@ class HomeComponent extends Component {
               bemClass('home', routeSlug, `--${routeSlug}`),
             ].join(' ')}
           >
-            {loggedIn ? (
+            {loggedIn && !routeIsSplash ? (
               <DrawerNavigation
                 loggedIn={loggedIn}
                 teamSlug={teamSlug}

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -81,6 +81,7 @@ class Root extends Component {
                   <Route path="check/me/ui-sandbox" component={Sandbox} />
                   <Route path="check/me/ui-sandbox/crash" component={SandboxCrash} />
                   <Route path="check/me(/:tab)" component={Me} />
+                  <Route path="check/feed/:feedId/invitation" component={FeedInvitation} splash />
                   <Route path="check/feed/:feedId/cluster/:clusterId" component={FeedItem} />
                   <Route path="check/feed/:feedId/request/:requestId" component={FeedClusterPage} />
                   <Route path=":team" component={Team} />
@@ -111,11 +112,10 @@ class Root extends Component {
                   <Route path=":team/suggested-matches(/:query)" component={SuggestedMatches} />
                   <Route path=":team/unmatched-media(/:query)" component={UnmatchedMedia} />
                   <Route path=":team/published(/:query)" component={Published} />
+                  <Route path=":team/feed/:feedId/invitation" component={FeedInvitationRespond} />
                   <Route path=":team/feed/:feedId/edit" component={EditFeed} />
                   <Route path=":team/feed/:feedId/:tab(/:query)" component={Feed} />
                   <Route path=":team/feed/create" component={SaveFeed} />
-                  <Route path=":team/feed-invitation/:feedInvitationId" component={FeedInvitation} splash />
-                  <Route path=":team/feed-invitation/:feedInvitationId/respond" component={FeedInvitationRespond} />
                   <Route path=":team/spam(/:query)" component={Spam} />
                   <Route path=":team/trash(/:query)" component={Trash} />
                   <Route path="*" component={NotFound} public />

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -28,6 +28,8 @@ import EditFeed from './feed/EditFeed';
 import Feed from './feed/Feed';
 import FeedItem from './feed/FeedItem';
 import FeedClusterPage from './feed/FeedClusterPage';
+import FeedInvitation from './feed/FeedInvitation';
+import FeedInvitationRespond from './feed/FeedInvitationRespond';
 import MediaPage from './media/MediaPage';
 import ReportDesigner from './media/ReportDesigner';
 import MediaTasks from './media/MediaTasks';
@@ -112,6 +114,8 @@ class Root extends Component {
                   <Route path=":team/feed/:feedId/edit" component={EditFeed} />
                   <Route path=":team/feed/:feedId/:tab(/:query)" component={Feed} />
                   <Route path=":team/feed/create" component={SaveFeed} />
+                  <Route path=":team/feed-invitation/:feedInvitationId" component={FeedInvitation} splash />
+                  <Route path=":team/feed-invitation/:feedInvitationId/respond" component={FeedInvitationRespond} />
                   <Route path=":team/spam(/:query)" component={Spam} />
                   <Route path=":team/trash(/:query)" component={Trash} />
                   <Route path="*" component={NotFound} public />

--- a/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.module.css
+++ b/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.module.css
@@ -28,6 +28,7 @@
     display: flex;
     /* stylelint-disable-next-line scale-unlimited/declaration-strict-value */
     font-size: 20px;
+    width: fit-content;
   }
 
   &.sizeSmall {

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -11,15 +11,9 @@ import styles from './FeedInvitation.module.css';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import ScheduleSendIcon from '../../icons/schedule_send.svg';
 import DoneIcon from '../../icons/done.svg';
-import NotFound from '../NotFound';
 import { can } from '../Can';
 
 const FeedInvitationComponent = ({ routeParams, ...props }) => {
-  // `feed_invitation` is null when attempting to view a feed invitation that doesn't exist or that you don't have permission to view
-  if (!props.feed_invitation) {
-    return <NotFound />;
-  }
-
   // display an error if the user is not an admin on any workspaces
   const noAdminWorkspaces = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 0;
   const oneAdminWorkspace = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 1;

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -20,7 +20,6 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
     return <NotFound />;
   }
 
-  const feedInvitationId = parseInt(routeParams.feedInvitationId, 10);
   // display an error if the user is not an admin on any workspaces
   const noAdminWorkspaces = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 0;
   const oneAdminWorkspace = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 1;
@@ -29,10 +28,10 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
   // redirect to the accept/decline page if the user only administers one workspace
   if (oneAdminWorkspace) {
     const team = props.me.teams.edges[0];
-    browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`);
+    browserHistory.push(`/${team.node.slug}/feed/${routeParams.feedId}/invitation`);
   }
 
-  const handleClick = team => browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`);
+  const handleClick = team => browserHistory.push(`/${team.node.slug}/feed/${routeParams.feedId}/invitation`);
 
   return (
     <div className={cx('feed-invitation-container', styles['feed-invitation-container'])}>
@@ -101,8 +100,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
 
 FeedInvitationComponent.propTypes = {
   routeParams: PropTypes.shape({
-    team: PropTypes.string.isRequired,
-    feedInvitationId: PropTypes.string.isRequired,
+    feedId: PropTypes.string.isRequired,
   }).isRequired,
 };
 
@@ -111,8 +109,8 @@ const FeedInvitation = ({ routeParams }) => (
     <QueryRenderer
       environment={Relay.Store}
       query={graphql`
-        query FeedInvitationQuery($feedInvitationId: ID!) {
-          feed_invitation(id: $feedInvitationId) {
+        query FeedInvitationQuery($feedId: Int) {
+          feed_invitation(feedId: $feedId) {
             state
             feed {
               name
@@ -137,7 +135,7 @@ const FeedInvitation = ({ routeParams }) => (
         }
       `}
       variables={{
-        feedInvitationId: parseInt(routeParams.feedInvitationId, 10),
+        feedId: parseInt(routeParams.feedId, 10),
       }}
       render={({ error, props }) => {
         if (!error && props) {
@@ -151,8 +149,7 @@ const FeedInvitation = ({ routeParams }) => (
 
 FeedInvitation.propTypes = {
   routeParams: PropTypes.shape({
-    team: PropTypes.string.isRequired,
-    feedInvitationId: PropTypes.string.isRequired,
+    feedId: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { QueryRenderer, graphql } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
+import { FormattedMessage } from 'react-intl';
+import cx from 'classnames/bind';
+import ErrorBoundary from '../error/ErrorBoundary';
+import Alert from '../cds/alerts-and-prompts/Alert';
+import styles from './FeedInvitation.module.css';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
+import ScheduleSendIcon from '../../icons/schedule_send.svg';
+import DoneIcon from '../../icons/done.svg';
+import NotFound from '../NotFound';
+import { can } from '../Can';
+
+const FeedInvitationComponent = ({ routeParams, ...props }) => {
+  // `feed_invitation` is null when attempting to view a feed invitation that doesn't exist or that you don't have permission to view
+  if (!props.feed_invitation) {
+    return <NotFound />;
+  }
+
+  const feedInvitationId = parseInt(routeParams.feedInvitationId, 10);
+  // display an error if the user is not an admin on any workspaces
+  const noAdminWorkspaces = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 0;
+  const oneAdminWorkspace = props.me.teams?.edges.filter(team => can(team.node.permissions, 'update Team')).length === 1;
+  const alreadyAccepted = props.feed_invitation?.state === 'accepted';
+
+  // redirect to the accept/decline page if the user only administers one workspace
+  if (oneAdminWorkspace) {
+    const team = props.me.teams.edges[0];
+    browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`);
+  }
+
+  return (
+    <div className={cx('feed-invitation-container', styles['feed-invitation-container'])}>
+      <div className={cx('feed-invitation-container-card', styles['feed-invitation-container-card'])}>
+        <div className={styles['header-icon']}>
+          <ScheduleSendIcon />
+        </div>
+        <div>
+          <div className={cx('typography-h6')}>
+            {props.feed_invitation.user.name}, <span className={styles.email}>{props.feed_invitation.user.email}</span>
+          </div>
+          <div className={cx('typography-body1', styles.invited)}>
+            <FormattedMessage id="feedInvitation.invited" defaultMessage="has invited your organization to contribute to a Check Shared Feed" description="This is a fragment of text that appears after the name of a person and email address, like: '[[Bob Smith, bob@example.com]] has invited your organization to...'. The name appears above the text and this part of the sentence continues on the second row of text. The two messages combined should read like a grammatically correct sentence." />
+          </div>
+          <div>
+            <span className={cx('typography-body1-bold')}>&ldquo;{props.feed_invitation.feed.name}&rdquo;</span>
+          </div>
+        </div>
+        <div className={cx('typography-h6')}>
+          <FormattedMessage id="feedInvitation.prompt" defaultMessage="Which workspace will you use to contribute fact-checks to this shared feed?" description="A question prompting the user to pick one of several workspaces from a list, reminding them that this will contribute data to a shared feed." />
+        </div>
+        {alreadyAccepted && (
+          <Alert
+            className={cx(styles['no-admin-alert'])}
+            contained
+            content={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
+            variant="info"
+          />
+        )}
+        {noAdminWorkspaces && (
+          <Alert
+            className={cx(styles['no-admin-alert'])}
+            contained
+            content={<FormattedMessage id="feedInvitation.noWorkspaces" defaultMessage="You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page." />}
+            variant="error"
+          />
+        )}
+        { !noAdminWorkspaces && !alreadyAccepted && props.me.teams?.edges
+          .filter(team => can(team.node.permissions, 'update Team'))
+          .map(team => (
+            <div className={cx(styles.workspace)}>
+              <div className={cx(styles.avatar)}>
+                <img src={team.node.avatar} alt={team.node.name} />
+              </div>
+              <span className="typography-body1">{team.node.name}</span>
+              <ButtonMain
+                label={<FormattedMessage id="feedInvitation.viewButton" defaultMessage="View invitation" description="Label for a button that the user presses to view an invitation that they are going to accept or reject" />}
+                iconLeft={<DoneIcon />}
+                variant="text"
+                size="small"
+                theme="validation"
+                onClick={() => browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`)}
+              />
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  );
+};
+
+FeedInvitationComponent.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    feedInvitationId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const FeedInvitation = ({ routeParams }) => (
+  <ErrorBoundary component="Feed">
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query FeedInvitationQuery($feedInvitationId: ID!) {
+          feed_invitation(id: $feedInvitationId) {
+            state
+            feed {
+              name
+            }
+            user {
+              name
+              email
+            }
+          }
+          me {
+            teams(first: 1000) {
+              edges {
+                node {
+                  name
+                  avatar
+                  slug
+                  permissions
+                }
+              }
+            }
+          }
+        }
+      `}
+      variables={{
+        feedInvitationId: parseInt(routeParams.feedInvitationId, 10),
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          return <FeedInvitationComponent routeParams={routeParams} {...props} />;
+        }
+        return null;
+      }}
+    />
+  </ErrorBoundary>
+);
+
+FeedInvitation.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    feedInvitationId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default FeedInvitation;

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -77,6 +77,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
               </div>
               <span className="typography-body1">{team.node.name}</span>
               <ButtonMain
+                className="int-feed-invitation__button--workspace"
                 label={<FormattedMessage id="feedInvitation.viewButton" defaultMessage="View invitation" description="Label for a button that the user presses to view an invitation that they are going to accept or reject" />}
                 iconLeft={<DoneIcon />}
                 variant="text"

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -32,6 +32,8 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
     browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`);
   }
 
+  const handleClick = team => browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`);
+
   return (
     <div className={cx('feed-invitation-container', styles['feed-invitation-container'])}>
       <div className={cx('feed-invitation-container-card', styles['feed-invitation-container-card'])}>
@@ -70,8 +72,13 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
         )}
         { !noAdminWorkspaces && !alreadyAccepted && props.me.teams?.edges
           .filter(team => can(team.node.permissions, 'update Team'))
+          .sort((a, b) => a.node.name.localeCompare(b.node.name))
           .map(team => (
-            <div className={cx(styles.workspace)}>
+            <div
+              className={cx(styles.workspace)}
+              onKeyDown={() => handleClick(team)}
+              onClick={() => handleClick(team)}
+            >
               <div className={cx(styles.avatar)}>
                 <img src={team.node.avatar} alt={team.node.name} />
               </div>
@@ -83,7 +90,6 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
                 variant="text"
                 size="small"
                 theme="validation"
-                onClick={() => browserHistory.push(`/${team.node.slug}/feed-invitation/${feedInvitationId}/respond`)}
               />
             </div>
           ))

--- a/src/app/components/feed/FeedInvitation.module.css
+++ b/src/app/components/feed/FeedInvitation.module.css
@@ -1,0 +1,114 @@
+.feed-invitation-container {
+  align-self: stretch;
+  display: flex;
+  gap: 32px;
+  justify-content: center;
+  padding: 100px 0;
+}
+
+.feed-invitation-container-card {
+  align-items: flex-start;
+  align-self: stretch;
+  background-color: var(--otherWhite);
+  border-radius: 8px;
+  color: var(--textPrimary);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0 32px 16px;
+  padding: 16px;
+  text-align: center;
+  width: 650px;
+
+  div {
+    width: 100%;
+  }
+
+  .header-icon {
+    align-items: center;
+    align-self: stretch;
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+
+    svg {
+      color: var(--alertMain);
+      height: 48px;
+      width: 48px;
+    }
+  }
+
+  .email {
+    color: var(--textPlaceholder);
+  }
+
+  .invited {
+    margin: 4px 0;
+  }
+
+  .description {
+    text-align: left;
+  }
+
+  .accept-decline {
+    align-items: flex-start;
+    align-self: stretch;
+    display: flex;
+    justify-content: space-between;
+    padding: 16px 0;
+  }
+
+  .action-container {
+    display: flex;
+    width: fit-content;
+
+    > div {
+      align-self: center;
+      margin-left: 8px;
+      width: fit-content;
+    }
+  }
+
+  .no-admin-alert {
+    text-align: left;
+  }
+
+  .workspace {
+    align-items: center;
+    background: var(--otherWhite);
+    border: 1px solid var(--grayBorderMain);
+    border-radius: 8px;
+    display: flex;
+    gap: 16px;
+    padding: 8px;
+    width: 618px;
+
+    button {
+      margin-left: auto;
+      visibility: hidden;
+    }
+
+    &:hover {
+      border: 1px solid var(--textLink);
+
+      button {
+        visibility: visible;
+      }
+    }
+
+    .avatar {
+      align-items: flex-start;
+      background: var(--otherWhite);
+      border: 2px solid var(--grayBorderMain);
+      border-radius: 6px;
+      display: flex;
+      gap: 12px;
+      padding: 8px;
+      width: fit-content;
+
+      img {
+        width: 24px;
+      }
+    }
+  }
+}

--- a/src/app/components/feed/FeedInvitation.module.css
+++ b/src/app/components/feed/FeedInvitation.module.css
@@ -78,6 +78,7 @@
     background: var(--otherWhite);
     border: 1px solid var(--grayBorderMain);
     border-radius: 8px;
+    cursor: pointer;
     display: flex;
     gap: 16px;
     padding: 8px;

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -124,6 +124,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
           <div className={cx(styles['accept-decline'])}>
             <div className={cx(styles['action-container'])}>
               <ButtonMain
+                className="int-feed-invitation-respond__button--accept"
                 label={<FormattedMessage id="feedInvitation.accept" defaultMessage="Accept Invitation" description="Label for a button that the user presses to accept an invitation they have received to collaborate with another organization" />}
                 variant="contained"
                 theme="brand"
@@ -135,6 +136,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
             <div className={cx(styles['action-container'])}>
               { saving && <MediasLoading theme="grey" variant="icon" size="icon" /> }
               <ButtonMain
+                className="int-feed-invitation-respond__button--reject"
                 label={<FormattedMessage id="feedInvitation.decline" defaultMessage="Decline Invitation" description="Label for a button that the user presses to decline an invitation they have received to collaborate with another organization" />}
                 variant="outlined"
                 theme="text"

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -45,7 +45,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
     return <NotFound />;
   }
 
-  const feedInvitationId = parseInt(routeParams.feedInvitationId, 10);
+  const feedInvitationId = props.feed_invitation.dbid;
   // determine if the current user is an admin of the current team
   const notAdmin = !can(props.me.current_team?.permissions, 'update Team');
   const alreadyAccepted = props.feed_invitation?.state === 'accepted';
@@ -180,7 +180,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
 FeedInvitationRespondComponent.propTypes = {
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired,
-    feedInvitationId: PropTypes.string.isRequired,
+    feedId: PropTypes.string.isRequired,
   }).isRequired,
 };
 
@@ -189,9 +189,10 @@ const FeedInvitationRespond = ({ routeParams }) => (
     <QueryRenderer
       environment={Relay.Store}
       query={graphql`
-        query FeedInvitationRespondQuery($feedInvitationId: ID!) {
-          feed_invitation(id: $feedInvitationId) {
+        query FeedInvitationRespondQuery($feedId: Int) {
+          feed_invitation(feedId: $feedId) {
             state
+            dbid
             feed {
               dbid
               name
@@ -212,7 +213,7 @@ const FeedInvitationRespond = ({ routeParams }) => (
         }
       `}
       variables={{
-        feedInvitationId: parseInt(routeParams.feedInvitationId, 10),
+        feedId: parseInt(routeParams.feedId, 10),
       }}
       render={({ error, props }) => {
         if (!error && props) {
@@ -227,7 +228,7 @@ const FeedInvitationRespond = ({ routeParams }) => (
 FeedInvitationRespond.propTypes = {
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired,
-    feedInvitationId: PropTypes.string.isRequired,
+    feedId: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -1,0 +1,232 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import { FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
+import cx from 'classnames/bind';
+import ErrorBoundary from '../error/ErrorBoundary';
+import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
+import { getErrorMessageForRelayModernProblem } from '../../helpers';
+import Alert from '../cds/alerts-and-prompts/Alert';
+import { FlashMessageSetterContext } from '../FlashMessage';
+import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
+import styles from './FeedInvitation.module.css';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
+import ScheduleSendIcon from '../../icons/schedule_send.svg';
+import NotFound from '../NotFound';
+import MediasLoading from '../media/MediasLoading';
+import { can } from '../Can';
+
+const acceptMutation = graphql`
+  mutation FeedInvitationRespondAcceptFeedInvitationMutation($input: UpdateFeedInvitationInput!) {
+    acceptFeedInvitation(input: $input) {
+      feed_invitation {
+        id
+      }
+    }
+  }
+`;
+
+const rejectMutation = graphql`
+  mutation FeedInvitationRespondRejectFeedInvitationMutation($input: RejectInput!) {
+    rejectFeedInvitation(input: $input) {
+      success
+    }
+  }
+`;
+
+const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
+  const [saving, setSaving] = React.useState(false);
+  const [confirmReject, setConfirmReject] = React.useState(false);
+  const setFlashMessage = React.useContext(FlashMessageSetterContext);
+  // `feed_invitation` is null when attempting to view a feed invitation that doesn't exist or that you don't have permission to view
+  if (!props.feed_invitation) {
+    return <NotFound />;
+  }
+
+  const feedInvitationId = parseInt(routeParams.feedInvitationId, 10);
+  // determine if the current user is an admin of the current team
+  const notAdmin = !can(props.me.current_team?.permissions, 'update Team');
+  const alreadyAccepted = props.feed_invitation?.state === 'accepted';
+
+  const onFailure = (error) => {
+    const message = getErrorMessageForRelayModernProblem(error, <GenericUnknownErrorMessage />);
+    setFlashMessage(message, 'error');
+    setSaving(false);
+  };
+
+  const handleAcceptInvite = () => {
+    setSaving(true);
+    const input = {
+      id: feedInvitationId,
+      team_id: props.me.current_team?.dbid,
+    };
+    commitMutation(Relay.Store, {
+      mutation: acceptMutation,
+      variables: { input },
+      onCompleted: () => browserHistory.push(`/${props.me.current_team?.slug}/feed/${props.feed_invitation?.feed.dbid}/edit`),
+      onError: onFailure,
+    });
+  };
+
+  const handleRejectInvite = () => {
+    setConfirmReject(false);
+    setSaving(true);
+    const input = {
+      id: feedInvitationId,
+    };
+    commitMutation(Relay.Store, {
+      mutation: rejectMutation,
+      variables: { input },
+      onCompleted: () => browserHistory.push(`/${props.me.current_team?.slug}/all-items`),
+      onError: onFailure,
+    });
+  };
+
+  return (
+    <div className={cx('feed-invitation-container', styles['feed-invitation-container'])}>
+      <div className={cx('feed-invitation-container-card', styles['feed-invitation-container-card'])}>
+        <div className={styles['header-icon']}>
+          <ScheduleSendIcon />
+        </div>
+        <div>
+          <div className={cx('typography-h6')}>
+            {props.feed_invitation.user.name}, <span className={styles.email}>{props.feed_invitation.user.email}</span>
+          </div>
+          <div className={cx('typography-body1', styles.invited)}>
+            <FormattedMessage id="feedInvitation.invited" defaultMessage="has invited your organization to contribute to a Check Shared Feed" description="This is a fragment of text that appears after the name of a person and email address, like: '[[Bob Smith, bob@example.com]] has invited your organization to...'. The name appears above the text and this part of the sentence continues on the second row of text. The two messages combined should read like a grammatically correct sentence." />
+          </div>
+          <div>
+            <span className={cx('typography-body1-bold')}>&ldquo;{props.feed_invitation.feed.name}&rdquo;</span>
+          </div>
+        </div>
+        <div className={cx('typography-body2', styles.description)}>
+          {props.feed_invitation.feed.description}
+        </div>
+        { notAdmin && (
+          <Alert
+            className={cx(styles['no-admin-alert'])}
+            contained
+            content={<FormattedMessage id="feedInvitation.notAdmin" defaultMessage="You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page." />}
+            variant="error"
+          />
+        )}
+        {alreadyAccepted && (
+          <Alert
+            className={cx(styles['no-admin-alert'])}
+            contained
+            content={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
+            variant="info"
+          />
+        )}
+        { !notAdmin && !alreadyAccepted && (
+          <div className={cx(styles['accept-decline'])}>
+            <div className={cx(styles['action-container'])}>
+              <ButtonMain
+                label={<FormattedMessage id="feedInvitation.accept" defaultMessage="Accept Invitation" description="Label for a button that the user presses to accept an invitation they have received to collaborate with another organization" />}
+                variant="contained"
+                theme="brand"
+                onClick={handleAcceptInvite}
+                disabled={saving}
+              />
+              { saving && <MediasLoading theme="grey" variant="icon" size="icon" /> }
+            </div>
+            <div className={cx(styles['action-container'])}>
+              { saving && <MediasLoading theme="grey" variant="icon" size="icon" /> }
+              <ButtonMain
+                label={<FormattedMessage id="feedInvitation.decline" defaultMessage="Decline Invitation" description="Label for a button that the user presses to decline an invitation they have received to collaborate with another organization" />}
+                variant="outlined"
+                theme="text"
+                disabled={saving}
+                onClick={() => { setConfirmReject(true); }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+      <ConfirmProceedDialog
+        open={confirmReject}
+        title={
+          <FormattedMessage
+            id="feedItem.importTitle"
+            defaultMessage="Import data to workspace"
+            description="Dialog title when importing a claim from feed page."
+          />
+        }
+        body={(
+          <>
+            <span className="typography-title">
+              <FormattedMessage
+                id="feedItem.importDescription"
+                defaultMessage="A new claim will be created in your workspace with media."
+                description="Dialog description when importing a claim from feed page."
+              />
+            </span>
+          </>
+        )}
+        // proceedDisabled={!selectedImportingTeam || (!importingClaimDescription && !importingClaim?.description)}
+        proceedLabel={<FormattedMessage id="feedItem.proceedImport" defaultMessage="Import" description="Button label to confirm importing claim from feed page" />}
+        onProceed={handleRejectInvite}
+        onCancel={() => { setConfirmReject(false); }}
+        isSaving={saving}
+      />
+    </div>
+  );
+};
+
+FeedInvitationRespondComponent.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    feedInvitationId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const FeedInvitationRespond = ({ routeParams }) => (
+  <ErrorBoundary component="Feed">
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query FeedInvitationRespondQuery($feedInvitationId: ID!) {
+          feed_invitation(id: $feedInvitationId) {
+            state
+            feed {
+              dbid
+              name
+              description
+            }
+            user {
+              name
+              email
+            }
+          }
+          me {
+            current_team {
+              dbid
+              slug
+              permissions
+            }
+          }
+        }
+      `}
+      variables={{
+        feedInvitationId: parseInt(routeParams.feedInvitationId, 10),
+      }}
+      render={({ error, props }) => {
+        if (!error && props) {
+          return <FeedInvitationRespondComponent routeParams={routeParams} {...props} />;
+        }
+        return null;
+      }}
+    />
+  </ErrorBoundary>
+);
+
+FeedInvitationRespond.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired,
+    feedInvitationId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default FeedInvitationRespond;

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -14,7 +14,6 @@ import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
 import styles from './FeedInvitation.module.css';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import ScheduleSendIcon from '../../icons/schedule_send.svg';
-import NotFound from '../NotFound';
 import MediasLoading from '../media/MediasLoading';
 import { can } from '../Can';
 
@@ -40,10 +39,6 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
   const [saving, setSaving] = React.useState(false);
   const [confirmReject, setConfirmReject] = React.useState(false);
   const setFlashMessage = React.useContext(FlashMessageSetterContext);
-  // `feed_invitation` is null when attempting to view a feed invitation that doesn't exist or that you don't have permission to view
-  if (!props.feed_invitation) {
-    return <NotFound />;
-  }
 
   const feedInvitationId = props.feed_invitation.dbid;
   // determine if the current user is an admin of the current team


### PR DESCRIPTION
## App-wide changes

 - routes can now have a `splash` prop, which indicates to the `Home` component that they should be rendered without the context of any workspace (aka no left menu drawer). This works similarly to the existing `public` prop, which is for special-case routes that don't need login. Talking to design, we agreed this seemed like something they'll need for future features.
 - `Home` component checks for the `splash` prop and renders without nav drawer
 - minor (?) change to `ButtonMain` css that specifies a width for the icon container (otherwise it inherits parent widths and renders wrong)

## Feature-specific changes

 - New route, `:team/feed-invitation/:feedInvitationId`, which is the landing page that prompts a user to choose which workspace they want to associate with a feed invitation. Note: `:team` doesn't really do anything here at this point and could just as easily be `/check/me` or something.
 - `FeedInvitation` component, associated with the above route. This checks for several possible rendering states:
    - user is attempting to access an invitation they have no permission to (display `NotFound`)
    - user is attempting to access a nonexistent invitation (display `NotFound`) - user is admin of exactly one workspace (redirect to `FeedInvitationRespond`) - user is attempting to access an invitation they have already accepted, display info-level alert message and prevent action - none of the above happens and the component renders its default, which shows a list of workspaces the user is admin on. clicking a button on a workspace item takes them to `FeedInvitationRespond` for that workspace
 - New route, `:team/feed-invitation/:feedInvitationId/respond`, which prompts the user to accept or decline a feed invitation. Here, `:team` matters and is the workspace that will be associated to a feed, should it be accepted
 - `FeedInvitationRespond` component, associated with the above route. This checks for several possible rendering states:
    - user is attempting to access an invitation they have no permission to (display `NotFound`)
    - user is attempting to access a nonexistent invitation (display `NotFound`) - user is not admin of the current team (display error message) - user is attempting to access an invitation they have already accepted, display info-level alert message and prevent action - none of the above happens and the component renders its default, which prompts the user to accept/decline the invitation

References: CV2-3806

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Things to pay attention to during code review

This wasn't specified in the design but seemed necessary, I added some info/error states as appropriate:

![image](https://github.com/meedan/check-web/assets/266454/8a0deb20-11ef-4e56-975f-7b1455a9df1d)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [X] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)