### PR TITLE
Allow workspace invite list for shared feeds to scroll

### DIFF
--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -51,7 +51,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
           <Alert
             className={cx(styles['no-admin-alert'])}
             contained
-            content={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
+            title={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
             variant="info"
           />
         )}
@@ -59,7 +59,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
           <Alert
             className={cx(styles['no-admin-alert'])}
             contained
-            content={<FormattedMessage id="feedInvitation.noWorkspaces" defaultMessage="You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page." />}
+            title={<FormattedMessage id="feedInvitation.noWorkspaces" defaultMessage="You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page." />}
             variant="error"
           />
         )}

--- a/src/app/components/feed/FeedInvitation.module.css
+++ b/src/app/components/feed/FeedInvitation.module.css
@@ -106,13 +106,19 @@
 }
 
 .feed-invitation-container {
-  align-self: stretch;
+  align-items: center;
+  align-self: center;
   display: flex;
+  flex-direction: column;
   gap: 32px;
-  justify-content: center;
+  height: 100%;
+  justify-content: flex-start;
+  overflow: auto;
   padding: 100px 0;
+  width: 100%;
 
   .feed-invitation-container-card {
+    align-self: center;
     width: 650px;
   }
 }

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -106,7 +106,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
             <Alert
               className={cx(styles['no-admin-alert'])}
               contained
-              content={<FormattedMessage id="feedInvitation.notAdmin" defaultMessage="You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page." />}
+              title={<FormattedMessage id="feedInvitation.notAdmin" defaultMessage="You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page." />}
               variant="error"
             />
           )}
@@ -114,7 +114,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
             <Alert
               className={cx(styles['no-admin-alert'])}
               contained
-              content={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
+              title={<FormattedMessage id="feedInvitation.alreadyAccepted" defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." />}
               variant="info"
             />
           )}


### PR DESCRIPTION
## Description

While QA-ing [1781](https://github.com/meedan/check-web/pull/1781) I took the opportunity to fix a bug with invitations when sent to a user with multiple workspaces. 

On small screens or users with lots of workspaces, the page would not scroll, so the user could not reach all of the workspaces, this PR addresses that

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
manul invites

## Things to pay attention to during code review

### BEFORE NO SCROLLBAR
<img width="856" alt="Screenshot 2023-12-22 at 10 12 39 AM" src="https://github.com/meedan/check-web/assets/418001/ffb245da-c890-4332-bac4-2cb0a8635d1a">

### AFTER Workspace List
<img width="1013" alt="Screenshot 2023-12-22 at 10 04 37 AM" src="https://github.com/meedan/check-web/assets/418001/0c7b4eb7-d1f3-43ba-84af-d95c2af18d3c">

### AFTER Workspace List2
<img width="1016" alt="Screenshot 2023-12-22 at 10 04 43 AM" src="https://github.com/meedan/check-web/assets/418001/056150c6-ee18-4dcc-80cd-b286528c4c77">

### AFTER Previous Invite
<img width="861" alt="Screenshot 2023-12-22 at 10 05 42 AM" src="https://github.com/meedan/check-web/assets/418001/fff335c7-0264-4412-a767-1996ce06c77d">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
