### PR TITLE
Persist smooch_menu_option_id when menu items are edited

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -14,6 +14,7 @@ const SmoochBotMainMenuOption = ({
   currentKeywords,
   currentLanguage,
   menu,
+  id,
   index,
   resources,
   hasUnsavedChanges,
@@ -192,6 +193,7 @@ SmoochBotMainMenuOption.defaultProps = {
   currentLanguage: null,
   currentKeywords: [],
   index: null,
+  id: '',
   hasUnsavedChanges: false,
 };
 
@@ -205,6 +207,7 @@ SmoochBotMainMenuOption.propTypes = {
   currentLanguage: PropTypes.string,
   menu: PropTypes.oneOf(['main', 'secondary']).isRequired,
   index: PropTypes.number,
+  id: PropTypes.string,
   hasUnsavedChanges: PropTypes.bool,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuOption.js
@@ -30,7 +30,7 @@ const SmoochBotMainMenuOption = ({
   const handleSave = () => {
     setSubmitted(true);
     if (text && value) {
-      onSave(text, description, value, currentKeywords);
+      onSave(text, description, value, id, currentKeywords);
     }
     if (keywordsUpdated) {
       // Reload the page so settings are refreshed

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -56,7 +56,7 @@ const SmoochBotMainMenuSection = ({
     setEditingOptionIndex(-1);
   };
 
-  const buildOption = (label, description, action, keywords) => {
+  const buildOption = (label, description, action, id, keywords) => {
     // If it's a sequence of digits, then it represents a resource
     if (/^[0-9]+$/.test(action)) {
       return {
@@ -65,6 +65,7 @@ const SmoochBotMainMenuSection = ({
         smooch_menu_custom_resource_id: action,
         smooch_menu_option_label: label,
         smooch_menu_option_description: description,
+        smooch_menu_option_id: id,
         smooch_menu_option_nlu_keywords: keywords,
         smooch_menu_project_media_title: '',
         smooch_menu_project_media_id: '',
@@ -75,6 +76,7 @@ const SmoochBotMainMenuSection = ({
       smooch_menu_option_value: action,
       smooch_menu_option_label: label,
       smooch_menu_option_description: description,
+      smooch_menu_option_id: id,
       smooch_menu_option_nlu_keywords: keywords,
       smooch_menu_project_media_title: '',
       smooch_menu_project_media_id: '',
@@ -89,8 +91,8 @@ const SmoochBotMainMenuSection = ({
     setShowNewOptionDialog(false);
   };
 
-  const handleSaveOption = (label, description, action, keywords) => {
-    const newOption = buildOption(label, description, action, keywords);
+  const handleSaveOption = (label, description, action, id, keywords) => {
+    const newOption = buildOption(label, description, action, id, keywords);
     const newOptions = options.slice();
     newOptions[editingOptionIndex] = newOption;
     onChangeMenuOptions(newOptions);

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenuSection.js
@@ -285,6 +285,7 @@ const SmoochBotMainMenuSection = ({
       { editingOptionIndex > -1 ?
         <SmoochBotMainMenuOption
           menu={menu}
+          id={options[editingOptionIndex].smooch_menu_option_id}
           resources={resources}
           onSave={handleSaveOption}
           onCancel={handleCancel}


### PR DESCRIPTION
## Description

When a menu item's title is changed, the `smooch_menu_option_id` property is lost. (This might apply to other edits as well.) The goal here is to persist that property when a menu item is edited.

References: CV2-4272

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
