### PR TITLE
Fix scrolling on item page annotations when screen becomes smaller

### DIFF
--- a/src/app/components/media/media.module.css
+++ b/src/app/components/media/media.module.css
@@ -210,6 +210,12 @@
         overflow: visible;
       }
 
+      .media-item-claim,
+      .media-item-medias,
+      .media-item-annotations {
+        max-height: unset;
+      }
+
       .media-item-claim {
         flex: 0 0 420px;
         margin: 0 0 16px;


### PR DESCRIPTION
## Description

Bug reported by Rick at Vera Files that when using a smaller screen to view the item page (he is split screening) he cannot scroll to the very bottom of the annotations list. This is because in that responsive size the whole container is set to scroll and when the screen is larger, the individual columns scroll. This PR fixes the height of each of the columns when the whole container is responsible for scrolling

References: CV2-4544

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manually changing the screen size to be small and short in order to require scrolling

## Things to pay attention to during code review

just a css change

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
