### PR TITLE
Restore table view in Trash

### DIFF
--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -20,9 +20,7 @@ import BlankState from '../layout/BlankState';
 import FeedBlankState from '../feed/FeedBlankState';
 import ListSort from '../cds/inputs/ListSort';
 import SearchResultsTable from './SearchResultsTable';
-import SelectAllTh from './SearchResultsTable/SelectAllTh';
 import SearchResultsCards from './SearchResultsCards';
-import WorkspaceItemCard from './SearchResultsCards/WorkspaceItemCard';
 import SearchRoute from '../../relay/SearchRoute';
 import CreateMedia from '../media/CreateMedia';
 import Can from '../Can';
@@ -345,28 +343,6 @@ function SearchResultsComponent({
     }
   });
 
-  const handleCheckboxChange = (checked, projectMedia) => {
-    const { id } = projectMedia;
-    if (!id) return; // Can't select unsaved object. Swallow mouse click.
-
-    let newIds;
-    if (checked) {
-      // Add
-      if (filteredSelectedProjectMediaIds.includes(id)) {
-        return;
-      }
-      newIds = [...filteredSelectedProjectMediaIds, id];
-      newIds.sort((a, b) => a - b);
-    } else {
-      // Remove
-      if (!filteredSelectedProjectMediaIds.includes(id)) {
-        return;
-      }
-      newIds = filteredSelectedProjectMediaIds.filter(oldId => oldId !== id);
-    }
-    setSelectedProjectMediaIds(newIds);
-  };
-
   let content = null;
 
   // Return nothing if feed doesn't have a list
@@ -404,36 +380,6 @@ function SearchResultsComponent({
         />
       );
     }
-  } else if (page === 'trash') {
-    content = (
-      <div>
-        { projectMedias.map(item => (
-          <WorkspaceItemCard
-            onCheckboxChange={(checked) => { handleCheckboxChange(checked, item); }}
-            isChecked={filteredSelectedProjectMediaIds.includes(item.id)}
-            isPublished={item.report_status === 'published'}
-            cardUrl={buildProjectMediaUrl(item)}
-            date={new Date(+item.last_seen * 1000)}
-            title={item.title}
-            description={item.description}
-            lastRequestDate={new Date(+item.list_columns_values.updated_at_timestamp * 1000)}
-            rating={item.team.verification_statuses.statuses.find(s => s.id === item.list_columns_values.status).label}
-            ratingColor={item.team.verification_statuses.statuses.find(s => s.id === item.list_columns_values.status).style.color}
-            requestsCount={item.requests_count}
-            mediaCount={item.list_columns_values.linked_items_count}
-            mediaThumbnail={{
-              media: {
-                picture: item.picture,
-                type: item.media.type,
-                url: item.media.url,
-              },
-            }}
-            mediaType={item.media.type}
-            suggestionsCount={item.list_columns_values.suggestions_count}
-          />
-        ))}
-      </div>
-    );
   } else {
     content = (
       <SearchResultsTable
@@ -578,12 +524,6 @@ function SearchResultsComponent({
                     />
                   </div> : null
                 }
-                <SelectAllTh
-                  className={styles.noBottomBorder}
-                  selectedIds={filteredSelectedProjectMediaIds}
-                  projectMedias={projectMedias}
-                  onChangeSelectedIds={handleChangeSelectedIds}
-                />
                 <span className={styles['search-pagination']}>
                   <Tooltip title={
                     <FormattedMessage id="search.previousPage" defaultMessage="Previous page" description="Pagination button to go to previous page" />

--- a/test/spec/media_spec.rb
+++ b/test/spec/media_spec.rb
@@ -23,7 +23,8 @@ shared_examples 'media' do |type|
     wait_for_selector('.media-actions__send-to-trash').click
     wait_for_selector('.message')
     wait_for_selector('#notistack-snackbar a').click
-    wait_for_selector('.workspace-item--card .int-checkbox__label').click
+    wait_for_selector('.media__heading')
+    wait_for_selector("table input[type='checkbox']").click
     wait_for_selector("//span[contains(text(), '(1 selected)')]", :xpath)
     wait_for_selector('#bulk-actions-menu__button').click
     wait_for_selector('.bulk-actions-menu__restore').click


### PR DESCRIPTION
## Description

This reverts the usage of WorkspaceItem card for the trash view while keeping the component available on Sandbox and other improvements in the codebase.

References CV2-3991

## Type of change

- [x] Reverting changes from work in progress
- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested locally that Trash view is restored to standard SearchResults table

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
