### PR TITLE
Reload page after handling feed invitation

### DIFF
--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
 import { FormattedMessage } from 'react-intl';
-import { browserHistory } from 'react-router';
 import cx from 'classnames/bind';
 import ErrorBoundary from '../error/ErrorBoundary';
 import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
@@ -63,7 +62,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
     commitMutation(Relay.Store, {
       mutation: acceptMutation,
       variables: { input },
-      onCompleted: () => browserHistory.push(`/${props.me.current_team?.slug}/feed/${props.feed_invitation?.feed.dbid}/edit`),
+      onCompleted: () => window.location.assign(`/${props.me.current_team?.slug}/feed/${props.feed_invitation?.feed.dbid}/edit`),
       onError: onFailure,
     });
   };
@@ -77,7 +76,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
     commitMutation(Relay.Store, {
       mutation: rejectMutation,
       variables: { input },
-      onCompleted: () => browserHistory.push(`/${props.me.current_team?.slug}/all-items`),
+      onCompleted: () => window.location.assign(`/${props.me.current_team?.slug}/all-items`),
       onError: onFailure,
     });
   };


### PR DESCRIPTION
## Description

Reload page after handling feed invitation, this way the Relay store is refreshed. This fixes an issue that the feed doesn't go away from the sidebar after an invitation is declined.

We may handle a proper Relay store update in the future.

Reference: CV2-3802.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Decline a feed invitation
- The feed should not be listed in the left sidebar anymore

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
