### PR TITLE
CV2-3916 display archived action in item history

### DIFF
--- a/localization/react-intl/src/app/components/annotations/Annotation.json
+++ b/localization/react-intl/src/app/components/annotations/Annotation.json
@@ -134,6 +134,26 @@
     "defaultMessage": "Source {name} updated by {author}"
   },
   {
+    "id": "annotation.markedAsSpam",
+    "description": "Log entry indicating an item marked as spam",
+    "defaultMessage": "Marked as Spam by {author}"
+  },
+  {
+    "id": "annotation.markAsSpam",
+    "description": "Log entry indicating an item send to trash",
+    "defaultMessage": "Send to Trash by {author}"
+  },
+  {
+    "id": "annotation.notSpam",
+    "description": "Log entry indicating an item not spam",
+    "defaultMessage": "Not spam by {author}"
+  },
+  {
+    "id": "annotation.restoreFromTrash",
+    "description": "Log entry indicating an item restore from trash",
+    "defaultMessage": "Restore from Trash by {author}"
+  },
+  {
     "id": "annotation.updateClaimDescription",
     "description": "Log entry indicating a claim has been edited",
     "defaultMessage": "Claim edited by {author}: {value}"

--- a/localization/react-intl/src/app/components/annotations/Annotation.json
+++ b/localization/react-intl/src/app/components/annotations/Annotation.json
@@ -121,7 +121,7 @@
   {
     "id": "annotation.addSource",
     "description": "Log entry indicating a source has been added",
-    "defaultMessage": "Source {name} add by {author}"
+    "defaultMessage": "Source {name} added by {author}"
   },
   {
     "id": "annotation.createProjectMedia",
@@ -140,18 +140,18 @@
   },
   {
     "id": "annotation.markAsSpam",
-    "description": "Log entry indicating an item send to trash",
-    "defaultMessage": "Send to Trash by {author}"
+    "description": "Log entry indicating an item sent to trash",
+    "defaultMessage": "Sent to Trash by {author}"
   },
   {
     "id": "annotation.notSpam",
     "description": "Log entry indicating an item not spam",
-    "defaultMessage": "Not spam by {author}"
+    "defaultMessage": "Marked as not Spam by {author}"
   },
   {
     "id": "annotation.restoreFromTrash",
-    "description": "Log entry indicating an item restore from trash",
-    "defaultMessage": "Restore from Trash by {author}"
+    "description": "Log entry indicating an item restored from trash",
+    "defaultMessage": "Restored from Trash by {author}"
   },
   {
     "id": "annotation.updateClaimDescription",

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -603,7 +603,7 @@ class Annotation extends Component {
           <span>
             <FormattedMessage
               id="annotation.addSource"
-              defaultMessage="Source {name} add by {author}"
+              defaultMessage="Source {name} added by {author}"
               description="Log entry indicating a source has been added"
               values={{
                 name: meta.source_name,
@@ -638,7 +638,7 @@ class Annotation extends Component {
               <span>
                 <FormattedMessage
                   id="annotation.addSource"
-                  defaultMessage="Source {name} add by {author}"
+                  defaultMessage="Source {name} added by {author}"
                   description="Log entry indicating a source has been added"
                   values={{
                     name: meta.source_name,
@@ -682,8 +682,8 @@ class Annotation extends Component {
             <span>
               <FormattedMessage
                 id="annotation.markAsSpam"
-                defaultMessage="Send to Trash by {author}"
-                description="Log entry indicating an item send to trash"
+                defaultMessage="Sent to Trash by {author}"
+                description="Log entry indicating an item sent to trash"
                 values={{
                   author: authorName,
                 }}
@@ -696,7 +696,7 @@ class Annotation extends Component {
               <span>
                 <FormattedMessage
                   id="annotation.notSpam"
-                  defaultMessage="Not spam by {author}"
+                  defaultMessage="Marked as not Spam by {author}"
                   description="Log entry indicating an item not spam"
                   values={{
                     author: authorName,
@@ -709,8 +709,8 @@ class Annotation extends Component {
               <span>
                 <FormattedMessage
                   id="annotation.restoreFromTrash"
-                  defaultMessage="Restore from Trash by {author}"
-                  description="Log entry indicating an item restore from trash"
+                  defaultMessage="Restored from Trash by {author}"
+                  description="Log entry indicating an item restored from trash"
                   values={{
                     author: authorName,
                   }}


### PR DESCRIPTION
## Description

Display archived actions in item history dialog.

References: CV2-3916

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

1. Create a new item.
2. Apply the following actions to item in step 1
    - Mark as Spam
    - Send to Trash
    - Restore from Trash
    - Not Spam
3. Access item in step 1 and open item history dialog
Result: Should see all actions in step 2 



## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
