### PR TITLE
Fallback to custom title with previous title value if item title gets blank

### DIFF
--- a/src/app/components/media/ItemTitle.js
+++ b/src/app/components/media/ItemTitle.js
@@ -38,6 +38,13 @@ const ItemTitleComponent = ({
   const claimTitle = projectMedia.claim_description?.description;
   const factCheckTitle = projectMedia.claim_description?.fact_check?.title;
 
+  React.useEffect(() => {
+    if ((titleField === 'claim_title' && claimTitle === '') || (titleField === 'fact_check_title' && factCheckTitle === '')) {
+      setTitleField('custom_title');
+      setCustomTitle(projectMedia.title);
+    }
+  }, [claimTitle, factCheckTitle]);
+
   const title = titleField ? {
     custom_title: customTitle,
     pinned_media_id: pinnedMediaId,

--- a/src/app/components/media/MediaClaim.js
+++ b/src/app/components/media/MediaClaim.js
@@ -43,6 +43,11 @@ const MediaClaim = ({ projectMedia }) => {
                   user {
                     name
                   }
+                  project_media {
+                    title
+                    title_field
+                    custom_title
+                  }
                 }
               }
             }

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -75,6 +75,13 @@ const MediaFactCheck = ({ projectMedia }) => {
                   user {
                     name
                   }
+                  claim_description {
+                    project_media {
+                      title
+                      title_field
+                      custom_title
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Description

If an item uses the claim title or fact-check title and they are deleted, then, in order to avoid that the title gets blank, fallback to custom title using the previous title value.

Reference: CV2-3986.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing unit tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
