### PR TITLE
Better handle submit button and char limit on manual tipline message [CV2-3864]

### DIFF
--- a/localization/react-intl/src/app/components/SendTiplineMessage.json
+++ b/localization/react-intl/src/app/components/SendTiplineMessage.json
@@ -15,6 +15,11 @@
     "defaultMessage": "Send message to {username} on {channel}"
   },
   {
+    "id": "sendTiplineMessage.placeholder",
+    "description": "Placeholder for message authoring field",
+    "defaultMessage": "Write a message to {username} on {channel}"
+  },
+  {
     "id": "sendTiplineMessage.inputLabel",
     "description": "Message input label",
     "defaultMessage": "Message"

--- a/src/app/components/SendTiplineMessage.js
+++ b/src/app/components/SendTiplineMessage.js
@@ -19,6 +19,7 @@ const SendTiplineMessage = ({ annotationId, channel, username }) => {
   const [text, setText] = React.useState();
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [isSending, setIsSending] = React.useState(false);
+  const [submitDisabled, setSubmitDisabled] = React.useState(true);
   const setFlashMessage = React.useContext(FlashMessageSetterContext);
 
   const submitMessage = (inReplyToId, message) => {
@@ -60,6 +61,11 @@ const SendTiplineMessage = ({ annotationId, channel, username }) => {
       onCompleted: onSuccess,
       onError: onFailure,
     });
+  };
+
+  const handleChange = (e) => {
+    const value = e.target.value.trim();
+    setSubmitDisabled(value.length === 0);
   };
 
   return (
@@ -118,18 +124,33 @@ const SendTiplineMessage = ({ annotationId, channel, username }) => {
           <div className={styles['dialog-content']}>
             <div className={inputStyles['form-fieldset']}>
               <div className={inputStyles['form-fieldset-field']}>
-                <LimitedTextArea
-                  value={text}
-                  label={
-                    <FormattedMessage
-                      id="sendTiplineMessage.inputLabel"
-                      defaultMessage="Message"
-                      description="Message input label"
+                <FormattedMessage
+                  id="sendTiplineMessage.placeholder"
+                  defaultMessage="Write a message to {username} on {channel}"
+                  description="Placeholder for message authoring field"
+                  values={{
+                    username,
+                    channel,
+                  }}
+                >
+                  { placeholder => (
+                    <LimitedTextArea
+                      value={text}
+                      placeholder={placeholder}
+                      label={
+                        <FormattedMessage
+                          id="sendTiplineMessage.inputLabel"
+                          defaultMessage="Message"
+                          description="Message input label"
+                        />
+                      }
+                      maxChars={800}
+                      maxlength="800"
+                      setValue={m => setText(m)}
+                      onChange={handleChange}
                     />
-                  }
-                  maxChars={800}
-                  setValue={m => setText(m)}
-                />
+                  )}
+                </FormattedMessage>
               </div>
             </div>
           </div>
@@ -150,7 +171,7 @@ const SendTiplineMessage = ({ annotationId, channel, username }) => {
             />
             <ButtonMain
               className="send-tipline-message__submit-button"
-              disabled={isSending}
+              disabled={isSending || submitDisabled}
               size="default"
               variant="contained"
               theme="brand"


### PR DESCRIPTION
## Description

This PR:
- Adds in a char limit to the manual tipline message textfield which matches the text char limit countdown
- Disables the submit button if the text of the message is 0
- Adds in a placeholder text for better UX on the textfield

References: [CV2-3864](https://meedan.atlassian.net/browse/CV2-3864)

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

### AFTER Empty message - note disabled button
<img width="606" alt="Screenshot 2024-02-13 at 11 02 55 AM" src="https://github.com/meedan/check-web/assets/418001/19cebb3e-1b05-440e-8366-9b59e5f66c26">

### AFTER - Char limit reached, can no longer enter text
<img width="606" alt="Screenshot 2024-02-13 at 11 03 09 AM" src="https://github.com/meedan/check-web/assets/418001/bd7f3f18-203d-4af8-876d-dcc5346e1419">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-3864]: https://meedan.atlassian.net/browse/CV2-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ