### PR TITLE
Displaying correct feed list title

### DIFF
--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -107,7 +107,7 @@ const FeedTopBar = ({
                   {
                     hasList ?
                       <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
-                        <span className={styles.feedListTitle}>{feed.saved_search.title}</span>
+                        <span className={styles.feedListTitle}>{feed.current_feed_team.saved_search.title}</span>
                       </div> :
                       <span className={styles.feedNoListTitle}><FormattedMessage id="feedTopBar.noListSelected" defaultMessage="no list selected" description="Message displayed on feed top bar when there is no list associated with the feed." /></span>
                   }
@@ -250,6 +250,11 @@ export default createFragmentContainer(FeedTopBar, graphql`
           name
           slug
         }
+      }
+    }
+    current_feed_team {
+      saved_search {
+        title
       }
     }
     saved_search {

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -107,7 +107,7 @@ const FeedTopBar = ({
                   {
                     hasList ?
                       <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
-                        <span className={styles.feedListTitle}>{feed.current_feed_team.saved_search.title}</span>
+                        <span className={styles.feedListTitle}>{feed.current_feed_team?.saved_search?.title || feed.saved_search.title}</span>
                       </div> :
                       <span className={styles.feedNoListTitle}><FormattedMessage id="feedTopBar.noListSelected" defaultMessage="no list selected" description="Message displayed on feed top bar when there is no list associated with the feed." /></span>
                   }


### PR DESCRIPTION
We had been displaying the organizer's list title on a shared feed page, when it should be displaying the list title of whatever list the current viewer is contributing to the feed. All this PR does is add the field we need and display it instead of the wrong data.

References: CV2-4415

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Verified locally.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)