### PR TITLE
Show correct report status for secondary items.

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -273,6 +273,7 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
     user_id
     channel
     notes_count: annotations_count(annotation_type: "comment")
+    report_status
     suggested_similar_items_count
     suggested_similar_relationships(first: 10000) {
       edges {

--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -40,7 +40,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   }, [factCheck?.title, factCheck?.summary, factCheck?.url, factCheck?.language]);
 
   const hasPermission = Boolean(can(projectMedia.permissions, 'create ClaimDescription') && claimDescription?.description);
-  const published = (projectMedia.report && projectMedia.report.data && projectMedia.report.data.state === 'published');
+  const published = (projectMedia.report_status === 'published') || (projectMedia.report && projectMedia.report.data && projectMedia.report.data.state === 'published');
   const readOnly = projectMedia.is_secondary || projectMedia.suggested_main_item;
   const isDisabled = Boolean(readOnly || published);
   const claimDescriptionMissing = !claimDescription || claimDescription.description?.trim()?.length === 0;


### PR DESCRIPTION
## Description

It should show the status from the parent.

Fixes CV2-4071.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: When accessing a secondary item, it should show the report status of the parent item.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
