### PR TITLE
Applying the same filter displays different number of items

### DIFF
--- a/src/app/components/search/DateRangeFilter.test.js
+++ b/src/app/components/search/DateRangeFilter.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
 import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
-import DateRangeFilter from './DateRangeFilter';
-import { getUTCOffset } from './DateRangeFilter';
+import DateRangeFilter, { getUTCOffset } from './DateRangeFilter';
 
 describe('<DateRangeFilter />', () => {
   it('should render basic filter', () => {
@@ -67,26 +66,26 @@ describe('<DateRangeFilter />', () => {
   });
 
   it('should calculate UTC offset for start', () => {
-    const isoDateTimeString = '2023-02-14T08:00:00.000Z'; //location: Portland, Oregon
+    const isoDateTimeString = '2023-02-14T08:00:00.000Z'; // location: Portland, Oregon
     const isStart = true;
     const result = getUTCOffset(isoDateTimeString, isStart);
-    
+
     expect(result).toBe('UTC-8:00');
   });
 
   it('should calculate UTC offset for end time in ', () => {
-    const isoDateTimeString = '2023-03-14T14:59:59.000Z'; //location: Tokyo
+    const isoDateTimeString = '2023-03-14T14:59:59.000Z'; // location: Tokyo
     const isStart = false;
     const result = getUTCOffset(isoDateTimeString, isStart);
 
     expect(result).toBe('UTC+9:00');
-  })
+  });
 
   it('should calculate UTC offset for timezones with minute offsets', () => {
-    const isoDateTimeString = '2024-04-09T18:29:59.000Z'; //location: Mumbai
+    const isoDateTimeString = '2024-04-09T18:29:59.000Z'; // location: Mumbai
     const isStart = false;
     const result = getUTCOffset(isoDateTimeString, isStart);
 
     expect(result).toBe('UTC+5:30');
-  })
+  });
 });

--- a/src/app/components/search/DateRangeFilter.test.js
+++ b/src/app/components/search/DateRangeFilter.test.js
@@ -3,6 +3,7 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
 import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
 import DateRangeFilter from './DateRangeFilter';
+import { getUTCOffset } from './DateRangeFilter';
 
 describe('<DateRangeFilter />', () => {
   it('should render basic filter', () => {
@@ -64,4 +65,28 @@ describe('<DateRangeFilter />', () => {
 
     expect(wrapper.find('select').first().props().value).toBe('media_published_at');
   });
+
+  it('should calculate UTC offset for start', () => {
+    const isoDateTimeString = '2023-02-14T08:00:00.000Z'; //location: Portland, Oregon
+    const isStart = true;
+    const result = getUTCOffset(isoDateTimeString, isStart);
+    
+    expect(result).toBe('UTC-8:00');
+  });
+
+  it('should calculate UTC offset for end time in ', () => {
+    const isoDateTimeString = '2023-03-14T14:59:59.000Z'; //location: Tokyo
+    const isStart = false;
+    const result = getUTCOffset(isoDateTimeString, isStart);
+
+    expect(result).toBe('UTC+9:00');
+  })
+
+  it('should calculate UTC offset for timezones with minute offsets', () => {
+    const isoDateTimeString = '2024-04-09T18:29:59.000Z'; //location: Mumbai
+    const isStart = false;
+    const result = getUTCOffset(isoDateTimeString, isStart);
+
+    expect(result).toBe('UTC+5:30');
+  })
 });


### PR DESCRIPTION
Applying the same filter displays different number of items.  To limit some confusing, it was decided that the UTC offset should be seen next to date to indicate the actual range

## Description

CV2-4416 - Applying the same filter displays different number of items

If an ISO string is converted back to a date, it assumes the local timezone unless one is stated, so using Date's getTimezoneOffset wasn't an option. The input field of the DatePicker requires an ISO value to display the correct date, so that couldn't be changed.  Plus, all saved list ranges are currently saved as ISO strings. Knowing that all start dates are made at 00:00:00 and end dates are 23:59:59, we can work backwards to figure out the original timezone the string was created in. Countries like India also have a UTC offset of +5:30 so minutes have to be considered.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Checked across multiple timezones using Chrome's Sensor's feature.  

## Things to pay attention to during code review

Changing timezones can change the date once the Datepicker is selected. 

## Checklist

- [X ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
