### PR TITLE
Editors should not be able to manage feed collaborators.

### DIFF
--- a/localization/react-intl/src/app/components/feed/FeedCollaboration.json
+++ b/localization/react-intl/src/app/components/feed/FeedCollaboration.json
@@ -58,5 +58,15 @@
     "id": "feedCollaboration.learnMore",
     "description": "Link to knowledge base article on shared feed invitations",
     "defaultMessage": "Learn more"
+  },
+  {
+    "id": "feedCollaboration.editorWarningCreateFeed",
+    "description": "Warning displayed on feed collaboration box on create feed page when user is an editor and can't invite people to the feed.",
+    "defaultMessage": "Contact your workspace admin to add other organizations to this shared feed."
+  },
+  {
+    "id": "feedCollaboration.editorWarningUpdateFeed",
+    "description": "Warning displayed on feed collaboration box on edit feed page when user is an editor and can't invite people to the feed.",
+    "defaultMessage": "Contact your workspace admin to manage Collaborating organizations."
   }
 ]

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -23,7 +23,7 @@ import UnmatchedMedia from './team/UnmatchedMedia';
 import Published from './team/Published';
 import Spam from './team/Spam';
 import Trash from './team/Trash';
-import SaveFeed from './feed/SaveFeed';
+import CreateFeed from './feed/CreateFeed';
 import EditFeedTeam from './feed/EditFeedTeam';
 import Feed from './feed/Feed';
 import FeedItem from './feed/FeedItem';
@@ -112,7 +112,7 @@ class Root extends Component {
                   <Route path=":team/suggested-matches(/:query)" component={SuggestedMatches} />
                   <Route path=":team/unmatched-media(/:query)" component={UnmatchedMedia} />
                   <Route path=":team/published(/:query)" component={Published} />
-                  <Route path=":team/feed/create" component={SaveFeed} />
+                  <Route path=":team/feed/create" component={CreateFeed} />
                   <Route path=":team/feed/:feedId/edit" component={EditFeedTeam} />
                   <Route path=":team/feed/:feedId/invitation" component={FeedInvitationRespond} />
                   <Route path=":team/feed/:feedId(/:tab(/:query))" component={Feed} />

--- a/src/app/components/feed/CreateFeed.js
+++ b/src/app/components/feed/CreateFeed.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { QueryRenderer, graphql } from 'react-relay/compat';
+import Relay from 'react-relay/classic';
+import SaveFeed from './SaveFeed';
+
+const CreateFeed = () => (
+  <QueryRenderer
+    environment={Relay.Store}
+    query={graphql`
+      query CreateFeedQuery {
+        team {
+          permissions
+        }
+      }
+    `}
+    render={({ error, props }) => {
+      if (!error && props) {
+        return (<SaveFeed permissions={JSON.parse(props.team.permissions)} />);
+      }
+      return null;
+    }}
+  />
+);
+
+export default CreateFeed;

--- a/src/app/components/feed/CreateFeed.js
+++ b/src/app/components/feed/CreateFeed.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
 import SaveFeed from './SaveFeed';
+import { safelyParseJSON } from '../../helpers';
 
 const CreateFeed = () => (
   <QueryRenderer
@@ -15,7 +16,7 @@ const CreateFeed = () => (
     `}
     render={({ error, props }) => {
       if (!error && props) {
-        return (<SaveFeed permissions={JSON.parse(props.team.permissions)} />);
+        return (<SaveFeed permissions={safelyParseJSON(props.team.permissions)} />);
       }
       return null;
     }}

--- a/src/app/components/feed/EditFeedTeam.js
+++ b/src/app/components/feed/EditFeedTeam.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
 import SaveFeed from './SaveFeed';
+import { safelyParseJSON } from '../../helpers';
 
 const EditFeedTeam = ({ routeParams }) => (
   <QueryRenderer
@@ -22,7 +23,7 @@ const EditFeedTeam = ({ routeParams }) => (
     }}
     render={({ error, props }) => {
       if (!error && props) {
-        return (<SaveFeed feedTeam={props.feed_team} permissions={JSON.parse(props.team.permissions)} />);
+        return (<SaveFeed feedTeam={props.feed_team} permissions={safelyParseJSON(props.team.permissions)} />);
       }
       return null;
     }}

--- a/src/app/components/feed/EditFeedTeam.js
+++ b/src/app/components/feed/EditFeedTeam.js
@@ -11,6 +11,9 @@ const EditFeedTeam = ({ routeParams }) => (
         feed_team(feedId: $feedId, teamSlug: $teamSlug) {
           ...SaveFeed_feedTeam
         }
+        team {
+          permissions
+        }
       }
     `}
     variables={{
@@ -19,7 +22,7 @@ const EditFeedTeam = ({ routeParams }) => (
     }}
     render={({ error, props }) => {
       if (!error && props) {
-        return (<SaveFeed feedTeam={props.feed_team} />);
+        return (<SaveFeed feedTeam={props.feed_team} permissions={JSON.parse(props.team.permissions)} />);
       }
       return null;
     }}

--- a/src/app/components/feed/FeedCollaboration.js
+++ b/src/app/components/feed/FeedCollaboration.js
@@ -36,6 +36,7 @@ const destroyInviteMutation = graphql`
     destroyFeedInvitation(input: $input) {
       deletedId
       feed {
+        teams_count
         feed_invitations(first: 100) {
           edges {
             node {
@@ -55,6 +56,7 @@ const removeTeamMutation = graphql`
     destroyFeedTeam(input: $input) {
       deletedId
       feed {
+        teams_count
         feed_teams(first: 100) {
           edges {
             node {

--- a/src/app/components/feed/FeedCollaboration.test.js
+++ b/src/app/components/feed/FeedCollaboration.test.js
@@ -46,7 +46,7 @@ describe('<FeedCollaboration />', () => {
   });
 
   it('should invite emails as feed creator', () => {
-    const wrapper = shallowWithIntl(<FeedCollaboration collaboratorId={123} feed={feed} onChange={() => {}} />);
+    const wrapper = shallowWithIntl(<FeedCollaboration collaboratorId={123} feed={feed} onChange={() => {}} permissions={{ 'create FeedInvitation': true }} />);
     const input = wrapper.find('.int-feed-collab__text-field');
     input.simulate('change', { target: { value: 'bar@foo.com' } });
     wrapper.find('.int-feed-collab__add-button').simulate('click');

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -77,6 +77,20 @@ const destroyMutation = graphql`
     destroyFeed(input: $input) {
       deletedId
       team {
+        feed_teams(first: 10000) {
+          edges {
+            node {
+              id
+              dbid
+              feed_id
+              saved_search_id
+              feed {
+                name
+              }
+              type: __typename
+            }
+          }
+        }
         feeds(first: 10000) {
           edges {
             node {

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -121,7 +121,7 @@ const destroyFeedTeamMutation = graphql`
 
 
 const SaveFeed = (props) => {
-  const { feedTeam } = props;
+  const { feedTeam, permissions } = props;
   const feed = feedTeam?.feed || {}; // Editing a feed or creating a new feed
   const isFeedOwner = feedTeam?.team_id === feed?.team?.dbid;
 
@@ -501,6 +501,7 @@ const SaveFeed = (props) => {
           collaboratorId={feedTeam?.team_id}
           feed={feed}
           onChange={setNewInvites}
+          permissions={permissions}
         />
       </div>
 
@@ -568,6 +569,7 @@ const SaveFeed = (props) => {
 
 SaveFeed.defaultProps = {
   feedTeam: {},
+  permissions: {},
 };
 
 SaveFeed.propTypes = {
@@ -586,6 +588,7 @@ SaveFeed.propTypes = {
       tags: PropTypes.arrayOf(PropTypes.string),
     }),
   }),
+  permissions: PropTypes.object, // { key => value } (e.g., { 'create FeedTeam' => true })
 };
 
 // Used in unit test


### PR DESCRIPTION
## Description

I had to wrap the `<SaveFeed />` component in a new `<CreateFeed />` component, which is basically a query renderer, and that now responds to the `feed/create` route. This way I'm able to get the permissions.

The rest of the code is basically checking for permissions and then rendering components or not based on them.

Reference: CV2-3953.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
