### PR TITLE
Fix/CV2-4392: TypeError: Cannot read properties of null (reading 'requests_count')

### DIFF
--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -28,7 +28,7 @@ function sort(items) {
   if (!items) {
     return [];
   }
-  return items.slice().sort((a, b) => b.node.target.requests_count - a.node.target.requests_count);
+  return items.slice().sort((a, b) => b.node.target?.requests_count - a.node.target?.requests_count);
 }
 
 const MediaSimilaritiesComponent = ({ projectMedia, superAdminMask }) => {
@@ -81,6 +81,9 @@ MediaSimilaritiesComponent.propTypes = {
 MediaSimilaritiesComponent.defaultProps = {
   superAdminMask: false,
 };
+
+// eslint-disable-next-line import/no-unused-modules
+export { MediaSimilaritiesComponent };
 
 export default createFragmentContainer(MediaSimilaritiesComponent, graphql`
   fragment MediaSimilaritiesComponent_projectMedia on ProjectMedia {

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
@@ -1,0 +1,47 @@
+import { shallowWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import React from 'react';
+import { MediaSimilaritiesComponent } from './MediaSimilaritiesComponent';
+
+describe('<MediaSimilaritiesComponent />', () => {
+  it('should render without errors even if requests_count is null', () => {
+
+  const permissions = JSON.stringify({ 'update Team': true, 'read Team': true });
+    const projectMedia = {
+      id: '1',
+      demand: 1,
+      confirmedSimilarCount: 1,
+      permissions,
+      confirmed_similar_relationships: {
+        edges: [
+          {
+            node: {
+              id: '1',
+              dbid: 1,
+              source_id: 1,
+              target_id: 1,
+            },
+          },
+          {
+            node: {
+              id: '2',
+              dbid: 2,
+              source_id: 1,
+              target_id: 1,
+            },
+          },
+        ],
+      },
+    };
+
+    const superAdminMask = false;
+    const wrapper = shallowWithIntl(
+      <MediaSimilaritiesComponent
+        projectMedia={projectMedia}
+        superAdminMask={superAdminMask}
+      />
+    );
+
+    console.log(wrapper.debug())
+    expect(wrapper.find('.media__more-medias')).toHaveLength(1);
+  });
+});

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
@@ -1,11 +1,10 @@
-import { shallowWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import React from 'react';
+import { shallowWithIntl } from '../../../../../test/unit/helpers/intl-test';
 import { MediaSimilaritiesComponent } from './MediaSimilaritiesComponent';
 
 describe('<MediaSimilaritiesComponent />', () => {
   it('should render without errors even if requests_count is null', () => {
-
-  const permissions = JSON.stringify({ 'update Team': true, 'read Team': true });
+    const permissions = JSON.stringify({ 'update Team': true, 'read Team': true });
     const projectMedia = {
       id: '1',
       demand: 1,
@@ -38,7 +37,7 @@ describe('<MediaSimilaritiesComponent />', () => {
       <MediaSimilaritiesComponent
         projectMedia={projectMedia}
         superAdminMask={superAdminMask}
-      />
+      />,
     );
 
     expect(wrapper.find('.media__more-medias')).toHaveLength(1);

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
@@ -41,7 +41,6 @@ describe('<MediaSimilaritiesComponent />', () => {
       />
     );
 
-    console.log(wrapper.debug())
     expect(wrapper.find('.media__more-medias')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Description
- add a unit test to reproduce the issue and ensure that the fixed works 
- add save navigation to avoid trying to read properties of null

Reference: CV2-4392

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
Add a unit test to verify the fix

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
