### PR TITLE
Display friendlier error message when importing feed items that already exist in the target workspace

### DIFF
--- a/src/app/components/ParsedText.js
+++ b/src/app/components/ParsedText.js
@@ -22,6 +22,17 @@ const marked = (text, truncateFileUrls, fileUrlName, mediaChips) => {
     ));
   }
 
+  // Turn Markdown URLs into links (e.g., [Text](https://url))
+
+  parsedText = reactStringReplace(parsedText, /(\[[^\]]+\]\(https?:\/\/[^ ]+\))/gm, (match, i) => {
+    const markdown = match.match(/\[(?<text>[^\]]+)\]\((?<url>https?:\/\/[^ ]+)\)/m); // Extract "text" and "url" from Markdown link
+    return (
+      <a className={styles['markdown-link']} href={markdown.groups.url} target="_blank" key={i} rel="noopener noreferrer">
+        {markdown.groups.text}
+      </a>
+    );
+  });
+
   // Turn other URLs into links
 
   parsedText = reactStringReplace(parsedText, /(https?:\/\/[^ ]+)/gm, (match, i) => (

--- a/src/app/components/ParsedText.module.css
+++ b/src/app/components/ParsedText.module.css
@@ -21,3 +21,10 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
+
+.markdown-link {
+  &:hover {
+    color: inherit !important;
+    text-decoration: none;
+  }
+}

--- a/src/app/components/feed/FeedImportDialog.js
+++ b/src/app/components/feed/FeedImportDialog.js
@@ -5,7 +5,6 @@ import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { createFragmentContainer, graphql, commitMutation } from 'react-relay/compat';
 import cx from 'classnames/bind';
 import Dialog from '@material-ui/core/Dialog';
-import Linkify from 'react-linkify';
 import { ToggleButton, ToggleButtonGroup } from '../cds/inputs/ToggleButtonGroup';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import TextField from '../cds/inputs/TextField';
@@ -16,6 +15,7 @@ import dialogStyles from '../../styles/css/dialog.module.css';
 import { withSetFlashMessage } from '../FlashMessage';
 import { getErrorMessage } from '../../helpers';
 import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
+import ParsedText from '../ParsedText';
 import mediaStyles from '../media/media.module.css';
 import styles from './FeedItem.module.css';
 
@@ -63,7 +63,7 @@ const FeedImportDialog = ({
 
   const onError = (error) => {
     const errorMessage = getErrorMessage(error);
-    const errorComponent = errorMessage ? <Linkify properties={{ target: '_blank', rel: 'noopener noreferrer' }}>{errorMessage}</Linkify> : <GenericUnknownErrorMessage />;
+    const errorComponent = errorMessage ? <ParsedText text={errorMessage} /> : <GenericUnknownErrorMessage />;
     setFlashMessage(errorComponent);
     setSaving(false);
     onClose();

--- a/src/app/components/feed/FeedImportDialog.js
+++ b/src/app/components/feed/FeedImportDialog.js
@@ -5,6 +5,7 @@ import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { createFragmentContainer, graphql, commitMutation } from 'react-relay/compat';
 import cx from 'classnames/bind';
 import Dialog from '@material-ui/core/Dialog';
+import Linkify from 'react-linkify';
 import { ToggleButton, ToggleButtonGroup } from '../cds/inputs/ToggleButtonGroup';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import TextField from '../cds/inputs/TextField';
@@ -13,7 +14,7 @@ import SmallMediaCard from '../cds/media-cards/SmallMediaCard';
 import AutoCompleteMediaItem from '../media/AutoCompleteMediaItem';
 import dialogStyles from '../../styles/css/dialog.module.css';
 import { withSetFlashMessage } from '../FlashMessage';
-import { getErrorMessageForRelayModernProblem } from '../../helpers';
+import { getErrorMessage } from '../../helpers';
 import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
 import mediaStyles from '../media/media.module.css';
 import styles from './FeedItem.module.css';
@@ -61,8 +62,9 @@ const FeedImportDialog = ({
   };
 
   const onError = (error) => {
-    const errorMessage = getErrorMessageForRelayModernProblem(error) || <GenericUnknownErrorMessage />;
-    setFlashMessage(errorMessage);
+    const errorMessage = getErrorMessage(error);
+    const errorComponent = errorMessage ? <Linkify properties={{ target: '_blank', rel: 'noopener noreferrer' }}>{errorMessage}</Linkify> : <GenericUnknownErrorMessage />;
+    setFlashMessage(errorComponent);
     setSaving(false);
     onClose();
   };


### PR DESCRIPTION
## Description

Display only the error message with links to existing items. Depends on Check API branch of same name.

Fixes: CV2-4631.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

![Captura de tela de 2024-05-22 15-26-44](https://github.com/meedan/check-web/assets/117518/1f0835fe-e096-4fd4-a802-cfc6aaee0b7b)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)