### PR TITLE
eliminate jumping around of loading animation

### DIFF
--- a/src/app/components/media/mediasloading.module.css
+++ b/src/app/components/media/mediasloading.module.css
@@ -39,12 +39,14 @@
   }
 
   &.pageLevel {
+    @mixin position absolute, 0, 0, 0, 0;
     height: 100%;
     width: 100%;
 
     :global(.check-icon) {
       @mixin position absolute, 50%, auto, auto, 50%;
-      transform: translate3d(-50%, -50%, 0);
+      animation-name: medias-loader-absolute;
+      transform: scale3d(1, 1, 1) translate3d(-50%, -50%, 0);
     }
   }
 
@@ -112,6 +114,16 @@
 
     to {
       transform: scale3d(1, 1, 1);
+    }
+  }
+
+  @keyframes medias-loader-absolute {
+    from {
+      transform: scale3d(.8, .8, 1) translate3d(-60%, -60%, 0);
+    }
+
+    to {
+      transform: scale3d(1, 1, 1) translate3d(-50%, -50%, 0);
     }
   }
 


### PR DESCRIPTION
## Description

Minor Friday PR time:
- something that has bothered me about the loading animation, admittedly I created, was when it was used in an absolute position such as the whole page version. The position would jump at the last second before the page loaded. 
- This was because of the scaling animation not taking into account the position change and the transform origin of the animation.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Things to pay attention to during code review

### BEFORE

https://github.com/meedan/check-web/assets/418001/370f66ea-6133-44c2-a3ae-4517cc295093

### AFTER

https://github.com/meedan/check-web/assets/418001/42b20c92-4336-4f55-8c79-084316a4a886


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
