### PR TITLE
fix alignment issue on newsletters settings page [CV2-4230]

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterComponent.module.css
+++ b/src/app/components/team/Newsletter/NewsletterComponent.module.css
@@ -90,14 +90,6 @@
     .newsletter-scheduler-title {
       align-items: center;
       display: flex;
-
-      .tooltip-icon {
-        color: var(--textSecondary);
-        display: inline-block;
-        font-size: var(--iconSizeSmall);
-        margin: 0 0 1px 6px;
-        vertical-align: middle;
-      }
     }
 
     .newsletter-scheduler-schedule {

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -68,8 +68,8 @@ const NewsletterScheduler = ({
             }
             arrow
           >
-            <span>
-              <InfoOutlinedIcon className={styles['tooltip-icon']} />
+            <span className={settingsStyles['tooltip-icon']}>
+              <InfoOutlinedIcon />
             </span>
           </Tooltip> :
           null

--- a/src/app/components/team/Settings.module.css
+++ b/src/app/components/team/Settings.module.css
@@ -129,6 +129,17 @@
             :global(.check-icon) {
               font-size: var(--iconSizeDefault);
             }
+
+            &.tooltip-icon {
+              color: var(--textSecondary);
+              flex: 0 0 var(--iconSizeSmall);
+              font-size: var(--iconSizeSmall);
+              margin: 0 0 1px 6px;
+
+              svg {
+                display: inline-block;
+              }
+            }
           }
 
           .setting-content-container-actions {


### PR DESCRIPTION
## Description

Small alignment issue with the newletters settings page

References: [CV2-4230](https://meedan.atlassian.net/browse/CV2-4230)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
manual testing

## Things to pay attention to during code review

### BEFORE
<img width="1188" alt="Screenshot 2024-02-12 at 10 10 26 AM" src="https://github.com/meedan/check-web/assets/418001/8c41711c-8586-4e52-b84e-f59ded771574">

### AFTER
<img width="1188" alt="Screenshot 2024-02-12 at 10 13 34 AM" src="https://github.com/meedan/check-web/assets/418001/f3ee18ad-e851-4d34-aa03-bdec430754ed">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-4230]: https://meedan.atlassian.net/browse/CV2-4230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ