### PR TITLE
Fixing default title value in `<ItemTitle />` component.

### DIFF
--- a/src/app/components/media/ItemTitle.js
+++ b/src/app/components/media/ItemTitle.js
@@ -50,7 +50,7 @@ const ItemTitleComponent = ({
     pinned_media_id: pinnedMediaId,
     claim_title: claimTitle,
     fact_check_title: factCheckTitle,
-  }[titleField] : projectMedia.title;
+  }[titleField] : (claimTitle || factCheckTitle || projectMedia.title);
 
   const icon = {
     custom_title: <TextFieldsIcon />,

--- a/src/app/components/media/ItemTitle.js
+++ b/src/app/components/media/ItemTitle.js
@@ -37,11 +37,14 @@ const ItemTitleComponent = ({
   const pinnedMediaId = projectMedia.media_slug;
   const claimTitle = projectMedia.claim_description?.description;
   const factCheckTitle = projectMedia.claim_description?.fact_check?.title;
+  const fallbackTitle = claimTitle || factCheckTitle || projectMedia.title;
 
   React.useEffect(() => {
     if ((titleField === 'claim_title' && claimTitle === '') || (titleField === 'fact_check_title' && factCheckTitle === '')) {
       setTitleField('custom_title');
       setCustomTitle(projectMedia.title);
+    } else if (!titleField) {
+      setCustomTitle(fallbackTitle);
     }
   }, [claimTitle, factCheckTitle]);
 
@@ -50,7 +53,7 @@ const ItemTitleComponent = ({
     pinned_media_id: pinnedMediaId,
     claim_title: claimTitle,
     fact_check_title: factCheckTitle,
-  }[titleField] : (claimTitle || factCheckTitle || projectMedia.title);
+  }[titleField] : fallbackTitle;
 
   const icon = {
     custom_title: <TextFieldsIcon />,

--- a/src/app/components/media/ItemTitle.test.js
+++ b/src/app/components/media/ItemTitle.test.js
@@ -47,7 +47,7 @@ describe('<ItemTitle />', () => {
 
   it('should have default title', () => {
     const wrapper = mountWithIntl(<ItemTitle projectMedia={{ ...projectMedia, title_field: null }} />);
-    expect(wrapper.find('.int-item-title__textfield--title input').render().attr('value')).toBe('Title');
+    expect(wrapper.find('.int-item-title__textfield--title input').render().attr('value')).toBe('Claim Title');
   });
 
   it('should have custom title', () => {


### PR DESCRIPTION
## Description

While a title field is not chosen for an item, the fallback should not be `projectMedia.title` straight... but the claim title and then the fact-check title.

Fixes CV2-3986.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- Create a new item but don't choose a title field
- Enter a claim
- The title field should reflect the claim value

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
