### PR TITLE
Changing cursor for disabled switch label.

### DIFF
--- a/src/app/components/cds/inputs/Switch.module.css
+++ b/src/app/components/cds/inputs/Switch.module.css
@@ -95,6 +95,7 @@
     .switch {
       :global(+ .MuiFormControlLabel-label) {
         color: var(--textPlaceholder);
+        cursor: default;
       }
     }
   }


### PR DESCRIPTION
## Description

Currently, the CDS `<Switch />` component shows a hand cursor even if it's disabled, which is confusing, since when it's disabled it can't be clicked. This PR sets the cursor to the default in that case.

Fixes CV2-3923.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Mouse over a disabled `<Switch />` component and you should see the default mouse cursor instead of a hand cursor.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
