### PR TITLE
Fix 'Receive fact-check' action button is displayed as 'Unsupported message in the conversation history

### DIFF
--- a/src/app/components/layout/ChatHistory.js
+++ b/src/app/components/layout/ChatHistory.js
@@ -75,13 +75,15 @@ const ChatHistory = ({
       } else {
         output = item.payload.text;
       }
-    // parse the payload for a button message to get the text from the capi structure
-    } else if (item.payload?.capi?.entry?.[0]?.changes?.[0]?.value?.messages?.length) {
-      output = item.payload?.capi?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.button?.text;
     } else if (item.payload?.messages?.length) {
       output = item.payload?.messages?.map(message => message.text).join('//');
     } else if (item.payload?.text && typeof item.payload.text === 'object') {
       output = item.payload.text;
+    }
+
+    // parse the payload for a button message to get the text from the capi structure
+    if (output === '' && item.payload?.capi?.entry?.[0]?.changes?.[0]?.value?.messages?.length) {
+      output = item.payload?.capi?.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.button?.text;
     }
 
     // Hide the machine label for the positive feedback button

--- a/src/app/components/layout/ChatHistory.test.js
+++ b/src/app/components/layout/ChatHistory.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import ChatHistory from './ChatHistory';
+
+describe('ChatHistory component', () => {
+  const mockTiplineMessage = {
+    id: 9941551,
+    event: null,
+    direction: 'incoming',
+    language: 'pt_BR',
+    platform: 'WhatsApp',
+    sent_at: new Date('Wed, 22 Nov 2023 17:30:30.000000000 UTC +00:00'),
+    uid: '126709780531714:126709231714',
+    external_id: '123343434',
+    payload: {
+      app: { _id: '126709780531714' },
+      capi: {
+        entry: [
+          {
+            id: '126709780531714',
+            changes: [
+              {
+                field: 'messages',
+                value: {
+                  contacts: [{ wa_id: '123343434', profile: { name: 'Test name' } }],
+                  messages: [
+                    {
+                      id: '123343434',
+                      from: '123343434',
+                      type: 'button',
+                      button: { text: 'Receber checagem', payload: 'Receber checagem' },
+                      context: {
+                        id: '123343434',
+                        from: '126709780531714',
+                      },
+                      timestamp: '1700674230',
+                    },
+                  ],
+                  metadata: {
+                    phone_number_id: '1233434349',
+                    display_phone_number: '1233434344',
+                  },
+                  messaging_product: 'whatsapp',
+                },
+              },
+            ],
+          },
+        ],
+        object: 'whatsapp_business_account',
+      },
+      appUser: { _id: '123343434:123343434', conversationStarted: true },
+      trigger: 'message:appUser',
+      version: 'v1.1',
+      messages: [
+        {
+          _id: '123343434',
+          name: 'Test name',
+          text: '',
+          type: 'button',
+          source: {
+            type: 'whatsapp',
+            originalMessageId: '123343434',
+          },
+          payload: null,
+          authorId: '123343434:123343434',
+          language: 'pt_BR',
+          received: 1700674230,
+          quotedMessage: { content: { _id: '123343434ZDN' } },
+        },
+      ],
+    },
+    team_id: 1797,
+    created_at: new Date('Wed, 22 Nov 2023 17:30:34.652769000 UTC +00:00'),
+    updated_at: new Date('Wed, 22 Nov 2023 17:30:34.652769000 UTC +00:00'),
+    state: 'received',
+  };
+
+  it('should parse message from capi structure', () => {
+    const wrapper = mountWithIntl(
+      <ChatHistory
+        title="Chat History"
+        history={[mockTiplineMessage]}
+        handleClose={() => {}}
+        intl={{}}
+        dateTime="1701714951"
+      />,
+    );
+
+    expect(wrapper.html()).toMatch('Receber checagem');
+  });
+});


### PR DESCRIPTION

## Description

- add the parser for the payload for a button message to get the text from the capi structure
- add a unit test for the Chat History component 

Reference: CV2-4032

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
