### PR TITLE
remove slack links from request tab [CV2-4130]

### DIFF
--- a/localization/react-intl/src/app/components/annotations/TiplineRequest.json
+++ b/localization/react-intl/src/app/components/annotations/TiplineRequest.json
@@ -8,10 +8,5 @@
     "id": "annotation.deletedUser",
     "description": "Label for deleted user",
     "defaultMessage": "Deleted User"
-  },
-  {
-    "id": "annotation.openInSlack",
-    "description": "Label for link to conversation in Slack",
-    "defaultMessage": "Open in Slack"
   }
 ]

--- a/src/app/components/annotations/TiplineRequest.js
+++ b/src/app/components/annotations/TiplineRequest.js
@@ -18,7 +18,6 @@ import {
   parseStringUnixTimestamp,
 } from '../../helpers';
 import Request from '../cds/requests-annotations/Request';
-import { units } from '../../styles/js/shared';
 import RequestReceipt from '../cds/requests-annotations/RequestReceipt';
 
 const messages = defineMessages({
@@ -91,7 +90,6 @@ const TiplineRequest = ({
       .join('\n')
     : null;
   const updatedAt = parseStringUnixTimestamp(activity.created_at);
-  const smoochSlackUrl = activity.smooch_user_slack_channel_url;
   let smoochExternalId = activity.smooch_user_external_identifier;
   if (smoochExternalId && messageType === 'whatsapp') {
     smoochExternalId = smoochExternalId.replace(/^[^:]+:/, '');
@@ -114,22 +112,6 @@ const TiplineRequest = ({
   }
   if (smoochRequestLanguage) {
     details.push(languageName(smoochRequestLanguage));
-  }
-  if (messageType !== 'telegram' && smoochSlackUrl) {
-    details.push((
-      <a
-        target="_blank"
-        style={{ margin: `0 ${units(0.5)}`, textDecoration: 'underline' }}
-        rel="noopener noreferrer"
-        href={smoochSlackUrl}
-      >
-        <FormattedMessage
-          id="annotation.openInSlack"
-          defaultMessage="Open in Slack"
-          description="Label for link to conversation in Slack"
-        />
-      </a>
-    ));
   }
 
   const reportHistory = [];
@@ -189,7 +171,6 @@ TiplineRequest.propTypes = {
   annotation: PropTypes.shape({
     value_json: PropTypes.object.isRequired,
     created_at: PropTypes.string.isRequired,
-    smooch_user_slack_channel_url: PropTypes.string,
     smooch_user_external_identifier: PropTypes.string.isRequired,
     smooch_report_received_at: PropTypes.number,
     smooch_report_update_received_at: PropTypes.number,


### PR DESCRIPTION
## Description

Slack links should not appear in the request list anymore

References: [CV2-4130](https://meedan.atlassian.net/browse/CV2-4130)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Things to pay attention to during code review

> 0 additions and 24 deletions.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-4130]: https://meedan.atlassian.net/browse/CV2-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ