### PR TITLE
displays only the number of existing organizations on shared Feed on collaborator page

### DIFF
--- a/src/app/components/feed/FeedCollaboration.js
+++ b/src/app/components/feed/FeedCollaboration.js
@@ -233,7 +233,7 @@ const FeedCollaboration = ({
             id="feedCollaboration.titleCollaborator"
             defaultMessage="Collaborating Organizations [{count}]"
             description="Title of the collaboration box in which feed organizer invites other organizations to a shared feed"
-            values={{ count: feed.feed_teams?.edges.length + feed.feed_invitations?.edges.length }}
+            values={{ count: feed.feed_teams?.edges.length }}
           /> :
           <FormattedMessage
             id="feedCollaboration.title"


### PR DESCRIPTION
## Description

count only the number of organizations that are part of the feed instead of counting all the sent invitations 

Reference: CV2-4124

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
