### PR TITLE
adding unsafe-inline to script-src

### DIFF
--- a/scripts/server-app.js
+++ b/scripts/server-app.js
@@ -20,7 +20,7 @@ app.use((req, res, next) => {
 
   // security headers to be applied only in production and QA
   if (process.env.NODE_ENV !== 'development') {
-    res.header('Content-Security-Policy', "default-src 'self'; script-src 'self' *.heapanalytics.com *.ngrok.com *.ngrok-agent.com *.intercomcdn.com *.pusher.com *.uptime.com *.simpleanalyticscdn.com *.cloudflareinsights.com *.pusher.com *.intercom.io *.google-analytics.com; style-src  'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; object-src 'none'; base-uri 'self'; connect-src 'self' *.intercom.io *.checkmedia.org wss://nexus-websocket-a.intercom.io wss://ws-mt1.pusher.com; font-src 'self' https://fonts.gstatic.com https://fonts.intercomcdn.com; frame-src 'self'; img-src 'self' https://qa-assets.checkmedia.org; manifest-src 'self'; media-src 'self'; worker-src blob:;");
+    res.header('Content-Security-Policy', "default-src 'self'; script-src 'unsafe-inline' *.heapanalytics.com *.ngrok.com *.ngrok-agent.com *.intercomcdn.com *.pusher.com *.uptime.com *.simpleanalyticscdn.com *.cloudflareinsights.com *.pusher.com *.intercom.io *.google-analytics.com; style-src  'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; object-src 'none'; base-uri 'self'; connect-src 'self' *.intercom.io *.checkmedia.org wss://nexus-websocket-a.intercom.io wss://ws-mt1.pusher.com; font-src 'self' https://fonts.gstatic.com https://fonts.intercomcdn.com; frame-src 'self'; img-src 'self' https://qa-assets.checkmedia.org; manifest-src 'self'; media-src 'self'; worker-src blob:;");
     res.header('Content-Security-Policy-Report-Only','');
     res.header('X-Frame-Options', 'SAMEORIGIN');
     res.header('X-XSS-Protection', '1; mode=block');


### PR DESCRIPTION
## Description

Updating to allow for inline scripts to run while I investigate further options.

References: CV2-4165

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Testing only available on QA

## Things to pay attention to during code review

Watch for scripts to load and run appropriately

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
