### PR TITLE
Fix: Messages not marked as 'read' after being read

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -56,7 +56,7 @@ class MediaComponent extends Component {
     if (!this.props.projectMedia.is_read) {
       commitMutation(Store, {
         mutation: graphql`
-          mutation BulkActionsMenuMarkAsReadMutation($input: BulkProjectMediaMarkReadInput!) {
+          mutation MediaComponentMarkAsReadMutation($input: BulkProjectMediaMarkReadInput!) {
             bulkProjectMediaMarkRead(input: $input) {
               updated_objects {
                 id

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -53,23 +53,21 @@ class MediaComponent extends Component {
 
   componentDidMount() {
     this.subscribe();
-
-    if (!this.props.projectMedia.read_by_me) {
+    if (!this.props.projectMedia.is_read) {
       commitMutation(Store, {
         mutation: graphql`
-          mutation MediaComponentCreateProjectMediaUserMutation($input: CreateProjectMediaUserInput!) {
-            createProjectMediaUser(input: $input) {
-              project_media {
+          mutation BulkActionsMenuMarkAsReadMutation($input: BulkProjectMediaMarkReadInput!) {
+            bulkProjectMediaMarkRead(input: $input) {
+              updated_objects {
                 id
-                read_by_someone: is_read
-                read_by_me: is_read(by_me: true)
+                is_read
               }
             }
           }
         `,
         variables: {
           input: {
-            project_media_id: this.props.projectMedia.dbid,
+            ids: [this.props.projectMedia.id],
             read: true,
           },
         },
@@ -264,8 +262,7 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
     dbid
     title
     type
-    read_by_someone: is_read
-    read_by_me: is_read(by_me: true)
+    is_read
     permissions
     pusher_channel
     project_id


### PR DESCRIPTION
## Description
Refactor read status mutation and field in MediaComponent. Verify the is_read field instead of read_by_me and replace the mutation used to mark a media item as read has been changed from MediaComponentCreateProjectMediaUserMutation to BulkActionsMenuMarkAsReadMutation when navigating to the media page and simplify the fields used to track the read status of a media item have been simplified from read_by_someone and read_by_me to a single is_read field.

Reference: CV-4381

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
