### PR TITLE
Sentry screening quick fix: Safe property access/conversion

### DIFF
--- a/src/app/components/search/SearchResultsTable/ReportPublishedByCell.js
+++ b/src/app/components/search/SearchResultsTable/ReportPublishedByCell.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import TableCell from '@material-ui/core/TableCell';
 
 export default function ReportPublishedByCell({ projectMedia }) {
-  const names = Object.values(projectMedia.list_columns_values.published_by);
+  const names = Object.values(projectMedia.list_columns_values?.published_by || {});
   return (
     <TableCell>
       { names.length === 0 ? '-' : names[0] }


### PR DESCRIPTION
The original code could be the source of two errors -- one, if `list_columns_values` is undefined an error would throw for the unsafe property access. Another is if `published_by` is undefined (or even just not an object), the `Object.values` call will throw an error because it can't extract values from anything but an object. From a user perspective, the rest of the file will behave correctly because if published_by is undefined, then the length of `names` will be 0 and will render to the user as "-", which is what we'd want.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)