### PR TITLE
redirect the user to all-items instead of the settings area [CV2-2760]

### DIFF
--- a/src/app/CheckContext.js
+++ b/src/app/CheckContext.js
@@ -125,7 +125,7 @@ class CheckContext {
     const newContext = {};
     if (team) {
       newContext.team = team;
-      path += `/${team.slug}`;
+      path += `/${team.slug}/all-items`;
     }
     if (project) {
       newContext.project = project;
@@ -139,7 +139,7 @@ class CheckContext {
   // When accessing Check root, redirect to a friendlier location if needed:
   // - if user was on a previous page before logging in, go to that previous page
   // - if no team, go to `/check/me/workspaces`
-  // - if team go to team root
+  // - if team go to team root all items
   maybeRedirect(location, userData) {
     if (location !== '/' || this.getTeamSlug() || !userData) return;
 


### PR DESCRIPTION
## Description

This has just been bothering me latetly, since going to the settings area as a "landing" page isn't really that useful.
This PR changes the landing page to all-items, when the user just puts in a plan URL without a specific page. It addresses one comment in CV2-2760, but not the full ticket

References: [CV2-2760](https://meedan.atlassian.net/browse/CV2-2760)

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

just go to URL and see what happens

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-2760]: https://meedan.atlassian.net/browse/CV2-2760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ