### PR TITLE
CV2-4231 Fixes and additions to shared feed confirmation modals

### DIFF
--- a/localization/react-intl/src/app/components/feed/SaveFeed.json
+++ b/localization/react-intl/src/app/components/feed/SaveFeed.json
@@ -82,7 +82,7 @@
   {
     "id": "saveFeed.confirmationDialogBody",
     "description": "Confirmation dialog message when saving an existing feed.",
-    "defaultMessage": "This shared feed will be available to all users of <strong>{name}</strong> and collaborating workspaces."
+    "defaultMessage": "Updates to this shared feed will be available to all users of <strong>{name}</strong> and collaborating workspaces."
   },
   {
     "id": "saveFeed.confirmationDialogBodyCreate",

--- a/localization/react-intl/src/app/components/feed/SaveFeed.json
+++ b/localization/react-intl/src/app/components/feed/SaveFeed.json
@@ -72,17 +72,22 @@
   {
     "id": "saveFeed.confirmationDialogTitle",
     "description": "Confirmation dialog title when saving a feed.",
-    "defaultMessage": "Are you sure you want to update this shared feed?"
+    "defaultMessage": "Update Shared Feed?"
   },
   {
-    "id": "saveFeed.invitationConfirmationDialogTitle",
-    "description": "Confirmation dialog title for feed collaboration invitations.",
-    "defaultMessage": "Collaboration invitations"
+    "id": "saveFeed.confirmationDialogTitleCreate",
+    "description": "Confirmation dialog title for creating a feed.",
+    "defaultMessage": "Create Shared Feed?"
   },
   {
     "id": "saveFeed.confirmationDialogBody",
-    "description": "Confirmation dialog message when saving a feed.",
-    "defaultMessage": "Are you sure you want to update this shared feed?"
+    "description": "Confirmation dialog message when saving an existing feed.",
+    "defaultMessage": "This shared feed will be available to all users of <strong>{name}</strong> and collaborating workspaces."
+  },
+  {
+    "id": "saveFeed.confirmationDialogBodyCreate",
+    "description": "Confirmation dialog message when creating a feed.",
+    "defaultMessage": "This shared feed will be available to all users of <strong>{name}</strong>."
   },
   {
     "id": "saveFeed.invitationConfirmationDialogBody",
@@ -98,6 +103,16 @@
     "id": "saveFeed.collaboratorRemovalConfirmationDialogBody",
     "description": "Confirmation dialog message when saving a feed.",
     "defaultMessage": "The following collaborating organizations will be removed from this shared feed:"
+  },
+  {
+    "id": "alert.sharedFeedRealTimeAlertTitle",
+    "description": "Alert box warning title to tell the user the shared feed they are updating or creating may not have real time updates",
+    "defaultMessage": "Shared feed data updates may not occur in real time"
+  },
+  {
+    "id": "alert.sharedFeedRealTimeAlertContent",
+    "description": "Alert box warning further explaining that shared feeds are updated hourly and recent content may not be visible",
+    "defaultMessage": "Check automatically refreshes all the data in shared feeds hourly. On each shared feed page you will see the time and date of the last update. If that date is prior to creating or making changes to the shared feed, then the data you will see will be accurate from the last update."
   },
   {
     "id": "saveFeed.confirmationDialogButton",

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -636,7 +636,7 @@ const SaveFeed = (props) => {
                 <p>
                   <FormattedHTMLMessage
                     id="saveFeed.confirmationDialogBody"
-                    defaultMessage="This shared feed will be available to all users of <strong>{name}</strong> and collaborating workspaces."
+                    defaultMessage="Updates to this shared feed will be available to all users of <strong>{name}</strong> and collaborating workspaces."
                     description="Confirmation dialog message when saving an existing feed."
                     values={
                       {


### PR DESCRIPTION
Added modal for creating feed with no invites and edited all other confirmation modals

Updated copy for creating and editing feeds
Added an alert to inform the user that updates are not in real time Added workspace name to confirmation message. If creating, it's the workspace of the user.  If editing it's the feed's workspace. Changed save function to always prompt the user to confirm in the modal before saving

CV2-4231 - Fixes and additions to shared feed confirmation modals

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Create feed w/o collaborators: click New Shared Feed, add name, choose workspace data, click Save.
Create feed w/collaborators: click New Shared Feed, add name, choose workspace data, enter email address and add, click Save.
Edit Feed w/o collaborators: in existing feed, select edit, modify name, click Save
Edit Feed w/collaborators: in existing feed, select edit, enter email address and add, click Save

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
