### PR TITLE
Fix: Display ItemThumbnail when there is media picture and add unit tests

### DIFF
--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.js
@@ -10,7 +10,7 @@ import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 const ItemThumbnail = ({
   type, picture, maskContent, url,
 }) => {
-  if (!type) {
+  if (!type && !picture) {
     return (
       <div className={`${styles.thumbnail} ${styles.container} ${styles.emptyMedia}`}>
         <div className={`${styles.iconContainer}`}>

--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.test.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import EmptyMediaIcon from '../../../icons/empty_media.svg';
+import VisibilityOffIcon from '../../../icons/visibility_off.svg';
+import ItemThumbnail from './ItemThumbnail';
+import MediaTypeDisplayIcon from '../../media/MediaTypeDisplayIcon';
+
+describe('<ItemThumbnail />', () => {
+  it('should render ItemThumbnail', () => {
+    const wrapper = mountWithIntl(
+      <ItemThumbnail
+        type="image"
+        picture="test.jpg"
+        maskContent={false}
+        url="http://test.com"
+      />);
+    expect(wrapper.find('img').length).toEqual(1);
+    expect(wrapper.find(EmptyMediaIcon).length).toEqual(0);
+    expect(wrapper.find(VisibilityOffIcon).length).toEqual(0);
+  });
+
+  it('should render when there is no media type', () => {
+    const wrapper = mountWithIntl(
+      <ItemThumbnail
+        picture="test.jpg"
+        maskContent={false}
+        url="http://test.com"
+      />);
+    expect(wrapper.find('img').length).toEqual(1);
+    expect(wrapper.find(EmptyMediaIcon).length).toEqual(0);
+  });
+
+  it('should render EmptyMediaIcon when there is no media type and no picture', () => {
+    const wrapper = mountWithIntl(
+      <ItemThumbnail
+        maskContent={false}
+        url="http://test.com"
+      />);
+    expect(wrapper.find(EmptyMediaIcon).length).toEqual(1);
+  });
+
+  it('should render VisibilityOffIcon when maskcontent', () => {
+    const wrapper = mountWithIntl(
+      <ItemThumbnail
+        maskContent
+        picture="test.jpg"
+        url="http://test.com"
+      />);
+    expect(wrapper.find(VisibilityOffIcon).length).toEqual(1);
+  });
+
+  it('should render MediaTypeDisplayIcon when there is no picture', () => {
+    const wrapper = mountWithIntl(
+      <ItemThumbnail
+        maskContent={false}
+        type="image"
+      />);
+    expect(wrapper.find(MediaTypeDisplayIcon).length).toEqual(1);
+  });
+});


### PR DESCRIPTION
## Description

Fix: Only Return EmptyMediaIcon When Both Media Type and Media Picture Are Null
Previously, the bug occurred because the media type was not provided, even though the picture value was present. This caused the application to return the EmptyMediaIcon incorrectly.
Reference: CV2-4685

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
add unit tests
## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
