### PR TITLE
Correctly display pagination element

### DIFF
--- a/src/app/components/team/TeamTags/TeamTagsComponent.module.css
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.module.css
@@ -2,7 +2,6 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  overflow: hidden;
   text-align: center;
   user-select: none;
   width: 100%;


### PR DESCRIPTION
A change in styling on the table underneath the pagination element caused the 'hidden' overflow attribute to get triggered, making it look like there was no pagination element. Removing `overflow: hidden` fixed this.

References: CV2-4367

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)