### PR TITLE
CV2-4422 and CV2-4420 - Cannot read properties of undefined

### DIFF
--- a/src/app/components/media/Similarity/MediaSuggestionsComponent.js
+++ b/src/app/components/media/Similarity/MediaSuggestionsComponent.js
@@ -542,7 +542,7 @@ const MediaSuggestionsComponent = ({
               size="large"
               theme="validation"
               disabled={disableAcceptRejectButtons}
-              customStyle={relationshipItem.target.media ? {} : { display: 'none' }}
+              customStyle={relationshipItem?.target?.media ? {} : { display: 'none' }}
               className="similarity-media-item__accept-relationship"
             />
           </span>

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -206,7 +206,7 @@ class Task extends Component {
     const matchingTaskIndex = this.props.localResponses.findIndex(item => item.node.dbid === task.dbid);
     // deep copy the local responses object
     const mutatedLocalResponses = JSON.parse(JSON.stringify(this.props.localResponses));
-    if (task.type === 'single_choice' && mutatedLocalResponses[matchingTaskIndex]?.node?.first_response_value) {
+    if (task.type === 'single_choice' && mutatedLocalResponses[matchingTaskIndex]?.node) {
       mutatedLocalResponses[matchingTaskIndex].node.first_response_value = textValue;
     } else {
       // value is an object, we transform it to a string separated by ', '

--- a/src/app/components/task/Task.js
+++ b/src/app/components/task/Task.js
@@ -206,7 +206,7 @@ class Task extends Component {
     const matchingTaskIndex = this.props.localResponses.findIndex(item => item.node.dbid === task.dbid);
     // deep copy the local responses object
     const mutatedLocalResponses = JSON.parse(JSON.stringify(this.props.localResponses));
-    if (task.type === 'single_choice') {
+    if (task.type === 'single_choice' && mutatedLocalResponses[matchingTaskIndex]?.node?.first_response_value) {
       mutatedLocalResponses[matchingTaskIndex].node.first_response_value = textValue;
     } else {
       // value is an object, we transform it to a string separated by ', '


### PR DESCRIPTION
Added additional checks if item is null to prevent 'Cannot read properties of undefined' error on Task and MediaSuggestionsComponent

## Description

CV2-4420
CV2-4422

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
