### PR TITLE
Handle the "unpublished" state in the "Publish" button in the Report Designer page

### DIFF
--- a/src/app/CheckPropTypes.js
+++ b/src/app/CheckPropTypes.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+const CheckPropTypes = {
+  reportState: PropTypes.oneOf(['paused', 'published', 'unpublished']),
+};
+
+export default CheckPropTypes;

--- a/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerTopBar.js
@@ -15,6 +15,7 @@ import IconArrowBack from '../../../icons/arrow_back.svg';
 import IconPlay from '../../../icons/play_arrow.svg';
 import IconPause from '../../../icons/pause.svg';
 import HelpIcon from '../../../icons/help.svg';
+import CheckPropTypes from '../../../CheckPropTypes';
 import styles from './ReportDesigner.module.css';
 
 const useStyles = makeStyles(theme => ({
@@ -184,7 +185,7 @@ const ReportDesignerTopBar = (props) => {
         </div>
       </div>
       <div className={styles['report-actions']}>
-        { state === 'paused' ?
+        { (state === 'paused' || state === 'unpublished') ?
           <ReportDesignerConfirmableButton
             theme="validation"
             disabled={readOnly}
@@ -443,7 +444,7 @@ ReportDesignerTopBar.defaultProps = {
 };
 
 ReportDesignerTopBar.propTypes = {
-  state: PropTypes.oneOf(['paused', 'published']).isRequired,
+  state: CheckPropTypes.reportState.isRequired,
   media: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired,
   defaultLanguage: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description

Also, taking this opportunity to do one thing Alex and I talked last Friday: Extract some common `propTypes` to a file so we can reuse them across the code base.

Reference: CV2-4665.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually:

- Create an item
- Add a fact-check
- Click on "Unpublished report"
- Make sure you get redirected to the report designer page and that the "Publish" button is visible and clickable

## Things to pay attention to during code review

I added a new standard we hope we can take forward: Abstract some common `propTypes` to a module we can reuse across the codebase.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
