### PR TITLE
Adding two new data points to the data dashboard.

### DIFF
--- a/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamData/TeamDataComponent.json
@@ -80,6 +80,16 @@
     "defaultMessage": "Number of user searches that did not return a report."
   },
   {
+    "id": "teamDataComponent.positiveFeedback",
+    "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
+    "defaultMessage": "Number of conversations that returned at least one result and the user answered \"Yes\"."
+  },
+  {
+    "id": "teamDataComponent.negativeFeedback",
+    "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
+    "defaultMessage": "Number of conversations that returned at least one result and the user answered \"No\"."
+  },
+  {
     "id": "teamDataComponent.newslettersSent",
     "description": "Explanation on table header, when hovering the \"help\" icon, on data settings page",
     "defaultMessage": "The total number of newsletters sent to subscribers."

--- a/src/app/components/team/TeamData/TeamDataComponent.js
+++ b/src/app/components/team/TeamData/TeamDataComponent.js
@@ -99,6 +99,16 @@ const messages = defineMessages({
     defaultMessage: 'Number of user searches that did not return a report.',
     description: messagesDescription,
   },
+  positiveFeedback: {
+    id: 'teamDataComponent.positiveFeedback',
+    defaultMessage: 'Number of conversations that returned at least one result and the user answered "Yes".',
+    description: messagesDescription,
+  },
+  negativeFeedback: {
+    id: 'teamDataComponent.negativeFeedback',
+    defaultMessage: 'Number of conversations that returned at least one result and the user answered "No".',
+    description: messagesDescription,
+  },
   newslettersSent: {
     id: 'teamDataComponent.newslettersSent',
     defaultMessage: 'The total number of newsletters sent to subscribers.',
@@ -193,6 +203,8 @@ const TeamDataComponent = ({
     'Total newsletters delivered': intl.formatMessage(messages.newslettersDelivered),
     'Positive searches': intl.formatMessage(messages.positiveSearches),
     'Negative searches': intl.formatMessage(messages.negativeSearches),
+    'Positive feedback': intl.formatMessage(messages.positiveFeedback),
+    'Negative feedback': intl.formatMessage(messages.negativeFeedback),
     'Total newsletters sent': intl.formatMessage(messages.newslettersSent),
   };
 


### PR DESCRIPTION
## Description

* "Positive feedback": Number of conversations that returned at least one result and the user answered "Yes".
* "Negative feedback": Number of conversations that returned at least one result and the user answered "No".

Reference: CV2-4160.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
