### PR TITLE
Display the "Add item" button on the "All items" page when there are no items

### DIFF
--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -22,6 +22,8 @@ import ListSort from '../cds/inputs/ListSort';
 import SearchResultsTable from './SearchResultsTable';
 import SearchResultsCards from './SearchResultsCards';
 import SearchRoute from '../../relay/SearchRoute';
+import CreateMedia from '../media/CreateMedia';
+import Can from '../Can';
 import { pageSize } from '../../urlHelpers';
 
 /**
@@ -333,6 +335,12 @@ function SearchResultsComponent({
           defaultMessage="There are no items here."
           description="Empty message that is displayed when search results are zero"
         />
+        { page === 'all-items' ?
+          <Can permissions={team.permissions} permission="create ProjectMedia">
+            <div className={styles['no-search-results-add']}>
+              <CreateMedia search={search} team={team} />
+            </div>
+          </Can> : null }
       </BlankState>
     );
     if (resultType === 'factCheck' || resultType === 'emptyFeed') {

--- a/src/app/components/search/SearchResults.module.css
+++ b/src/app/components/search/SearchResults.module.css
@@ -1,3 +1,9 @@
+.no-search-results-add {
+  display: flex;
+  justify-content: center;
+  margin: 64px 0;
+}
+
 .search-results-status-cell {
   max-width: 224px;
   overflow: hidden;


### PR DESCRIPTION
## Description

A recent commit introduced a change and then there was no "Add item" button anymore on the "All items" page when it was empty. This PR adds it back, but not on the toolbar.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- Create a new workspace
- Click on "All items" on the left sidebar
- Note that there is a "Add item" button on the center

![Captura de tela de 2024-01-09 13-33-00](https://github.com/meedan/check-web/assets/117518/b0c40e82-aea4-4c31-8561-41cd02f842ff)

## Things to pay attention to during code review

@brianfleming feel free to fix positioning, margin, etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
