### PR TITLE
Quick fix to avoid layout thrashing

### DIFF
--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -31,13 +31,13 @@ function sort(items) {
   return items.slice().sort((a, b) => b.node.target.requests_count - a.node.target.requests_count);
 }
 
-const MediaSimilaritiesComponent = ({ projectMedia, isHighlighting, superAdminMask }) => {
+const MediaSimilaritiesComponent = ({ projectMedia, superAdminMask }) => {
   const classes = useStyles();
 
   return (
     <div className="media__more-medias" id="matched-media">
       <div className={classes.container}>
-        <span className={`${classes.overlay} ${isHighlighting ? classes.animation : ''}`} id="matched-overlay" />
+        <span id="matched-overlay" />
         { sort(projectMedia.confirmed_similar_relationships?.edges).map(relationship => (
           <MediaRelationship
             key={relationship.node.id}


### PR DESCRIPTION
I noticed there was a forced reflow on the page happening that was causing much longer load times than necessary when rendering similar media items on a page. Fortunately the fix for this involves removing code that isn't even used. We don't use `isHighlighting` anymore, but its inclusion in the render function meant we were still conditionally applying CSS based on a variable and causing reflows as seen here: https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing?utm_source=devtools#avoid_layout_thrashing

This might improve load times for the media page where there are many similar medias listed in the middle pane. It might even improve the situation for CV2-3889

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I verified in the web inspector profile that this stops the reflow from happening, but really I need to test it with production data to see if there is a significant perf improvement.