### PR TITLE
Quick fix for double-preview on youtube videos

### DIFF
--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -87,7 +87,7 @@ const MediaCardLarge = ({
             superAdminMask={superAdminMask}
           />
         ) : null }
-        { isWebPage ? (
+        { isWebPage && !isYoutube ? (
           <WebPageMediaCard
             projectMedia={projectMedia}
             currentUserRole={currentUserRole}


### PR DESCRIPTION
When rendering a media page for a YouTube video, we were showing both the embedded youtube player and also the web page preview for the video, due to the fact that youtube pages are also web pages. This was confusing since it looked like a double-video. This fix only shows the youtube preview for youtube videos, removing the double effect.

### Before

![image](https://github.com/meedan/check-web/assets/266454/0c14fd3b-6ed3-4ba1-864d-e3c206f3a44d)

### After

![image](https://github.com/meedan/check-web/assets/266454/efba7f4a-5ed5-4b42-8153-31c02b3576a5)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [X] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)