### PR TITLE
Simplifying language filter for fact-check feeds.

### DIFF
--- a/src/app/components/search/LanguageFilter.js
+++ b/src/app/components/search/LanguageFilter.js
@@ -43,7 +43,7 @@ const LanguageFilter = ({
     if (value && value.language) return 'language';
     if (value && value.report_language) return 'report_language';
     if (value && value.request_language) return 'request_language';
-    return 'language';
+    return 'report_language';
   };
   const defaultLanguages = value && value[getValueType()] ? value[getValueType()] : [];
   const [userLanguages, setUserLanguages] = React.useState(defaultLanguages);

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -556,6 +556,7 @@ const SearchFields = ({
         readOnly={readOnlyFields.includes('language_filter')}
         onRemove={() => handleRemoveField('language_filter')}
         teamSlug={team.slug}
+        optionsToHide={page === 'feed' ? ['request_language', 'language'] : []}
       />
     ),
     assigned_to: (


### PR DESCRIPTION
## Description

For a feed sharing only fact-checks, we don't need all the options for the "Language" filter... we just need "Report language".

Fixes CV2-4296.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: create a feed and choose to share only fact-checks. On that feed page, the language filter should list only the "Report language" option.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
