### PR TITLE
use gitlab-provided base aws image in build qa

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - deploy
 
 build_qa:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -14,10 +14,7 @@ build_qa:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
-    - apk add --no-cache curl jq python3 py3-pip git
-    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - unzip awscliv2.zip
-    - ./aws/install
+    - apk add --no-cache curl jq python3 git
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build --build-arg DEPLOY_BRANCH=develop --build-arg TIMESTAMP=$(date '+%Y%m%d%H%M%S') -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"


### PR DESCRIPTION
## Description

fixes aws cli installation failure in build_qa step of gitlab deployment pipeline by using a gitlab-provdied docker image with awscliv2 built in, and removes pip install step

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)
