### PR TITLE
Fix content warning button issues

### DIFF
--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -89,6 +89,7 @@ const AspectRatio = ({
         <SensitiveContentMenuButton
           projectMedia={projectMedia}
           currentUserRole={currentUserRole}
+          onSave={(enabled) => { setMaskContent(enabled); }}
         /> : null
       }
     </div>

--- a/src/app/components/layout/AspectRatio.module.css
+++ b/src/app/components/layout/AspectRatio.module.css
@@ -50,6 +50,10 @@
   width: 100%;
   z-index: 100;
 
+  .toggleShowHideButton {
+    pointer-events: auto;
+  }
+
   .visibilityIcon {
     display: none;
     font-size: var(--iconSizeDefault);
@@ -72,5 +76,5 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 20;
+  z-index: 1002;
 }

--- a/src/app/components/media/SensitiveContentMenuButton.js
+++ b/src/app/components/media/SensitiveContentMenuButton.js
@@ -25,6 +25,7 @@ const SensitiveContentMenu = ({
   projectMedia,
   setFlashMessage,
   container,
+  onSave,
 }) => {
   let warningType = null;
   let warningTypeCustom = null;
@@ -86,7 +87,10 @@ const SensitiveContentMenu = ({
       const message = getErrorMessage(error, <GenericUnknownErrorMessage />);
       setFlashMessage(message, 'error');
     };
-    const onSuccess = () => { onDismiss(); };
+    const onSuccess = () => {
+      onDismiss();
+      onSave(enableSwitch);
+    };
 
     if (enableSwitch && !contentType) {
       setFormError('no_warning_type');
@@ -328,6 +332,7 @@ const SensitiveContentMenu = ({
 const SensitiveContentMenuButton = ({
   currentUserRole,
   projectMedia,
+  onSave,
   setFlashMessage,
 }) => {
   const { show_warning_cover } = projectMedia;
@@ -352,12 +357,17 @@ const SensitiveContentMenuButton = ({
         key={anchorEl}
         anchorEl={anchorEl}
         onDismiss={() => setAnchorEl(null)}
+        onSave={onSave}
         projectMedia={projectMedia}
         setFlashMessage={setFlashMessage}
         container={containerRef.current}
       />
     </div>
   );
+};
+
+SensitiveContentMenuButton.defaultProps = {
+  onSave: () => {},
 };
 
 SensitiveContentMenuButton.propTypes = {
@@ -367,6 +377,7 @@ SensitiveContentMenuButton.propTypes = {
     show_warning_cover: PropTypes.bool.isRequired,
   }).isRequired,
   setFlashMessage: PropTypes.func.isRequired,
+  onSave: PropTypes.func,
 };
 
 export default createFragmentContainer(withSetFlashMessage(SensitiveContentMenuButton), graphql`


### PR DESCRIPTION
## Description

The content warning button could not be clicked on because it was set to not get pointed events in the situation where a pender card was displayed. Thats why it was only broken on social media items

References: CV2-4576

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

nothing really

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
