### PR TITLE
"Fix 'Report' button navigation error when item page URL has trailing slash

### DIFF
--- a/src/app/components/media/MediaFactCheck.js
+++ b/src/app/components/media/MediaFactCheck.js
@@ -46,7 +46,7 @@ const MediaFactCheck = ({ projectMedia }) => {
   const claimDescriptionMissing = !claimDescription || claimDescription.description?.trim()?.length === 0;
 
   const handleGoToReport = () => {
-    window.location.assign(`${window.location.pathname.replace(/\/(suggested-matches|similar-media)/, '')}/report`);
+    window.location.assign(`${window.location.pathname.replace(/\/(suggested-matches|similar-media)\/?$/, '').replace(/\/$/, '')}/report`);
   };
 
   const handleBlur = (field, value) => {


### PR DESCRIPTION
## Description

Update handleGoToReport function to handle URLs with trailing slashes

Reference: CV2-4574

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- Go to some item page and add a slash at the end of the URL, e.g: media/22485/
- click on the "published/unpublished report" button 
- check that you are redirected to the report page
- 
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
