### PR TITLE
Adding two new columns to the data dashboard

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
@@ -60,6 +60,16 @@
     "defaultMessage": "Conversations are 24-hour message threads between you and your users. They are opened when messages sent by Check to users are delivered."
   },
   {
+    "id": "teamDataComponent.whatsappConversationsUser",
+    "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
+    "defaultMessage": "Service conversations are user-initiated. They are opened by the first message sent by the bot in response to a customer's message."
+  },
+  {
+    "id": "teamDataComponent.whatsappConversationsBusiness",
+    "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
+    "defaultMessage": "Marketing conversations are business-initiated, and opened by the first message sent by the bot in response to a customer's message."
+  },
+  {
     "id": "teamDataComponent.positiveSearches",
     "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
     "defaultMessage": "Number of user searches that returned at least one report."

--- a/src/app/components/team/TeamData/TeamDataComponent.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.js
@@ -121,6 +121,16 @@ const messages = defineMessages({
     defaultMessage: 'Conversations are 24-hour message threads between you and your users. They are opened when messages sent by Check to users are delivered.',
     description: messagesDescription,
   },
+  whatsappConversationsUser: {
+    id: 'teamDataComponent.whatsappConversationsUser',
+    defaultMessage: "Service conversations are user-initiated. They are opened by the first message sent by the bot in response to a customer's message.",
+    description: messagesDescription,
+  },
+  whatsappConversationsBusiness: {
+    id: 'teamDataComponent.whatsappConversationsBusiness',
+    defaultMessage: "Marketing conversations are business-initiated, and opened by the first message sent by the bot in response to a customer's message.",
+    description: messagesDescription,
+  },
   positiveSearches: {
     id: 'teamDataComponent.positiveSearches',
     defaultMessage: 'Number of user searches that returned at least one report.',
@@ -210,6 +220,8 @@ const TeamDataComponent = ({
 
   const helpMessages = {
     'WhatsApp conversations': intl.formatMessage(messages.whatsappConversations),
+    'WhatsApp marketing conversations (business-initiated)': intl.formatMessage(messages.whatsappConversationsBusiness),
+    'WhatsApp service conversations (user-initiated)': intl.formatMessage(messages.whatsappConversationsUser),
     'Unique users': intl.formatMessage(messages.uniqueUsers),
     'Returning users': intl.formatMessage(messages.returningUsers),
     'Published reports': intl.formatMessage(messages.publishedReports),


### PR DESCRIPTION
## Description

Adding two new columns "WhatsApp Service Conversations" and "WhatsApp Marketing Conversations" to the workspace data dashboard.

Reference: CV2-4121.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

You need to have a local WhatsApp Cloud API to test this properly. But, as far as this frontend is concerned, you should see two new columns added to the right of "WhatsApp Conversations" when you visit the data dashboard of a workspace that has a tipline configured.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
