### PR TITLE
Apply some UI tweaks for shared feed media clusters list

### DIFF
--- a/localization/react-intl/src/app/components/feed/FeedClusters.json
+++ b/localization/react-intl/src/app/components/feed/FeedClusters.json
@@ -43,5 +43,10 @@
     "id": "feedClusters.nextPage",
     "description": "Pagination button to go to next page",
     "defaultMessage": "Next page"
+  },
+  {
+    "id": "feedClusters.noTitle",
+    "description": "No title available",
+    "defaultMessage": "(no title)"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaTypeDisplayName.json
+++ b/localization/react-intl/src/app/components/media/MediaTypeDisplayName.json
@@ -28,5 +28,35 @@
     "id": "media.typeBlank",
     "description": "Label to show that the type of media is was imported into the application",
     "defaultMessage": "Imported fact-check"
+  },
+  {
+    "id": "media.typeFacebook",
+    "description": "Label to show that the type of media is a Facebook post",
+    "defaultMessage": "Facebook"
+  },
+  {
+    "id": "media.typeInstagram",
+    "description": "Label to show that the type of media is an Instagram post",
+    "defaultMessage": "Instagram"
+  },
+  {
+    "id": "media.typeTelegram",
+    "description": "Label to show that the type of media is a Telegram message",
+    "defaultMessage": "Telegram"
+  },
+  {
+    "id": "media.typeTiktok",
+    "description": "Label to show that the type of media is a Tiktok video",
+    "defaultMessage": "Tiktok"
+  },
+  {
+    "id": "media.typeTwitter",
+    "description": "Label to show that the type of media is a Twitter tweet",
+    "defaultMessage": "Twitter"
+  },
+  {
+    "id": "media.typeYoutube",
+    "description": "Label to show that the type of media is a Youtube video",
+    "defaultMessage": "Youtube"
   }
 ]

--- a/localization/react-intl/src/app/components/media/MediaTypeDisplayName.json
+++ b/localization/react-intl/src/app/components/media/MediaTypeDisplayName.json
@@ -32,12 +32,12 @@
   {
     "id": "media.typeFacebook",
     "description": "Label to show that the type of media is a Facebook post",
-    "defaultMessage": "Facebook"
+    "defaultMessage": "Facebook Post"
   },
   {
     "id": "media.typeInstagram",
     "description": "Label to show that the type of media is an Instagram post",
-    "defaultMessage": "Instagram"
+    "defaultMessage": "Instagram Post"
   },
   {
     "id": "media.typeTelegram",
@@ -47,16 +47,16 @@
   {
     "id": "media.typeTiktok",
     "description": "Label to show that the type of media is a Tiktok video",
-    "defaultMessage": "Tiktok"
+    "defaultMessage": "Tiktok Post"
   },
   {
     "id": "media.typeTwitter",
     "description": "Label to show that the type of media is a Twitter tweet",
-    "defaultMessage": "Twitter"
+    "defaultMessage": "X (Twitter) Post"
   },
   {
     "id": "media.typeYoutube",
     "description": "Label to show that the type of media is a Youtube video",
-    "defaultMessage": "Youtube"
+    "defaultMessage": "Youtube Video"
   }
 ]

--- a/localization/react-intl/src/app/components/search/SearchResults.json
+++ b/localization/react-intl/src/app/components/search/SearchResults.json
@@ -15,6 +15,11 @@
     "defaultMessage": "Rating"
   },
   {
+    "id": "searchResults.sortRequestsCount",
+    "description": "Label for sort criteria option displayed in a drop-down in the feed page.",
+    "defaultMessage": "Requests (count)"
+  },
+  {
     "id": "projectBlankState.blank",
     "description": "Empty message that is displayed when search results are zero",
     "defaultMessage": "There are no items here."

--- a/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
+++ b/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
@@ -22,6 +22,6 @@
   {
     "id": "sharedItemCard.factCheckCount",
     "description": "A label showing the number of fact-checks represented in an item.",
-    "defaultMessage": "{count, plural, one {Fact-check} other {Fact-checks}}"
+    "defaultMessage": "{count, plural, one {# Fact-check} other {# Fact-checks}}"
   }
 ]

--- a/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
+++ b/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "sharedItemCard.medias",
-    "description": "This appears as a label next to a number, like '1,234 Medias'. It should indicate to the user that whatever number they are viewing represents the number of medias attached to an item .",
-    "defaultMessage": "Medias"
+    "description": "This appears as a label next to a number, like '1,234 Medias'. It should indicate to the user that whatever number they are viewing represents the number of medias attached to an item.",
+    "defaultMessage": "{mediaCount, plural, one {Media} other {Medias}}"
   },
   {
     "id": "sharedItemCard.requests",
     "description": "This appears as a label next to a number, like '1,234 Requests'. It should indicate to the user that whatever number they are viewing represents the number of requests an item has gotten.",
-    "defaultMessage": "Requests"
+    "defaultMessage": "{requestsCount, plural, one {Request} other {Requests}}"
   },
   {
     "id": "sharedItemCard.lastRequested",
@@ -22,6 +22,6 @@
   {
     "id": "sharedItemCard.factCheckCount",
     "description": "A label showing the number of fact-checks represented in an item.",
-    "defaultMessage": "{count} Fact-checks"
+    "defaultMessage": "{count} plural, one {Fact-check} other {Fact-checks}"
   }
 ]

--- a/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
+++ b/localization/react-intl/src/app/components/search/SearchResultsCards/SharedItemCard.json
@@ -22,6 +22,6 @@
   {
     "id": "sharedItemCard.factCheckCount",
     "description": "A label showing the number of fact-checks represented in an item.",
-    "defaultMessage": "{count} plural, one {Fact-check} other {Fact-checks}"
+    "defaultMessage": "{count, plural, one {Fact-check} other {Fact-checks}}"
   }
 ]

--- a/localization/react-intl/src/app/components/search/SearchResultsTable/ItemThumbnail.json
+++ b/localization/react-intl/src/app/components/search/SearchResultsTable/ItemThumbnail.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "ItemThumbnail.mediaType",
+    "description": "type of the media item",
+    "defaultMessage": "{mediaType}"
+  }
+]

--- a/src/app/components/feed/FeedClusters.js
+++ b/src/app/components/feed/FeedClusters.js
@@ -19,7 +19,7 @@ import FeedBlankState from './FeedBlankState';
 import FeedFilters from './FeedFilters';
 import styles from './FeedClusters.module.css';
 
-const pageSize = 10;
+const pageSize = 50;
 
 const messages = defineMessages({
   sortTitle: {
@@ -104,8 +104,8 @@ const FeedClustersComponent = ({
   };
 
   const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
     { value: 'requests_count', label: intl.formatMessage(messages.sortRequestsCount) },
+    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
     { value: 'media_count', label: intl.formatMessage(messages.sortMediaCount) },
     { value: 'last_request_date', label: intl.formatMessage(messages.sortLastRequestDate) },
   ];
@@ -209,7 +209,12 @@ const FeedClustersComponent = ({
             return (
               <div key={cluster.id} className={cx('feed-clusters__card', styles.feedClusterCard)}>
                 <SharedItemCard
-                  title={cluster.title || cluster.center.title}
+                  title={
+                    cluster.title ||
+                    cluster.center.title ||
+                    cluster.center.media_slug ||
+                    <FormattedMessage id="feedClusters.noTitle" description="No title available" defaultMessage="(no title)" />
+                  }
                   description={cluster.center.description}
                   mediaThumbnail={{ media: { url: media.url, picture: media.picture, type: media.type } }}
                   workspaces={cluster.teams.edges.map(edge => ({ name: edge.node.name, url: edge.node.avatar }))}
@@ -232,8 +237,8 @@ const FeedClustersComponent = ({
 
 FeedClustersComponent.defaultProps = {
   page: 1,
-  sort: 'title',
-  sortType: 'ASC',
+  sort: 'requests_count',
+  sortType: 'DESC',
   otherFilters: {},
 };
 
@@ -307,8 +312,8 @@ const ConnectedFeedClustersComponent = injectIntl(FeedClustersComponent); // FIX
 const FeedClusters = ({ teamSlug, feedId }) => {
   const [searchParams, setSearchParams] = React.useState({
     page: 1,
-    sort: 'title',
-    sortType: 'ASC',
+    sort: 'requests_count',
+    sortType: 'DESC',
     teamFilters: null,
     otherFilters: {},
   });
@@ -387,6 +392,7 @@ const FeedClusters = ({ teamSlug, feedId }) => {
                     center {
                       title
                       description
+                      media_slug
                       media {
                         url
                         type

--- a/src/app/components/media/MediaTypeDisplayName.js
+++ b/src/app/components/media/MediaTypeDisplayName.js
@@ -16,6 +16,18 @@ export default function MediaTypeDisplayName({ mediaType }) {
     return <FormattedMessage id="media.typeAudio" defaultMessage="Audio" description="Label to show that the type of media is an audio file" />;
   case 'Blank':
     return <FormattedMessage id="media.typeBlank" defaultMessage="Imported fact-check" description="Label to show that the type of media is was imported into the application" />;
+  case 'Facebook':
+    return <FormattedMessage id="media.typeFacebook" defaultMessage="Facebook" description="Label to show that the type of media is a Facebook post" />;
+  case 'Instagram':
+    return <FormattedMessage id="media.typeInstagram" defaultMessage="Instagram" description="Label to show that the type of media is an Instagram post" />;
+  case 'Telegram':
+    return <FormattedMessage id="media.typeTelegram" defaultMessage="Telegram" description="Label to show that the type of media is a Telegram message" />;
+  case 'Tiktok':
+    return <FormattedMessage id="media.typeTiktok" defaultMessage="Tiktok" description="Label to show that the type of media is a Tiktok video" />;
+  case 'Twitter':
+    return <FormattedMessage id="media.typeTwitter" defaultMessage="Twitter" description="Label to show that the type of media is a Twitter tweet" />;
+  case 'Youtube':
+    return <FormattedMessage id="media.typeYoutube" defaultMessage="Youtube" description="Label to show that the type of media is a Youtube video" />;
   case '-':
   default:
     return <React.Fragment>-</React.Fragment>;

--- a/src/app/components/media/MediaTypeDisplayName.js
+++ b/src/app/components/media/MediaTypeDisplayName.js
@@ -17,17 +17,17 @@ export default function MediaTypeDisplayName({ mediaType }) {
   case 'Blank':
     return <FormattedMessage id="media.typeBlank" defaultMessage="Imported fact-check" description="Label to show that the type of media is was imported into the application" />;
   case 'Facebook':
-    return <FormattedMessage id="media.typeFacebook" defaultMessage="Facebook" description="Label to show that the type of media is a Facebook post" />;
+    return <FormattedMessage id="media.typeFacebook" defaultMessage="Facebook Post" description="Label to show that the type of media is a Facebook post" />;
   case 'Instagram':
-    return <FormattedMessage id="media.typeInstagram" defaultMessage="Instagram" description="Label to show that the type of media is an Instagram post" />;
+    return <FormattedMessage id="media.typeInstagram" defaultMessage="Instagram Post" description="Label to show that the type of media is an Instagram post" />;
   case 'Telegram':
     return <FormattedMessage id="media.typeTelegram" defaultMessage="Telegram" description="Label to show that the type of media is a Telegram message" />;
   case 'Tiktok':
-    return <FormattedMessage id="media.typeTiktok" defaultMessage="Tiktok" description="Label to show that the type of media is a Tiktok video" />;
+    return <FormattedMessage id="media.typeTiktok" defaultMessage="Tiktok Post" description="Label to show that the type of media is a Tiktok video" />;
   case 'Twitter':
-    return <FormattedMessage id="media.typeTwitter" defaultMessage="Twitter" description="Label to show that the type of media is a Twitter tweet" />;
+    return <FormattedMessage id="media.typeTwitter" defaultMessage="X (Twitter) Post" description="Label to show that the type of media is a Twitter tweet" />;
   case 'Youtube':
-    return <FormattedMessage id="media.typeYoutube" defaultMessage="Youtube" description="Label to show that the type of media is a Youtube video" />;
+    return <FormattedMessage id="media.typeYoutube" defaultMessage="Youtube Video" description="Label to show that the type of media is a Youtube video" />;
   case '-':
   default:
     return <React.Fragment>-</React.Fragment>;

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -42,6 +42,11 @@ const messages = defineMessages({
     defaultMessage: 'Rating',
     description: 'Label for sort criteria option displayed in a drop-down in the fact-checks page.',
   },
+  sortRequestsCount: {
+    id: 'searchResults.sortRequestsCount',
+    defaultMessage: 'Requests (count)',
+    description: 'Label for sort criteria option displayed in a drop-down in the feed page.',
+  },
 });
 
 /**
@@ -649,6 +654,7 @@ const SearchResultsContainer = Relay.createContainer(withPusher(injectIntl(Searc
           ${SearchFields.getFragment('team')}
           id
           slug
+          name
           search_id,
           permissions,
           search { id, number_of_results },

--- a/src/app/components/search/SearchResultsCards/FactCheckCard.js
+++ b/src/app/components/search/SearchResultsCards/FactCheckCard.js
@@ -23,9 +23,9 @@ const FactCheckCard = ({
     <Card
       footer={
         <Tooltip title={teamName}>
-          <div>
+          <span>
             <TeamAvatar team={{ avatar: teamAvatar }} size="30px" />
-          </div>
+          </span>
         </Tooltip>
       }
     >

--- a/src/app/components/search/SearchResultsCards/FactCheckCard.js
+++ b/src/app/components/search/SearchResultsCards/FactCheckCard.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import Card, { CardHoverContext } from '../../cds/media-cards/Card';
 import TeamAvatar from '../../team/TeamAvatar';
 import ItemDate from '../../cds/media-cards/ItemDate';
+import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 import ItemRating from '../../cds/media-cards/ItemRating';
 import ItemDescription from '../../cds/media-cards/ItemDescription';
 import styles from './FactCheckCard.module.css';
@@ -16,10 +17,15 @@ const FactCheckCard = ({
   summary,
   url,
   teamAvatar,
+  teamName,
 }) => (
   <div className={`${styles.factCheckCard} fact-check-card`}>
     <Card
-      footer={<TeamAvatar team={{ avatar: teamAvatar }} size="30px" />}
+      footer={
+        <Tooltip title={teamName} arrow>
+          <TeamAvatar team={{ avatar: teamAvatar }} size="30px" />
+        </Tooltip>
+      }
     >
       <div className={styles.factCheckCardDescription}>
         <CardHoverContext.Consumer>

--- a/src/app/components/search/SearchResultsCards/FactCheckCard.js
+++ b/src/app/components/search/SearchResultsCards/FactCheckCard.js
@@ -22,8 +22,10 @@ const FactCheckCard = ({
   <div className={`${styles.factCheckCard} fact-check-card`}>
     <Card
       footer={
-        <Tooltip title={teamName} arrow>
-          <TeamAvatar team={{ avatar: teamAvatar }} size="30px" />
+        <Tooltip title={teamName}>
+          <div>
+            <TeamAvatar team={{ avatar: teamAvatar }} size="30px" />
+          </div>
         </Tooltip>
       }
     >

--- a/src/app/components/search/SearchResultsCards/SharedItemCard.js
+++ b/src/app/components/search/SearchResultsCards/SharedItemCard.js
@@ -184,14 +184,16 @@ const SharedItemCard = ({
               theme="lightBrand"
               iconLeft={<FactCheckIcon />}
               variant="contained"
-              label={<FormattedMessage
-                id="sharedItemCard.factCheckCount"
-                defaultMessage="{count, plural, one {Fact-check} other {Fact-checks}}"
-                description="A label showing the number of fact-checks represented in an item."
-                values={{
-                  count: getCompactNumber(intl.locale, factCheckCount),
-                }}
-              />}
+              label={
+                <FormattedMessage
+                  id="sharedItemCard.factCheckCount"
+                  defaultMessage="{count, plural, one {# Fact-check} other {# Fact-checks}}"
+                  description="A label showing the number of fact-checks represented in an item."
+                  values={{
+                    count: getCompactNumber(intl.locale, factCheckCount),
+                  }}
+                />
+              }
             />
           ) : null }
           { (date && !feedContainsMediaRequests && feedContainsFactChecks) ? (

--- a/src/app/components/search/SearchResultsCards/SharedItemCard.js
+++ b/src/app/components/search/SearchResultsCards/SharedItemCard.js
@@ -186,7 +186,7 @@ const SharedItemCard = ({
               variant="contained"
               label={<FormattedMessage
                 id="sharedItemCard.factCheckCount"
-                defaultMessage="{count} plural, one {Fact-check} other {Fact-checks}"
+                defaultMessage="{count, plural, one {Fact-check} other {Fact-checks}}"
                 description="A label showing the number of fact-checks represented in an item."
                 values={{
                   count: getCompactNumber(intl.locale, factCheckCount),

--- a/src/app/components/search/SearchResultsCards/SharedItemCard.js
+++ b/src/app/components/search/SearchResultsCards/SharedItemCard.js
@@ -90,7 +90,12 @@ const SharedItemCard = ({
               compact
               details={[
                 mediaCount && (
-                  <FormattedMessage id="sharedItemCard.medias" defaultMessage="Medias" description="This appears as a label next to a number, like '1,234 Medias'. It should indicate to the user that whatever number they are viewing represents the number of medias attached to an item .">
+                  <FormattedMessage
+                    id="sharedItemCard.medias"
+                    defaultMessage="{mediaCount, plural, one {Media} other {Medias}}"
+                    description="This appears as a label next to a number, like '1,234 Medias'. It should indicate to the user that whatever number they are viewing represents the number of medias attached to an item."
+                    values={{ mediaCount }}
+                  >
                     { mediasLabel => (
                       <Tooltip
                         arrow
@@ -111,7 +116,12 @@ const SharedItemCard = ({
                     )}
                   </FormattedMessage>),
                 requestsCount && (
-                  <FormattedMessage id="sharedItemCard.requests" defaultMessage="Requests" description="This appears as a label next to a number, like '1,234 Requests'. It should indicate to the user that whatever number they are viewing represents the number of requests an item has gotten.">
+                  <FormattedMessage
+                    id="sharedItemCard.requests"
+                    defaultMessage="{requestsCount, plural, one {Request} other {Requests}}"
+                    description="This appears as a label next to a number, like '1,234 Requests'. It should indicate to the user that whatever number they are viewing represents the number of requests an item has gotten."
+                    values={{ requestsCount }}
+                  >
                     { requestsLabel => (
                       <Tooltip
                         arrow
@@ -176,7 +186,7 @@ const SharedItemCard = ({
               variant="contained"
               label={<FormattedMessage
                 id="sharedItemCard.factCheckCount"
-                defaultMessage="{count} Fact-checks"
+                defaultMessage="{count} plural, one {Fact-check} other {Fact-checks}"
                 description="A label showing the number of fact-checks represented in an item."
                 values={{
                   count: getCompactNumber(intl.locale, factCheckCount),

--- a/src/app/components/search/SearchResultsCards/index.js
+++ b/src/app/components/search/SearchResultsCards/index.js
@@ -19,6 +19,7 @@ const SearchResultsCards = ({ projectMedias, team }) => (
             statusColor={status.style?.color}
             url={values.fact_check_url}
             teamAvatar={values.team_avatar}
+            teamName={team.name}
           />
         </div>
       );

--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import VisibilityOffIcon from '../../../icons/visibility_off.svg';
 import styles from './ItemThumbnail.module.css';
@@ -32,13 +33,22 @@ const ItemThumbnail = ({
       mediaType = mediaTypeFromUrl(url);
     }
     return (
-      <div className={`${styles.thumbnail} ${styles.container}`}>
-        <div className={styles.iconContainer}>
-          <Tooltip title={mediaType} arrow>
+      <Tooltip
+        title={
+          <FormattedMessage
+            id="ItemThumbnail.mediaType"
+            defaultMessage="{mediaType}"
+            description="type of the media item"
+            values={{ mediaType }}
+          />
+        }
+      >
+        <div className={`${styles.thumbnail} ${styles.container}`}>
+          <div className={styles.iconContainer}>
             <MediaTypeDisplayIcon mediaType={mediaType} className={styles.mediaIcon} fontSize="var(--iconSizeDefault)" />
-          </Tooltip>
+          </div>
         </div>
-      </div>
+      </Tooltip>
     );
   }
   return (

--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import VisibilityOffIcon from '../../../icons/visibility_off.svg';
 import styles from './ItemThumbnail.module.css';
 import MediaTypeDisplayIcon, { mediaTypeFromUrl } from '../../media/MediaTypeDisplayIcon';
+import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 
 const ItemThumbnail = ({
   type, picture, maskContent, url,
@@ -33,7 +34,9 @@ const ItemThumbnail = ({
     return (
       <div className={`${styles.thumbnail} ${styles.container}`}>
         <div className={styles.iconContainer}>
-          <MediaTypeDisplayIcon mediaType={mediaType} className={styles.mediaIcon} fontSize="var(--iconSizeDefault)" />
+          <Tooltip title={mediaType} arrow>
+            <MediaTypeDisplayIcon mediaType={mediaType} className={styles.mediaIcon} fontSize="var(--iconSizeDefault)" />
+          </Tooltip>
         </div>
       </div>
     );

--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import VisibilityOffIcon from '../../../icons/visibility_off.svg';
 import styles from './ItemThumbnail.module.css';
+import MediaTypeDisplayName from '../../media/MediaTypeDisplayName';
 import MediaTypeDisplayIcon, { mediaTypeFromUrl } from '../../media/MediaTypeDisplayIcon';
 import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 
@@ -35,11 +35,8 @@ const ItemThumbnail = ({
     return (
       <Tooltip
         title={
-          <FormattedMessage
-            id="ItemThumbnail.mediaType"
-            defaultMessage="{mediaType}"
-            description="type of the media item"
-            values={{ mediaType }}
+          <MediaTypeDisplayName
+            mediaType={mediaType}
           />
         }
       >


### PR DESCRIPTION
## Description

- Change page size from 10 to 50, so it becomes consistent with other lists

- Default sorting: Number of requests, descending

- Bug: Some cards don’t have a title - we need to avoid empty titles

- Pluralization must be fixed for some card components:

- Add workspace name tooltip to the Fact-Check only card, already exists on cluster card

- Add a tooltip for the media thumbnail to indicate type of media

Reference: CV2-4354

## Type of change

- [X] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)


## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
