### PR TITLE
Apply content warning for embeds aka PenderCard

### DIFF
--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedHTMLMessage, injectIntl, defineMessages } from 'react-intl';
+import { FormattedMessage, FormattedHTMLMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import { graphql, createFragmentContainer } from 'react-relay/compat';
 import Lightbox from 'react-image-lightbox';
 import 'react-image-lightbox/style.css';
@@ -196,6 +196,18 @@ const AspectRatio = ({
 
   const warningCategory = warningType;
 
+  const isPenderCard = children.type.name === 'PenderCard';
+  const showStraightPenderCard = !maskContent && !superAdminMask && isPenderCard;
+
+  if (showStraightPenderCard) {
+    return (
+      <div style={{ position: 'relative' }}>
+        <ButtonsContainer />
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div className={`${uniqueClassName} ${classes.container}`}>
       { expandedContent ?
@@ -288,12 +300,21 @@ const AspectRatio = ({
 AspectRatio.propTypes = {
   children: PropTypes.node.isRequired,
   downloadUrl: PropTypes.string,
+  expandedImage: PropTypes.string,
   isVideoFile: PropTypes.bool,
   superAdminMask: PropTypes.bool,
+  currentUserRole: PropTypes.string.isRequired,
+  projectMedia: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    show_warning_cover: PropTypes.bool.isRequired,
+    dynamic_annotation_flag: PropTypes.object.isRequired,
+  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 AspectRatio.defaultProps = {
   downloadUrl: '',
+  expandedImage: '',
   isVideoFile: false,
   superAdminMask: false,
 };

--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -196,7 +196,7 @@ const AspectRatio = ({
 
   const warningCategory = warningType;
 
-  const isPenderCard = children.type.name === 'PenderCard';
+  const isPenderCard = children.type?.name === 'PenderCard';
   const showStraightPenderCard = !maskContent && !superAdminMask && isPenderCard;
 
   if (showStraightPenderCard) {

--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -97,12 +97,18 @@ const MediaCardLarge = ({
           />
         ) : null }
         { isPender ? (
-          <PenderCard
-            url={media.url}
-            fallback={null}
-            domId={`pender-card-${Math.floor(Math.random() * 1000000)}`}
-            mediaVersion={data.refreshes_count}
-          />
+          <AspectRatio
+            projectMedia={projectMedia}
+            currentUserRole={currentUserRole}
+            superAdminMask={superAdminMask}
+          >
+            <PenderCard
+              url={media.url}
+              fallback={null}
+              domId={`pender-card-${Math.floor(Math.random() * 1000000)}`}
+              mediaVersion={data.refreshes_count}
+            />
+          </AspectRatio>
         ) : null }
         { isBlank ? (
           <Box

--- a/src/app/components/media/SensitiveContentMenuButton.js
+++ b/src/app/components/media/SensitiveContentMenuButton.js
@@ -347,7 +347,7 @@ const SensitiveContentMenuButton = ({
 };
 
 SensitiveContentMenuButton.propTypes = {
-  currentUserRole: PropTypes.object.isRequired,
+  currentUserRole: PropTypes.string.isRequired,
   projectMedia: PropTypes.shape({
     dbid: PropTypes.number.isRequired,
     show_warning_cover: PropTypes.bool.isRequired,


### PR DESCRIPTION
## Description

This commit places the AspectRatio (maybe we should rename it) component around PenderCard for content screen functionality for embeds

References: CV2-3279

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually.
How to test: Make sure Admin screen is displayed for embeds and it is also possible for regular users to set content screen for embedded content.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
