### PR TITLE
Fix: icon displaying the wrong name in the tooltip on FactCheckCard

### DIFF
--- a/src/app/components/search/SearchResultsCards/FactCheckCard.js
+++ b/src/app/components/search/SearchResultsCards/FactCheckCard.js
@@ -65,6 +65,7 @@ FactCheckCard.propTypes = {
   summary: PropTypes.string,
   url: PropTypes.string,
   teamAvatar: PropTypes.string.isRequired, // URL
+  teamName: PropTypes.string.isRequired,
 };
 
 export default FactCheckCard;

--- a/src/app/components/search/SearchResultsCards/index.js
+++ b/src/app/components/search/SearchResultsCards/index.js
@@ -19,7 +19,7 @@ const SearchResultsCards = ({ projectMedias, team }) => (
             statusColor={status.style?.color}
             url={values.fact_check_url}
             teamAvatar={values.team_avatar}
-            teamName={team.name}
+            teamName={values?.team_name}
           />
         </div>
       );


### PR DESCRIPTION

## Description

fix the team name displayed on FactCheckCard by passing the team name of the project media

Reference: CV2-4530

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Hover the team icon on the FactCheckCard and check the team name

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
