### PR TITLE
Fix/cv2-4436: Custom lists should be sorted alphabetically in the shared feed

### DIFF
--- a/src/app/components/feed/SelectList.js
+++ b/src/app/components/feed/SelectList.js
@@ -91,7 +91,7 @@ const SelectListQueryRenderer = ({
                 >
                   <option value={null}>{selectLabel}</option>
                   {
-                    // Attempting to sort a read-only array directly would result in a TypeError, so we create a new array first to avoid the error. 
+                    // Attempting to sort a read-only array directly would result in a TypeError, so we create a new array first to avoid the error.
                     [...props.team.saved_searches.edges]
                       .sort((a, b) => a.node.title.localeCompare(b.node.title))
                       .map(l => (

--- a/src/app/components/feed/SelectList.js
+++ b/src/app/components/feed/SelectList.js
@@ -90,9 +90,14 @@ const SelectListQueryRenderer = ({
                   label={label}
                 >
                   <option value={null}>{selectLabel}</option>
-                  { props.team.saved_searches.edges.map(l => (
-                    <option value={l.node.dbid}>{l.node.title}</option>
-                  )) }
+                  {
+                    // Attempting to sort a read-only array directly would result in a TypeError, so we create a new array first to avoid the error. 
+                    [...props.team.saved_searches.edges]
+                      .sort((a, b) => a.node.title.localeCompare(b.node.title))
+                      .map(l => (
+                        <option key={l.node.dbid} value={l.node.dbid}>{l.node.title}</option>
+                      ))
+                  }
                 </Select>
               )}
             </FormattedMessage>


### PR DESCRIPTION
## Description

Fix: Alphabetical Sorting of Custom Lists in Shared Feed
In the SelectList component, custom lists are now sorted alphabetically before being displayed

Reference: CV2-4436

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
- In the shared feed settings page attempt to select a custom list from the dropdown menu.
Check that the lists are displayed in alphabetical order within the dropdown menu.

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
