### PR TITLE
Fix "sticky" tooltip

### DIFF
--- a/src/app/components/team/TeamTags/TeamTagsComponent.js
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.js
@@ -108,7 +108,6 @@ const TeamTagsComponent = ({
       { totalTags > pageSize && // only display paginator if there are more than pageSize worth of tags overall in the database
         <div className={styles['tags-wrapper']}>
           <Tooltip
-            disableHoverListener={isPaginationLoading || cursor - pageSize < 0}
             title={
               <FormattedMessage id="search.previousPage" defaultMessage="Previous page" description="Pagination button to go to previous page" />
             }
@@ -141,7 +140,6 @@ const TeamTagsComponent = ({
             />
           </span>
           <Tooltip
-            disableHoverListener={isPaginationLoading || cursor + pageSize >= totalCount}
             title={
               <FormattedMessage id="search.nextPage" defaultMessage="Next page" description="Pagination button to go to next page" />
             }

--- a/src/app/components/team/TeamTags/TeamTagsComponent.module.css
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.module.css
@@ -2,7 +2,6 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  overflow: hidden;
   text-align: center;
   user-select: none;
   width: 100%;


### PR DESCRIPTION
This was discovered when QA was testing CV2-4367 -- the tooltips weren't going away on buttons that entered a disabled state due to there being no more pages to go to.

This was a bug introduced in https://github.com/meedan/check-web/commit/95ca6ef12f8c3bb96197f80f0c356067c3109d95 -- we added `disableHoverListener`, which not only disables hovering, but disables the listener that tells when hovering *finishes*. So if you press "next" until the button is disabled, then mouse away from the button, the tooltip does not get removed, because the hover listener is gone. Removing this entirely, which means the tooltip will appear on the disabled button, but better than having it stick around forever.

cc @brianfleming for the design implications.