### PR TITLE
Commit deleting feed invitations and removing feed collaborators only…

### DIFF
--- a/localization/react-intl/src/app/components/feed/SaveFeed.json
+++ b/localization/react-intl/src/app/components/feed/SaveFeed.json
@@ -97,7 +97,7 @@
   {
     "id": "saveFeed.collaboratorRemovalConfirmationDialogBody",
     "description": "Confirmation dialog message when saving a feed.",
-    "defaultMessage": "The following collaborating organizations will be removed fro this Feed:"
+    "defaultMessage": "The following collaborating organizations will be removed from this shared feed:"
   },
   {
     "id": "saveFeed.confirmationDialogButton",

--- a/src/app/components/feed/FeedCollaboration.js
+++ b/src/app/components/feed/FeedCollaboration.js
@@ -3,15 +3,11 @@
 // Perhaps a better approach is to have TeamAvatar receive team.avatar value directly as prop
 import React from 'react';
 import PropTypes from 'prop-types';
-import { graphql, commitMutation, createFragmentContainer } from 'react-relay/compat';
-import Relay from 'react-relay/classic';
+import { graphql, createFragmentContainer } from 'react-relay/compat';
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import cx from 'classnames/bind';
 import * as EmailValidator from 'email-validator';
 import styles from './FeedCollaboration.module.css';
-import { FlashMessageSetterContext } from '../FlashMessage';
-import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
-import { getErrorMessageForRelayModernProblem } from '../../helpers';
 import Alert from '../cds/alerts-and-prompts/Alert';
 import Tooltip from '../cds/alerts-and-prompts/Tooltip';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
@@ -31,58 +27,20 @@ const messages = defineMessages({
   },
 });
 
-const destroyInviteMutation = graphql`
-  mutation FeedCollaborationDestroyFeedInvitationMutation($input: DestroyFeedInvitationInput!) {
-    destroyFeedInvitation(input: $input) {
-      deletedId
-      feed {
-        teams_count
-        feed_invitations(first: 100) {
-          edges {
-            node {
-              id
-              email
-              state
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-const removeTeamMutation = graphql`
-  mutation FeedCollaborationDestroyFeedTeamMutation($input: DestroyFeedTeamInput!) {
-    destroyFeedTeam(input: $input) {
-      deletedId
-      feed {
-        teams_count
-        feed_teams(first: 100) {
-          edges {
-            node {
-              id
-              team {
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
 const FeedCollaboration = ({
   collaboratorId,
   feed,
   intl,
   permissions,
   onChange,
+  onChangeCollaboratorsToRemove,
+  onChangeInvitesToDelete,
   readOnly,
 }) => {
   const [textValue, setTextValue] = React.useState('');
   const [invites, setInvites] = React.useState([]);
-  const setFlashMessage = React.useContext(FlashMessageSetterContext);
+  const [invitesToDelete, setInvitesToDelete] = React.useState([]);
+  const [collaboratorsToRemove, setCollaboratorsToRemove] = React.useState([]);
 
   const handleAdd = (email) => {
     if (EmailValidator.validate(email)) {
@@ -94,11 +52,6 @@ const FeedCollaboration = ({
     }
   };
 
-  const onFailure = (error) => {
-    const message = getErrorMessageForRelayModernProblem(error, <GenericUnknownErrorMessage />);
-    setFlashMessage(message, 'error');
-  };
-
   const handleDelete = (email) => {
     const newInvites = [...invites];
     newInvites.splice(newInvites.indexOf(email), 1);
@@ -106,20 +59,18 @@ const FeedCollaboration = ({
     onChange(newInvites);
   };
 
-  const handleSubmitDeleteInvite = (id) => {
-    commitMutation(Relay.Store, {
-      mutation: destroyInviteMutation,
-      variables: { input: { id } },
-      onError: onFailure,
-    });
+  const handleSelectInvitesToDelete = (id) => {
+    const newInvitesToDelete = [...invitesToDelete];
+    newInvitesToDelete.push(id);
+    setInvitesToDelete(newInvitesToDelete);
+    onChangeInvitesToDelete(newInvitesToDelete);
   };
 
-  const handleSubmitRemoveTeam = (id) => {
-    commitMutation(Relay.Store, {
-      mutation: removeTeamMutation,
-      variables: { input: { id } },
-      onError: onFailure,
-    });
+  const handleSelectCollaboratorsToRemove = (id) => {
+    const newCollaboratorsToRemove = [...collaboratorsToRemove];
+    newCollaboratorsToRemove.push(id);
+    setCollaboratorsToRemove(newCollaboratorsToRemove);
+    onChangeCollaboratorsToRemove(newCollaboratorsToRemove);
   };
 
   const FeedCollabRow = ({
@@ -300,25 +251,31 @@ const FeedCollaboration = ({
         />
       )}
       <div className={styles['feed-collab-invites']}>
-        { feed.feed_teams?.edges.map(ft => (
-          <FeedCollabRow
-            key={ft.node.team.name}
-            className="feed-collab-row__member"
-            label={ft.node.team.name}
-            team={ft.node.team}
-            type={ft.node.team.dbid === feed.team.dbid ? 'organizer' : 'collaborator'}
-            onRemove={() => handleSubmitRemoveTeam(ft.node.id)}
-          />
-        ))}
-        { feed.feed_invitations?.edges.filter(fi => fi.node.state === 'invited').map(fi => (
-          <FeedCollabRow
-            key={fi.node.email}
-            className="feed-collab-row__invitation-sent"
-            label={fi.node.email}
-            onRemove={() => handleSubmitDeleteInvite(fi.node.id)}
-            type="invitation-sent"
-          />
-        ))}
+        { feed.feed_teams?.edges
+          .filter(ft => !collaboratorsToRemove.includes(ft.node.id))
+          .map(ft => (
+            <FeedCollabRow
+              key={ft.node.team.name}
+              className="feed-collab-row__member"
+              label={ft.node.team.name}
+              team={ft.node.team}
+              type={ft.node.team.dbid === feed.team.dbid ? 'organizer' : 'collaborator'}
+              onRemove={() => handleSelectCollaboratorsToRemove(ft.node.id)}
+            />
+          ))
+        }
+        { feed.feed_invitations?.edges
+          .filter(fi => (fi.node.state === 'invited' && !invitesToDelete.includes(fi.node.id)))
+          .map(fi => (
+            <FeedCollabRow
+              key={fi.node.email}
+              className="feed-collab-row__invitation-sent"
+              label={fi.node.email}
+              onRemove={() => handleSelectInvitesToDelete(fi.node.id)}
+              type="invitation-sent"
+            />
+          ))
+        }
         { invites.map(email => (
           <FeedCollabRow
             key={email}

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -684,7 +684,7 @@ const SaveFeed = (props) => {
                   <p className={styles.paragraphMarginTop}>
                     <FormattedMessage
                       id="saveFeed.collaboratorRemovalConfirmationDialogBody"
-                      defaultMessage="The following collaborating organizations will be removed fro this Feed:"
+                      defaultMessage="The following collaborating organizations will be removed from this shared feed:"
                       description="Confirmation dialog message when saving a feed."
                     />
                   </p>


### PR DESCRIPTION
… after save is pressed

## Description

This PR makes all actions in the FeedCollaboration box be commited after the whole feed is saved (SaveFeed.js) as opposed to instantly sending mutations to remove collaborator and dismiss invitations by just clicking the X button of each row. This makes the behavior consistent with the sending invitations one which had to happen only after the feed was saved (and created).


References: CV2-4125

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually, that removing collaborating orgs and deleting pending invitations are not commited immediately but only after hitting the Save feed button.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
