### PR TITLE
Some material UI clean up and introduce new button style

### DIFF
--- a/localization/react-intl/src/app/components/drawer/Projects/FeedsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/FeedsComponent.json
@@ -6,7 +6,7 @@
   },
   {
     "id": "projectsComponent.sharedFeedNavHeader",
-    "description": "The navigation name of the shared feeds section with included Beta messaging",
+    "description": "The navigation name of the shared feeds section with included Beta messaging and the total count of items in the list below",
     "defaultMessage": "Shared Feeds [{feedsLength}] <sup>BETA</sup>"
   },
   {

--- a/localization/react-intl/src/app/components/drawer/Projects/FeedsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/FeedsComponent.json
@@ -7,17 +7,12 @@
   {
     "id": "projectsComponent.sharedFeedNavHeader",
     "description": "The navigation name of the shared feeds section with included Beta messaging",
-    "defaultMessage": "Shared Feeds <sup>BETA</sup>"
-  },
-  {
-    "id": "projectsComponent.sharedFeeds",
-    "description": "Collaborating is a label to describe the type of shared feeds listed. In this case it means that they are groups of workspaces working together.",
-    "defaultMessage": "Collaborating [{feedsLength}]"
+    "defaultMessage": "Shared Feeds [{feedsLength}] <sup>BETA</sup>"
   },
   {
     "id": "projectsComponent.newSharedFeed",
-    "description": "Tooltip for the button that navigates to shared feed creation page",
-    "defaultMessage": "New shared feed"
+    "description": "Label for the button that navigates to shared feed creation page",
+    "defaultMessage": "New Shared Feed"
   },
   {
     "id": "projectsComponent.noSharedFeeds",

--- a/src/app/components/drawer/DrawerNavigationComponent.js
+++ b/src/app/components/drawer/DrawerNavigationComponent.js
@@ -72,7 +72,7 @@ class DrawerNavigationComponent extends Component {
 
   render() {
     const {
-      team, currentUserIsMember, classes, drawerOpen, drawerType,
+      team, currentUserIsMember, drawerOpen, drawerType,
     } = this.props;
 
     // This component now renders based on teamPublicFragment
@@ -88,7 +88,6 @@ class DrawerNavigationComponent extends Component {
         open={Boolean(drawerOpen)}
         variant="persistent"
         anchor="left"
-        classes={classes}
       >
         <React.Fragment>
           {!!team && (currentUserIsMember || !team.private) ? (
@@ -103,7 +102,6 @@ class DrawerNavigationComponent extends Component {
 DrawerNavigationComponent.propTypes = {
   pusher: pusherShape.isRequired,
   clientSessionId: PropTypes.string.isRequired,
-  classes: PropTypes.object.isRequired,
 };
 
 DrawerNavigationComponent.contextTypes = {

--- a/src/app/components/drawer/DrawerNavigationComponent.test.js
+++ b/src/app/components/drawer/DrawerNavigationComponent.test.js
@@ -45,7 +45,6 @@ describe('<DrawerNavigationComponent />', () => {
       pusher={pusher}
       clientSessionId="checkClientSessionId"
       params={params}
-      classes={{ paper: 'check-paper' }}
     />);
     expect(header.find(DrawerProjects)).toHaveLength(1);
   });
@@ -70,7 +69,6 @@ describe('<DrawerNavigationComponent />', () => {
       pusher={pusher}
       clientSessionId="checkClientSessionId"
       params={params}
-      classes={{ paper: 'check-paper' }}
     />);
 
     expect(header.find(DrawerProjects)).toHaveLength(1);

--- a/src/app/components/drawer/Projects/FeedsComponent.js
+++ b/src/app/components/drawer/Projects/FeedsComponent.js
@@ -2,17 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedHTMLMessage, injectIntl, defineMessages } from 'react-intl';
 import { browserHistory, withRouter } from 'react-router';
-import Collapse from '@material-ui/core/Collapse';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import cx from 'classnames/bind';
 import ProjectsListItem from './ProjectsListItem';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
-import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
-import AddCircleIcon from '../../../icons/add_circle.svg';
-import ExpandLessIcon from '../../../icons/expand_less.svg';
-import ExpandMoreIcon from '../../../icons/expand_more.svg';
+import AddIcon from '../../../icons/add.svg';
 import Can from '../../Can';
 import ScheduleSendIcon from '../../../icons/schedule_send.svg';
 import { withSetFlashMessage } from '../../FlashMessage';
@@ -32,16 +28,6 @@ const FeedsComponent = ({
   location,
   intl,
 }) => {
-  const [collapsed, setCollapsed] = React.useState(false);
-  const getBooleanPref = (key, fallback) => {
-    const inStore = window.storage.getValue(key);
-    if (inStore === null) return fallback;
-    return (inStore === 'true');
-  };
-
-  const [feedsExpanded, setFeedsExpanded] =
-    React.useState(getBooleanPref('drawer.feedsExpanded', true));
-
   // Get/set which list item should be highlighted
   const pathParts = window.location.pathname.split('/');
   const [activeItem, setActiveItem] = React.useState({ type: pathParts[2], id: parseInt(pathParts[3], 10) });
@@ -61,15 +47,7 @@ const FeedsComponent = ({
   const handleClick = (route, id) => {
     if (route !== activeItem.type || id !== activeItem.id) {
       setActiveItem({ type: route, id });
-      if (collapsed) {
-        setCollapsed(false);
-      }
     }
-  };
-
-  const handleToggleFeedsExpand = () => {
-    setFeedsExpanded(!feedsExpanded);
-    window.storage.set('drawer.feedsExpanded', !feedsExpanded);
   };
 
   const filteredFeeds = feeds.filter((feed, index, self) => {
@@ -87,90 +65,81 @@ const FeedsComponent = ({
       <div className={styles.listTitle}>
         <FormattedHTMLMessage
           id="projectsComponent.sharedFeedNavHeader"
-          defaultMessage="Shared Feeds <sup>BETA</sup>"
+          defaultMessage="Shared Feeds [{feedsLength}] <sup>BETA</sup>"
           description="The navigation name of the shared feeds section with included Beta messaging"
+          values={{ feedsLength: feeds.length }}
         />
       </div>
+      <Can permissions={team.permissions} permission="create Feed">
+        <div className={styles.listMainAction}>
+          <ButtonMain
+            className="projects-list__add-feed"
+            label={
+              <FormattedHTMLMessage
+                id="projectsComponent.newSharedFeed"
+                defaultMessage="New Shared Feed"
+                description="Label for the button that navigates to shared feed creation page"
+              />
+            }
+            iconLeft={<AddIcon />}
+            variant="contained"
+            size="default"
+            theme="text"
+            onClick={(e) => { handleCreateFeed(); e.stopPropagation(); }}
+          />
+        </div>
+      </Can>
       <div className={styles.listWrapperScrollWrapper}>
         <List dense disablePadding className={styles.listWrapper}>
-          {/* Shared feeds */}
-          <ListItem onClick={handleToggleFeedsExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>
-            { feedsExpanded ? <ExpandLessIcon className={styles.listChevron} /> : <ExpandMoreIcon className={styles.listChevron} /> }
-            <ListItemText disableTypography className={styles.listHeaderLabel}>
-              <FormattedMessage
-                tagName="span"
-                id="projectsComponent.sharedFeeds"
-                defaultMessage="Collaborating [{feedsLength}]"
-                description="Collaborating is a label to describe the type of shared feeds listed. In this case it means that they are groups of workspaces working together."
-                values={{ feedsLength: feeds.length }}
-              />
-              <Can permissions={team.permissions} permission="create Feed">
-                <Tooltip arrow title={<FormattedMessage id="projectsComponent.newSharedFeed" defaultMessage="New shared feed" description="Tooltip for the button that navigates to shared feed creation page" />}>
-                  <span className={styles.listHeaderLabelButton}>
-                    <ButtonMain
-                      className="projects-list__add-feed"
-                      iconCenter={<AddCircleIcon />}
-                      variant="contained"
-                      size="small"
-                      theme="text"
-                      onClick={(e) => { handleCreateFeed(); e.stopPropagation(); }}
-                    />
-                  </span>
-                </Tooltip>
-              </Can>
-            </ListItemText>
-          </ListItem>
-          <Collapse in={feedsExpanded} className={styles.listCollapseWrapper}>
-            { feeds.length === 0 ?
-              <ListItem className={[styles.listItem, styles.listItem_containsCount, styles.listItem_empty].join(' ')}>
-                <ListItemText disableTypography className={styles.listLabel}>
-                  <span>
-                    <FormattedMessage tagName="em" id="projectsComponent.noSharedFeeds" defaultMessage="No shared feeds" description="Displayed under the shared feed header when there are no feeds in it" />
-                  </span>
-                </ListItemText>
-              </ListItem> :
-              <>
-                {filteredFeeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map((feed) => {
-                  let itemProps = {};
-                  let itemIcon = null;
-                  switch (feed.type) {
-                  // Feeds created by the workspace
-                  case 'Feed':
-                    itemProps = { routePrefix: 'feed' };
-                    break;
-                  // Feeds not created by the workspace, but joined upon invitation
-                  case 'FeedTeam':
-                    itemProps = { routePrefix: 'feed' };
-                    break;
-                  // Feed invitations received but not processed yet
-                  case 'FeedInvitation':
-                    itemProps = { routePrefix: 'feed', routeSuffix: '/invitation' };
-                    itemIcon = <ScheduleSendIcon className={cx(styles.listIcon, styles.listIconInvitedFeed)} />;
-                    break;
-                  default:
-                    break;
-                  }
-                  return (
-                    <ProjectsListItem
-                      className={cx(
-                        {
-                          [styles.listItemInvited]: feed.type === 'FeedInvitation',
-                        })
-                      }
-                      key={feed.id}
-                      project={feed}
-                      teamSlug={team.slug}
-                      onClick={handleClick}
-                      isActive={isActive('feed', feed.dbid)}
-                      icon={itemIcon}
-                      tooltip={feed.type === 'FeedInvitation' ? intl.formatMessage(messages.pendingInvitationFeedTooltip, { feedTitle: feed.title }) : feed.title}
-                      {...itemProps}
-                    />
-                  );
-                })}
-              </>
-            }
-          </Collapse>
+          { feeds.length === 0 ?
+            <ListItem className={[styles.listItem, styles.listItem_containsCount, styles.listItem_empty].join(' ')}>
+              <ListItemText disableTypography className={styles.listLabel}>
+                <span>
+                  <FormattedMessage tagName="em" id="projectsComponent.noSharedFeeds" defaultMessage="No shared feeds" description="Displayed under the shared feed header when there are no feeds in it" />
+                </span>
+              </ListItemText>
+            </ListItem> :
+            <>
+              {filteredFeeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map((feed) => {
+                let itemProps = {};
+                let itemIcon = null;
+                switch (feed.type) {
+                // Feeds created by the workspace
+                case 'Feed':
+                  itemProps = { routePrefix: 'feed' };
+                  break;
+                // Feeds not created by the workspace, but joined upon invitation
+                case 'FeedTeam':
+                  itemProps = { routePrefix: 'feed' };
+                  break;
+                // Feed invitations received but not processed yet
+                case 'FeedInvitation':
+                  itemProps = { routePrefix: 'feed', routeSuffix: '/invitation' };
+                  itemIcon = <ScheduleSendIcon className={cx(styles.listIcon, styles.listIconInvitedFeed)} />;
+                  break;
+                default:
+                  break;
+                }
+                return (
+                  <ProjectsListItem
+                    className={cx(
+                      {
+                        [styles.listItemInvited]: feed.type === 'FeedInvitation',
+                      })
+                    }
+                    key={feed.id}
+                    project={feed}
+                    teamSlug={team.slug}
+                    onClick={handleClick}
+                    isActive={isActive('feed', feed.dbid)}
+                    icon={itemIcon}
+                    tooltip={feed.type === 'FeedInvitation' ? intl.formatMessage(messages.pendingInvitationFeedTooltip, { feedTitle: feed.title }) : feed.title}
+                    {...itemProps}
+                  />
+                );
+              })}
+            </>
+          }
         </List>
       </div>
     </React.Fragment>

--- a/src/app/components/drawer/Projects/FeedsComponent.js
+++ b/src/app/components/drawer/Projects/FeedsComponent.js
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedHTMLMessage, injectIntl, defineMessages } from 'react-intl';
 import { browserHistory, withRouter } from 'react-router';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import cx from 'classnames/bind';
 import ProjectsListItem from './ProjectsListItem';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
@@ -90,15 +87,13 @@ const FeedsComponent = ({
         </div>
       </Can>
       <div className={styles.listWrapperScrollWrapper}>
-        <List dense disablePadding className={styles.listWrapper}>
+        <ul className={styles.listWrapper}>
           { feeds.length === 0 ?
-            <ListItem className={[styles.listItem, styles.listItem_containsCount, styles.listItem_empty].join(' ')}>
-              <ListItemText disableTypography className={styles.listLabel}>
-                <span>
-                  <FormattedMessage tagName="em" id="projectsComponent.noSharedFeeds" defaultMessage="No shared feeds" description="Displayed under the shared feed header when there are no feeds in it" />
-                </span>
-              </ListItemText>
-            </ListItem> :
+            <li className={cx(styles.listItem, styles.listItem_empty)}>
+              <div className={styles.listLabel}>
+                <FormattedMessage tagName="em" id="projectsComponent.noSharedFeeds" defaultMessage="No shared feeds" description="Displayed under the shared feed header when there are no feeds in it" />
+              </div>
+            </li> :
             <>
               {filteredFeeds.sort((a, b) => (a?.title?.localeCompare(b.title))).map((feed) => {
                 let itemProps = {};
@@ -140,7 +135,7 @@ const FeedsComponent = ({
               })}
             </>
           }
-        </List>
+        </ul>
       </div>
     </React.Fragment>
   );

--- a/src/app/components/drawer/Projects/FeedsComponent.js
+++ b/src/app/components/drawer/Projects/FeedsComponent.js
@@ -63,7 +63,7 @@ const FeedsComponent = ({
         <FormattedHTMLMessage
           id="projectsComponent.sharedFeedNavHeader"
           defaultMessage="Shared Feeds [{feedsLength}] <sup>BETA</sup>"
-          description="The navigation name of the shared feeds section with included Beta messaging"
+          description="The navigation name of the shared feeds section with included Beta messaging and the total count of items in the list below"
           values={{ feedsLength: feeds.length }}
         />
       </div>

--- a/src/app/components/drawer/Projects/FeedsComponent.js
+++ b/src/app/components/drawer/Projects/FeedsComponent.js
@@ -72,7 +72,7 @@ const FeedsComponent = ({
           <ButtonMain
             className="projects-list__add-feed"
             label={
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="projectsComponent.newSharedFeed"
                 defaultMessage="New Shared Feed"
                 description="Label for the button that navigates to shared feed creation page"

--- a/src/app/components/drawer/Projects/Projects.module.css
+++ b/src/app/components/drawer/Projects/Projects.module.css
@@ -18,6 +18,10 @@
   }
 }
 
+.listMainAction {
+  padding: 0 18px;
+}
+
 .listWrapper {
   --drawerListIconSize: 18px;
   --drawerexpandIconSize: 14px;

--- a/src/app/components/drawer/Projects/Projects.module.css
+++ b/src/app/components/drawer/Projects/Projects.module.css
@@ -61,11 +61,14 @@
 
   .listHeader {
     @mixin typography-caption;
+    align-items: center;
     border: solid 1px var(--otherWhite);
     color: var(--textPlaceholder);
     cursor: pointer;
+    display: flex;
     font-weight: 500;
     height: 30px;
+    justify-content: flex-start;
     margin: 0 0 2px;
     padding: 0 0 0 7px;
     text-transform: uppercase;
@@ -74,6 +77,7 @@
     .listHeaderLabel {
       align-items: center;
       display: flex;
+      flex-basis: 100%;
       margin: 0;
 
       > span {
@@ -191,7 +195,10 @@
   .listItemCount {
     @mixin typography-body1;
     color: var(--textSecondary);
+    position: absolute;
     right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   .groupList {

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { withRouter, Link } from 'react-router';
 import Collapse from '@material-ui/core/Collapse';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import cx from 'classnames/bind';
 import ProjectsListItem from './ProjectsListItem';
 import NewProject from './NewProject';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
@@ -92,33 +89,33 @@ const ProjectsComponent = ({
         />
       </div>
       <div className={styles.listWrapperScrollWrapper}>
-        <List dense disablePadding className={[styles.listWrapper, 'projects-list'].join(' ')}>
+        <ul className={cx(styles.listWrapper, 'projects-list')}>
           {/* All items */}
           <Link
             onClick={handleAllItems}
             to={`/${team.slug}/all-items`}
             className={styles.linkList}
           >
-            <ListItem
-              className={[
+            <li
+              className={cx(
                 'projects-list__all-items',
                 styles.listItem,
                 styles.listItem_containsCount,
-                activeItem.type === 'all-items'
-                  ? styles.listItem_active
-                  : '',
-              ].join(' ')}
+                {
+                  [styles.listItem_active]: activeItem.type === 'all-items',
+                })
+              }
             >
               <CategoryIcon className={styles.listIcon} />
-              <ListItemText disableTypography className={styles.listLabel}>
+              <div className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.allItems" defaultMessage="All" description="Label for the 'All items' list displayed on the left sidebar" />
-              </ListItemText>
-              <ListItemSecondaryAction className={styles.listItemCount}>
+              </div>
+              <div title={team.medias_count} className={styles.listItemCount}>
                 <small>
                   {team.medias_count}
                 </small>
-              </ListItemSecondaryAction>
-            </ListItem>
+              </div>
+            </li>
           </Link>
           { /* Assigned to me */}
           <Link
@@ -126,20 +123,22 @@ const ProjectsComponent = ({
             to={`/${team.slug}/assigned-to-me`}
             className={styles.linkList}
           >
-            <ListItem
-              className={[
+            <li
+              className={cx(
                 'projects-list__assigned-to-me',
                 styles.listItem,
                 styles.listItem_containsCount,
-                activeItem.type === 'assigned-to-me' ? styles.listItem_active : '',
-              ].join(' ')}
+                {
+                  [styles.listItem_active]: activeItem.type === 'assigned-to-me',
+                })
+              }
             >
               <PersonIcon className={styles.listIcon} />
-              <ListItemText disableTypography className={styles.listLabel}>
+              <div className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.assignedToMe" defaultMessage="Assigned to me" description="Label for a list displayed on the left sidebar that includes items that are assigned to the current user" />
-              </ListItemText>
+              </div>
               <ProjectsCoreListCounter query={{ ...assignedToMeDefaultQuery, assigned_to: [currentUser.dbid] }} />
-            </ListItem>
+            </li>
           </Link>
           { team.smooch_bot &&
             <Link
@@ -147,20 +146,22 @@ const ProjectsComponent = ({
               to={`/${team.slug}/tipline-inbox`}
               className={styles.linkList}
             >
-              <ListItem
-                className={[
+              <li
+                className={cx(
                   'projects-list__tipline-inbox',
                   styles.listItem,
                   styles.listItem_containsCount,
-                  activeItem.type === 'tipline-inbox' ? styles.listItem_active : '',
-                ].join(' ')}
+                  {
+                    [styles.listItem_active]: activeItem.type === 'tipline-inbox',
+                  })
+                }
               >
                 <InboxIcon className={styles.listIcon} />
-                <ListItemText disableTypography className={styles.listLabel}>
+                <div className={styles.listLabel}>
                   <FormattedMessage tagName="span" id="projectsComponent.tiplineInbox" defaultMessage="Inbox" description="Label for a list displayed on the left sidebar that includes items from is any tip line channel and the item status is unstarted" />
-                </ListItemText>
+                </div>
                 <ProjectsCoreListCounter query={{ ...tiplineInboxDefaultQuery, verification_status: [team.verification_statuses.default] }} />
-              </ListItem>
+              </li>
             </Link>
           }
           <Link
@@ -168,22 +169,22 @@ const ProjectsComponent = ({
             to={`/${team.slug}/imported-fact-checks`}
             className={styles.linkList}
           >
-            <ListItem
-              className={[
+            <li
+              className={cx(
                 'projects-list__imported-fact-checks',
                 styles.listItem,
                 styles.listItem_containsCount,
-                activeItem.type === 'imported-fact-checks'
-                  ? styles.listItem_active
-                  : '',
-              ].join(' ')}
+                {
+                  [styles.listItem_active]: activeItem.type === 'imported-fact-checks',
+                })
+              }
             >
               <FileDownloadIcon className={styles.listIcon} />
-              <ListItemText disableTypography className={styles.listLabel}>
+              <div className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.importedReports" defaultMessage="Imported" description="Label for a list displayed on the left sidebar that includes items from the 'Imported fact-checks' channel" />
-              </ListItemText>
+              </div>
               <ProjectsCoreListCounter query={importedReportsDefaultQuery} />
-            </ListItem>
+            </li>
           </Link>
 
           { team.alegre_bot && team.alegre_bot.alegre_settings.master_similarity_enabled &&
@@ -192,22 +193,22 @@ const ProjectsComponent = ({
               to={`/${team.slug}/suggested-matches`}
               className={styles.linkList}
             >
-              <ListItem
-                className={[
+              <li
+                className={cx(
                   'projects-list__suggested-matches',
                   styles.listItem,
                   styles.listItem_containsCount,
-                  activeItem.type === 'suggested-matches'
-                    ? styles.listItem_active
-                    : '',
-                ].join(' ')}
+                  {
+                    [styles.listItem_active]: activeItem.type === 'suggested-matches',
+                  })
+                }
               >
                 <LightbulbIcon className={styles.listIcon} />
-                <ListItemText disableTypography className={styles.listLabel}>
+                <div className={styles.listLabel}>
                   <FormattedMessage tagName="span" id="projectsComponent.suggestedMatches" defaultMessage="Suggestions" description="Label for a list displayed on the left sidebar that includes items that have a number of suggestions is more than 1" />
-                </ListItemText>
+                </div>
                 <ProjectsCoreListCounter query={suggestedMatchesDefaultQuery} />
-              </ListItem>
+              </li>
             </Link>
           }
 
@@ -217,20 +218,22 @@ const ProjectsComponent = ({
               to={`/${team.slug}/unmatched-media`}
               className={styles.linkList}
             >
-              <ListItem
-                className={[
+              <li
+                className={cx(
                   'projects-list__unmatched-media',
                   styles.listItem,
                   styles.listItem_containsCount,
-                  activeItem.type === 'unmatched-media' ? styles.listItem_active : '',
-                ].join(' ')}
+                  {
+                    [styles.listItem_active]: activeItem.type === 'unmatched-media',
+                  })
+                }
               >
                 <UnmatchedIcon className={styles.listIcon} />
-                <ListItemText disableTypography className={styles.listLabel}>
+                <div className={styles.listLabel}>
                   <FormattedMessage tagName="span" id="projectsComponent.unmatchedMedia" defaultMessage="Unmatched media" description="Label for a list displayed on the left sidebar that includes items that were unmatched from other items (detached or rejected)" />
-                </ListItemText>
+                </div>
                 <ProjectsCoreListCounter query={unmatchedMediaDefaultQuery} />
-              </ListItem>
+              </li>
             </Link>
           }
           <Link
@@ -238,26 +241,29 @@ const ProjectsComponent = ({
             to={`/${team.slug}/published`}
             className={styles.linkList}
           >
-            <ListItem
-              className={[
+            <li
+              className={cx(
                 'projects-list__published',
                 styles.listItem,
                 styles.listItem_containsCount,
-                activeItem.type === 'published' ? styles.listItem_active : '',
-              ].join(' ')}
+                {
+                  [styles.listItem_active]: activeItem.type === 'published',
+                })
+              }
             >
               <PublishedIcon className={styles.listIcon} />
-              <ListItemText disableTypography className={styles.listLabel}>
+              <div className={styles.listLabel}>
                 <FormattedMessage tagName="span" id="projectsComponent.published" defaultMessage="Published" description="Label for a list displayed on the left sidebar that includes items that have published reports" />
-              </ListItemText>
+              </div>
               <ProjectsCoreListCounter query={publishedDefaultQuery} />
-            </ListItem>
+            </li>
           </Link>
 
           {/* Lists Header */}
-          <ListItem onClick={handleToggleListsExpand} className={[styles.listHeader, 'project-list__header'].join(' ')}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+          <li onClick={handleToggleListsExpand} className={cx(styles.listHeader, 'project-list__header')}>
             { listsExpanded ? <ExpandLessIcon className={styles.listChevron} /> : <ExpandMoreIcon className={styles.listChevron} /> }
-            <ListItemText disableTypography className={styles.listHeaderLabel}>
+            <div className={styles.listHeaderLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.lists" defaultMessage="Custom Lists" description="List of items with some filters applied" />
               <Can permissions={team.permissions} permission="create Project">
                 <Tooltip arrow title={<FormattedMessage id="projectsComponent.newListButton" defaultMessage="New list" description="Tooltip for button that opens list creation dialog" />}>
@@ -275,20 +281,20 @@ const ProjectsComponent = ({
                   </span>
                 </Tooltip>
               </Can>
-            </ListItemText>
-          </ListItem>
+            </div>
+          </li>
 
           {/* Lists */}
           <React.Fragment>
             <Collapse in={listsExpanded} className={styles.listCollapseWrapper}>
               { savedSearches.length === 0 ?
-                <ListItem className={[styles.listItem, styles.listItem_containsCount, styles.listItem_empty].join(' ')}>
-                  <ListItemText disableTypography className={styles.listLabel}>
+                <li className={cx(styles.listItem, styles.listItem_containsCount, styles.listItem_empty)}>
+                  <div className={styles.listLabel}>
                     <span>
                       <FormattedMessage tagName="em" id="projectsComponent.noCustomLists" defaultMessage="No custom lists" description="Displayed under the custom list header when there are no lists in it" />
                     </span>
-                  </ListItemText>
-                </ListItem> :
+                  </div>
+                </li> :
                 <>
                   {savedSearches.sort((a, b) => (a.title.localeCompare(b.title))).map(search => (
                     <ProjectsListItem
@@ -305,26 +311,34 @@ const ProjectsComponent = ({
               }
             </Collapse>
           </React.Fragment>
-        </List>
+        </ul>
       </div>
-      <List dense disablePadding className={[styles.listWrapper, styles.listFooter].join(' ')}>
+      <ul className={cx(styles.listWrapper, styles.listFooter)}>
         {/* Spam */}
         <Link
           onClick={handleSpam}
           to={`/${team.slug}/spam`}
           className={styles.linkList}
         >
-          <ListItem
-            className={['project-list__link-spam', 'project-list__item-spam', styles.listItem, styles.listItem_containsCount, activeItem.type === 'spam' ? styles.listItem_active : ''].join(' ')}
+          <li
+            className={cx(
+              'project-list__link-spam',
+              'project-list__item-spam',
+              styles.listItem,
+              styles.listItem_containsCount,
+              {
+                [styles.listItem_active]: activeItem.type === 'spam',
+              })
+            }
           >
             <ReportIcon className={styles.listIcon} />
-            <ListItemText disableTypography className={styles.listLabel}>
+            <div className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.spam" defaultMessage="Spam" description="Label for a list displayed on the left sidebar that includes items that have been trashed" />
-            </ListItemText>
-            <ListItemSecondaryAction title={team.medias_count} className={styles.listItemCount}>
+            </div>
+            <div title={team.spam_count} className={styles.listItemCount}>
               <small>{String(team.spam_count)}</small>
-            </ListItemSecondaryAction>
-          </ListItem>
+            </div>
+          </li>
         </Link>
 
         {/* Trash */}
@@ -333,27 +347,27 @@ const ProjectsComponent = ({
           to={`/${team.slug}/trash`}
           className={styles.linkList}
         >
-          <ListItem
-            className={[
+          <li
+            className={cx(
               'project-list__link-trash',
               'project-list__item-trash',
               styles.listItem,
               styles.listItem_containsCount,
-              activeItem.type === 'trash'
-                ? styles.listItem_active
-                : '',
-            ].join(' ')}
+              {
+                [styles.listItem_active]: activeItem.type === 'trash',
+              })
+            }
           >
             <DeleteIcon className={styles.listIcon} />
-            <ListItemText disableTypography className={styles.listLabel}>
+            <div className={styles.listLabel}>
               <FormattedMessage tagName="span" id="projectsComponent.trash" defaultMessage="Trash" description="Label for a list displayed on the left sidebar that includes items marked as spam" />
-            </ListItemText>
-            <ListItemSecondaryAction title={team.trash_count} className={styles.listItemCount}>
+            </div>
+            <div title={team.trash_count} className={styles.listItemCount}>
               <small>{String(team.trash_count)}</small>
-            </ListItemSecondaryAction>
-          </ListItem>
+            </div>
+          </li>
         </Link>
-      </List>
+      </ul>
 
       {/* Dialog to create list */}
 

--- a/src/app/components/drawer/Projects/ProjectsListCounter.js
+++ b/src/app/components/drawer/Projects/ProjectsListCounter.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import { getCompactNumber } from '../../../helpers';
 import styles from './Projects.module.css';
 
 const ProjectsListCounter = ({ numberOfItems, intl }) => (
-  <ListItemSecondaryAction title={numberOfItems} className={styles.listItemCount}>
+  <div title={numberOfItems} className={styles.listItemCount}>
     <small>
       { !Number.isNaN(parseInt(numberOfItems, 10)) ?
         getCompactNumber(intl.locale, numberOfItems) : null }
     </small>
-  </ListItemSecondaryAction>
+  </div>
 );
 
 ProjectsListCounter.propTypes = {

--- a/src/app/components/drawer/Projects/ProjectsListItem.js
+++ b/src/app/components/drawer/Projects/ProjectsListItem.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
+import cx from 'classnames/bind';
 import ProjectsListCounter from './ProjectsListCounter';
 import styles from './Projects.module.css';
 
@@ -23,39 +22,41 @@ const ProjectsListItem = ({
     }
   };
 
-  const defaultClassName = ['project-list__link', className].join(' ');
-
   const Item = listItemProps => (
     <Link
       onClick={handleClick}
       className={styles.linkList}
       to={`/${teamSlug}/${routePrefix}/${project.dbid}${routeSuffix}`}
     >
-      <ListItem
+      <li
         title={tooltip}
         key={`${project.id}-${project.title}`}
-        className={[
-          defaultClassName,
+        className={cx(
+          'project-list__link',
           styles.listItem,
           styles.listItem_containsCount,
-          isActive ? styles.listItem_active : '',
-        ].join(' ')}
+          {
+            [className]: true,
+            [styles.listItem_active]: isActive,
+          })
+        }
         {...listItemProps}
       >
         {icon}
-        <ListItemText
-          disableTypography
-          className={[
+        <div
+          className={cx(
             styles.listLabel,
-            !icon ? styles.listLabel_plainText : '',
-          ].join(' ')}
+            {
+              [styles.listLabel_plainText]: !icon,
+            })
+          }
         >
           <span>
             {project.title || project.name}
           </span>
-        </ListItemText>
+        </div>
         <ProjectsListCounter numberOfItems={project.medias_count} />
-      </ListItem>
+      </li>
     </Link>
   );
 


### PR DESCRIPTION
## Description

- We were not really using material ui for anything important in the side navigation that we couldn't easily do with plain html, this PR removes those items
- Since we are slowing down shared feed development, we don't need different "types" of shared feeds right now, so I removed the "Collaborating" header wording and removed the collapse functionality, since its now just a single list and expand/collapse is not needed.
- Added a new Main action button style for side navigations. its used first here for shared feeds, but will eventually be used for upcoming Articles work
- updated some setting of css classes from the join array style to us the classnames bind approach

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual verification, running integration tests

## Things to pay attention to during code review

no significant functionality or styles changes

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
