### PR TITLE
Fix checking to display "more actions" button

### DIFF
--- a/src/app/components/feed/FeedActions.js
+++ b/src/app/components/feed/FeedActions.js
@@ -23,6 +23,9 @@ const FeedActions = ({
   const { feed } = feedTeam;
   const isFeedOwner = feedTeam.team_id === feed.team.dbid;
 
+  const permissionRequired = isFeedOwner ? 'destroy Feed' : 'destroy FeedTeam';
+  const mergedPermissions = { ...JSON.parse(feed?.permissions), ...JSON.parse(feedTeam.permissions) };
+
   const handleMenuClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -77,8 +80,7 @@ const FeedActions = ({
 
   return (
     <>
-      {/* FIXME: Review actual permissions for creator org vs invited org */}
-      <Can permissions={feed.permissions} permission="destroy Feed">
+      <Can permissions={JSON.stringify(mergedPermissions)} permission={permissionRequired}>
         <ButtonMain
           className={`typography-button ${styles.saveFeedButtonMoreActions}`}
           theme="text"
@@ -244,6 +246,7 @@ FeedActions.propTypes = {
 export default createFragmentContainer(FeedActions, graphql`
   fragment FeedActions_feedTeam on FeedTeam {
     team_id
+    permissions
     feed {
       permissions
       saved_search_id

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -486,11 +486,11 @@ const SaveFeed = (props) => {
           />
           { feed.id ?
             <FeedActions
+              feedTeam={{ ...feedTeam, permissions: feedTeam.permissions }}
               disableSaveButton={disableSaveButton}
               saving={saving}
               handleDelete={handleDelete}
               handleLeaveFeed={handleLeaveFeed}
-              feedTeam={feedTeam}
             />
             : null }
         </div>
@@ -597,6 +597,7 @@ export default createFragmentContainer(SaveFeed, graphql`
     id
     saved_search_id
     team_id
+    permissions
     team {
       slug
     }


### PR DESCRIPTION
## Description

- Merge the permissions of feed and feedTeam
- verify whats is the permissions required if the user is from an organization invited or a feed owner

Reference: CV2-3805-leave-shared-feeds
## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
