### PR TITLE
Update icon on sidebar when a list is shared or unshared in a feed

### DIFF
--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -26,6 +26,9 @@ const createMutation = graphql`
     createFeed(input: $input) {
       feed {
         dbid
+        saved_search {
+          is_part_of_feeds
+        }
       }
       team {
         feeds(first: 10000) {
@@ -59,6 +62,12 @@ const updateMutation = graphql`
     updateFeed(input: $input) {
       feed {
         dbid
+        saved_search {
+          is_part_of_feeds
+        }
+        saved_search_was {
+          is_part_of_feeds
+        }
       }
       team {
         feeds(first: 10000) {
@@ -115,6 +124,9 @@ mutation SaveFeedUpdateFeedTeamMutation($input: UpdateFeedTeamInput!) {
       dbid
       saved_search_id
       saved_search {
+        is_part_of_feeds
+      }
+      saved_search_was {
         is_part_of_feeds
       }
     }

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -269,10 +269,7 @@ const SaveFeed = (props) => {
     commitMutation(Relay.Store, {
       mutation: updateFeedTeamMutation,
       variables: { input },
-      onCompleted: () => {
-        handleViewFeed(feedTeam.feed.dbid);
-        // window.location.reload();
-      },
+      onCompleted: () => handleViewFeed(feedTeam.feed.dbid),
       onError: onFailure,
     });
   };

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -114,6 +114,9 @@ mutation SaveFeedUpdateFeedTeamMutation($input: UpdateFeedTeamInput!) {
     feed_team {
       dbid
       saved_search_id
+      saved_search {
+        is_part_of_feeds
+      }
     }
   }
 }
@@ -266,7 +269,10 @@ const SaveFeed = (props) => {
     commitMutation(Relay.Store, {
       mutation: updateFeedTeamMutation,
       variables: { input },
-      onCompleted: () => handleViewFeed(feedTeam.feed.dbid),
+      onCompleted: () => {
+        handleViewFeed(feedTeam.feed.dbid);
+        // window.location.reload();
+      },
       onError: onFailure,
     });
   };


### PR DESCRIPTION
## Description

The sidebar shows an icon next to lists that are part of feeds. This PR makes sure that the icon is updated (without requiring a page reload) for lists when they are selected or unselected in feeds (both created feeds and invited feeds).

References: CV2-4413.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually, without reloading the page at any time:

- Go to the edit page of a feed you created
- Choose a list A
- Save
=> Make sure that there is a green icon next to the list A on the sidebar
- Go to the edit page of the same feed again
- Choose a list B
- Save
 => Make sure that there is a green icon next to the list B on the sidebar
 => Make sure that there isn't a green icon next to the list A on the sidebar

Repeat the same steps for a feed you were invited to.

## Things to pay attention to during code review

This currently requires the Check API branch `fix/CV2-4413-missing-icon-for-custom-list-being-shared-in-feeds`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
