### PR TITLE
Enable quick filters for feed clusters.

### DIFF
--- a/localization/react-intl/src/app/components/feed/QuickFilterMenu.json
+++ b/localization/react-intl/src/app/components/feed/QuickFilterMenu.json
@@ -11,12 +11,12 @@
   },
   {
     "id": "quickFilterMenu.otherWorkspaces",
-    "description": "Label for a menu item that filters a search of fact-checks so that the user only sees those that are *not* in their workspace",
-    "defaultMessage": "Fact-checks <strong>not</strong> in my workspace"
+    "description": "Label for a menu item that filters a search of items so that the user only sees those that are *not* in their workspace",
+    "defaultMessage": "Items <strong>not</strong> in my workspace"
   },
   {
     "id": "quickFilterMenu.myWorkspace",
-    "description": "Label for a menu item that filters a search of fact-checks so that the user only sees those that are in their workspace",
-    "defaultMessage": "Fact-checks <strong>only</strong> in my workspace"
+    "description": "Label for a menu item that filters a search of items so that the user only sees those that are in their workspace",
+    "defaultMessage": "Items <strong>only</strong> in my workspace"
   }
 ]

--- a/src/app/components/feed/FeedClusters.js
+++ b/src/app/components/feed/FeedClusters.js
@@ -140,7 +140,6 @@ const FeedClustersComponent = ({
           feed={feed}
           teamFilters={teamFilters}
           setTeamFilters={handleChangeTeamFilters}
-          hideQuickFilterMenu
         />
         <FeedFilters
           onSubmit={handleChangeFilters}

--- a/src/app/components/feed/QuickFilterMenu.js
+++ b/src/app/components/feed/QuickFilterMenu.js
@@ -67,8 +67,8 @@ const QuickFilterMenu = ({
           </ListItemIcon>
           <FormattedHTMLMessage
             id="quickFilterMenu.otherWorkspaces"
-            defaultMessage="Fact-checks <strong>not</strong> in my workspace"
-            description="Label for a menu item that filters a search of fact-checks so that the user only sees those that are *not* in their workspace"
+            defaultMessage="Items <strong>not</strong> in my workspace"
+            description="Label for a menu item that filters a search of items so that the user only sees those that are *not* in their workspace"
           />
         </MenuItem>
         <MenuItem
@@ -80,8 +80,8 @@ const QuickFilterMenu = ({
           </ListItemIcon>
           <FormattedHTMLMessage
             id="quickFilterMenu.myWorkspace"
-            defaultMessage="Fact-checks <strong>only</strong> in my workspace"
-            description="Label for a menu item that filters a search of fact-checks so that the user only sees those that are in their workspace"
+            defaultMessage="Items <strong>only</strong> in my workspace"
+            description="Label for a menu item that filters a search of items so that the user only sees those that are in their workspace"
           />
         </MenuItem>
       </Menu>


### PR DESCRIPTION
## Description

The "quick filters" was enabled only for fact-checks-only feeds. This PR enables them for medias feeds too. So, I also changed the copy from "fact-checks" to the more generic "items", the same way we did for the team filters.

Fixes CV2-4601.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. The quick filters (:zap:) should be displayed on the header in the feed clusters page.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
