### PR TITLE
Bug fix: Unfreeze screen when importing media to imported report.

### DIFF
--- a/src/app/components/media/BlankMediaButton.js
+++ b/src/app/components/media/BlankMediaButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { graphql, commitMutation } from 'react-relay/compat';
@@ -40,7 +39,7 @@ const BlankMediaButton = ({
   const handleSuccess = (projectMediaDbid) => {
     const teamSlug = window.location.pathname.match(/^\/([^/]+)/)[1];
     const newPath = `/${teamSlug}/media/${projectMediaDbid}`;
-    browserHistory.push(newPath);
+    window.location.assign(newPath);
   };
 
   const handleSubmitExisting = (projectMedia) => {


### PR DESCRIPTION
## Description

Previously, these steps were not working:

* From any item without a report, click the "Manage media" button
* Select the option "Move all media to an imported fact-check" and search for any imported report
* Click on "Add to report"

Nothing was happening after the last step. The fix was to replace how redirection happens.

Fixes: CV2-3974.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually, as per description.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
