### PR TITLE
card improvements

### DIFF
--- a/localization/react-intl/src/app/components/cds/media-cards/ItemReportStatus.json
+++ b/localization/react-intl/src/app/components/cds/media-cards/ItemReportStatus.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "itemReportStatus.tooltipPublished",
+    "description": "Tooltip of a report status icon when the report is published",
+    "defaultMessage": "Published Fact-Check"
+  },
+  {
+    "id": "itemReportStatus.tooltipUnpublished",
+    "description": "Tooltip of a report status icon when the report is not published",
+    "defaultMessage": "Unpublished Fact-Check"
+  }
+]

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -91,7 +91,7 @@ const SandboxComponent = ({ admin }) => {
   ];
 
   const [articleCardShared, setArticleCardShared] = React.useState(false);
-  const [articleCardVariant, setArticleCardVariant] = React.useState('explainer');
+  const [articleCardVariant, setArticleCardVariant] = React.useState('fact-check');
 
   const [listItemShared, setListItemShared] = React.useState(Boolean(false));
   const [listItemCluster, setListItemCluster] = React.useState(Boolean(false));
@@ -438,6 +438,7 @@ const SandboxComponent = ({ admin }) => {
               title="Moby-Dick; or, The Whale."
               summary="Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to sea as soon as I can."
               date={1702677106.846}
+              publishedAt={articleCardShared ? null : 1702677106.846}
               statusLabel={articleCardVariant === 'fact-check' ? 'The Status is very very long' : null}
               statusColor={articleCardVariant === 'fact-check' ? '#ff0000' : null}
               teamName={articleCardShared ? 'Kitty Team' : null}

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -438,7 +438,7 @@ const SandboxComponent = ({ admin }) => {
               title="Moby-Dick; or, The Whale."
               summary="Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to sea as soon as I can."
               date={1702677106.846}
-              statusLabel={articleCardVariant === 'fact-check' ? 'The Status' : null}
+              statusLabel={articleCardVariant === 'fact-check' ? 'The Status is very very long' : null}
               statusColor={articleCardVariant === 'fact-check' ? '#ff0000' : null}
               teamName={articleCardShared ? 'Kitty Team' : null}
               teamAvatar={articleCardShared ? 'https://placekitten.com/300/300' : null}
@@ -615,13 +615,14 @@ const SandboxComponent = ({ admin }) => {
               mediaCount={12345}
               requestsCount={listItemRequests ? 7890 : null}
               lastRequestDate={new Date('2024-01-15T12:00:22Z')}
-              factCheckUrl={listItemFactCheckLink && 'https://example.com/this-is-a/very-long-url/that-could-break-some-layout/if-we-let-it'}
+              factCheckUrl={listItemFactCheckLink && 'https://example.com/this-is-a/very-long-url/that-could-break-some-layout/if-we-let-it/this-is-a/very-long-url/that-could-break-some-layout/if-we-let-it'}
               factCheckCount={listItemFactCheckCount}
               channels={listItemRequests && { main: 8, others: [5, 8, 7, 6, 9, 10, 13] }}
               rating={listItemFactCheck ? 'False' : null}
               ratingColor={listItemFactCheck ? '#f00' : null}
               onCheckboxChange={!listItemShared ? () => {} : null}
             />
+            <br />
             <ClusterCard
               title="Title of a Workspace Item Card Item"
               date={new Date('2023-12-15T17:19:40Z')}

--- a/src/app/components/Sandbox.js
+++ b/src/app/components/Sandbox.js
@@ -446,7 +446,7 @@ const SandboxComponent = ({ admin }) => {
               languageCode="en"
               tags={['Novel', 'Moby Dick', '19th Century']}
               onChangeTags={() => {}}
-              url="https://example.com"
+              url="https://example.com/this-is-a/very-long-url/that-could-break-some-layout/if-we-let-it/this-is-a/very-long-url/that-could-break-some-layout/if-we-let-it"
               variant={articleCardVariant}
             />
           </div>

--- a/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.js
+++ b/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.js
@@ -47,7 +47,7 @@ const ButtonMain = ({
         {iconLeft}
       </div>
     )}
-    <span className={`test-label__button ${styles.buttonMainLabel}`}>
+    <span className={cx('test-label__button', styles.buttonMainLabel)}>
       {label}
     </span>
     { iconCenter && (

--- a/src/app/components/cds/media-cards/ArticleUrl.js
+++ b/src/app/components/cds/media-cards/ArticleUrl.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames/bind';
 import FactCheckIcon from '../../../icons/fact_check.svg';
 import BookIcon from '../../../icons/book.svg';
 import styles from './Card.module.css';
@@ -16,11 +17,9 @@ const ArticleUrl = ({
   if (!url) return null;
 
   return (
-    <span className={`article-url ${styles.articleLink}`}>
+    <span className={cx('article-url', styles.articleLink)}>
       { icons[variant] }
-      <span>
-        <a href={url} target="_blank" rel="noreferrer noopener">{url}</a>
-      </span>
+      <a href={url} target="_blank" rel="noreferrer noopener" title={url}>{url}</a>
     </span>
   );
 };

--- a/src/app/components/cds/media-cards/Card.module.css
+++ b/src/app/components/cds/media-cards/Card.module.css
@@ -45,6 +45,21 @@
     white-space: nowrap;
     width: 100%;
 
+    .cardTitle {
+      -webkit-box-orient: vertical;
+      display: -webkit-box; /* stylelint-disable-line */
+      margin: 0;
+      white-space: normal;
+    }
+
+    .cardDescription {
+      -webkit-box-orient: vertical;
+      color: var(--color-gray-37);
+      display: -webkit-box; /* stylelint-disable-line */
+      font-size: var(--font-size-body-2);
+      white-space: pre-line;
+    }
+
     .cardSummaryContent {
       flex: 1 1 auto;
       overflow: hidden;
@@ -84,32 +99,19 @@
         color: var(--color-blue-54);
       }
     }
-  }
 
-  .cardTitle {
-    -webkit-box-orient: vertical;
-    display: -webkit-box; /* stylelint-disable-line */
-    margin: 0;
-    white-space: normal;
-  }
+    &.cardSummaryCollapsed {
+      .cardTitle {
+        -webkit-line-clamp: 1;
+        overflow: hidden;
+        white-space: normal;
+      }
 
-  .cardTitleCollapse {
-    -webkit-line-clamp: 1;
-    overflow: hidden;
-    white-space: normal;
-  }
-
-  .cardDescription {
-    -webkit-box-orient: vertical;
-    color: var(--color-gray-37);
-    display: -webkit-box; /* stylelint-disable-line */
-    font-size: var(--font-size-body-2);
-    white-space: pre-line;
-  }
-
-  .cardDescriptionCollapse {
-    -webkit-line-clamp: 2;
-    overflow: hidden;
+      .cardDescription {
+        -webkit-line-clamp: 2;
+        overflow: hidden;
+      }
+    }
   }
 
   .cardTag {

--- a/src/app/components/cds/media-cards/Card.module.css
+++ b/src/app/components/cds/media-cards/Card.module.css
@@ -100,6 +100,12 @@
       }
     }
 
+    &.hideCollapse {
+      .toggleCollapse {
+        display: none;
+      }
+    }
+
     &.cardSummaryCollapsed {
       .cardTitle {
         -webkit-line-clamp: 1;

--- a/src/app/components/cds/media-cards/Card.module.css
+++ b/src/app/components/cds/media-cards/Card.module.css
@@ -133,6 +133,7 @@
   .cardChannels {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: 3px;
 
     span {

--- a/src/app/components/cds/media-cards/Card.module.css
+++ b/src/app/components/cds/media-cards/Card.module.css
@@ -1,44 +1,13 @@
-.toggleCollapse {
-  align-items: center;
-  background-color: var(--color-blue-98);
-  border: 0 solid var(--color-gray-88);
-  border-radius: 8px;
-  color: var(--color-gray-37);
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  height: 28px;
-  justify-content: center;
-  margin-top: 8px;
-  padding: 2px;
-  width: 28px;
-
-  svg {
-    font-size: var(--iconSizeSmall);
-    margin: 0;
-    vertical-align: middle;
-  }
-
-  &:hover {
-    background-color: var(--color-blue-98);
-    color: var(--color-blue-54);
-  }
-}
-
 .articleLink {
   align-items: center;
   color: var(--color-blue-32);
   display: flex;
   font-size: var(--font-size-body-2);
   gap: 3px;
-
-  div {
-    display: grid;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  margin: 3px 0;
 
   svg {
+    flex: 0 0 var(--iconSizeTiny);
     font-size: var(--iconSizeTiny);
   }
 
@@ -64,20 +33,56 @@
   .cardContent {
     align-items: flex-start;
     display: flex;
-    flex-wrap: wrap;
     gap: 0 16px;
-    justify-content: space-between;
   }
 
   .cardSummary {
     display: flex;
+    flex-direction: row;
     gap: 6px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    width: 100%;
 
-    p {
-      margin: 0;
+    .cardSummaryContent {
+      flex: 1 1 auto;
+      overflow: hidden;
+    }
+
+    .toggleCollapse {
+      align-items: center;
+      background-color: var(--color-blue-98);
+      border: 0 solid var(--color-gray-88);
+      border-radius: 8px;
+      color: var(--color-gray-37);
+      cursor: pointer;
+      display: flex;
+      flex: 0 0 30px;
+      flex-direction: column;
+      height: 30px;
+      justify-content: center;
+      margin-top: 8px;
+      padding: 2px;
+      width: 30px;
+
+      :global(.check-icon) {
+        font-size: var(--iconSizeSmall);
+        margin: 0;
+        vertical-align: middle;
+      }
+
+      &.toggleCollapseVisible {
+        visibility: visible;
+      }
+
+      &.toggleCollapseHidden {
+        visibility: hidden;
+      }
+
+      &:hover {
+        color: var(--color-blue-54);
+      }
     }
   }
 
@@ -98,6 +103,7 @@
     -webkit-box-orient: vertical;
     color: var(--color-gray-37);
     display: -webkit-box; /* stylelint-disable-line */
+    font-size: var(--font-size-body-2);
     white-space: pre-line;
   }
 
@@ -109,13 +115,6 @@
   .cardTag {
     display: flex;
     justify-content: flex-end;
-  }
-
-  .cardTagLabel {
-    align-items: center;
-    display: flex;
-    font-weight: 400;
-    gap: 4px;
   }
 
   .cardTagIcon {

--- a/src/app/components/cds/media-cards/ItemDescription.js
+++ b/src/app/components/cds/media-cards/ItemDescription.js
@@ -53,6 +53,7 @@ const ItemDescription = ({
         {
           [className]: true,
           [styles.cardSummaryCollapsed]: isCollapsed,
+          [styles.hideCollapse]: !isTextOverflowing,
         })
       }
     >

--- a/src/app/components/cds/media-cards/ItemDescription.js
+++ b/src/app/components/cds/media-cards/ItemDescription.js
@@ -48,22 +48,30 @@ const ItemDescription = ({
 
   return (
     <div className={cx(styles.cardSummary, className)}>
-      <div>
+      <div className={styles.cardSummaryContent}>
         <h6 className={`typography-button ${styles.cardTitle} ${isCollapsed ? styles.cardTitleCollapse : ''}`}>{title}</h6>
         { description ?
-          <p className="typography-body2">
+          <>
             <span className={`description-text ${styles.cardDescription} ${isCollapsed ? styles.cardDescriptionCollapse : ''}`} ref={descriptionRef}>
               {description}
             </span>
             <ArticleUrl url={url} variant={variant} />
-          </p>
+          </>
           : null }
       </div>
-      <div style={{ visibility: shouldShowButton ? 'visible' : 'hidden' }}>
-        <button type="button" onClick={toggleCollapse} className={`${styles.toggleCollapse}`}>
-          { isCollapsed ? <UnfoldMoreIcon /> : <UnfoldLessIcon /> }
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={toggleCollapse}
+        className={cx(
+          [styles.toggleCollapse],
+          {
+            [[styles.toggleCollapseVisible]]: shouldShowButton,
+            [[styles.toggleCollapseHidden]]: !shouldShowButton,
+          })
+        }
+      >
+        { isCollapsed ? <UnfoldMoreIcon /> : <UnfoldLessIcon /> }
+      </button>
     </div>
   );
 };

--- a/src/app/components/cds/media-cards/ItemDescription.js
+++ b/src/app/components/cds/media-cards/ItemDescription.js
@@ -47,12 +47,20 @@ const ItemDescription = ({
   }, [description]);
 
   return (
-    <div className={cx(styles.cardSummary, className)}>
+    <div
+      className={cx(
+        [styles.cardSummary],
+        {
+          [className]: true,
+          [styles.cardSummaryCollapsed]: isCollapsed,
+        })
+      }
+    >
       <div className={styles.cardSummaryContent}>
-        <h6 className={`typography-button ${styles.cardTitle} ${isCollapsed ? styles.cardTitleCollapse : ''}`}>{title}</h6>
+        <h6 className={cx('typography-button', styles.cardTitle)}>{title}</h6>
         { description ?
           <>
-            <span className={`description-text ${styles.cardDescription} ${isCollapsed ? styles.cardDescriptionCollapse : ''}`} ref={descriptionRef}>
+            <span className={cx('description-text', styles.cardDescription)} ref={descriptionRef}>
               {description}
             </span>
             <ArticleUrl url={url} variant={variant} />

--- a/src/app/components/cds/media-cards/ItemRating.js
+++ b/src/app/components/cds/media-cards/ItemRating.js
@@ -18,7 +18,8 @@ const ItemRating = ({
       variant="outlined"
       size={size}
       theme="text"
-      label={<span className={styles.cardTagLabel}><EllipseIcon className={styles.cardTagIcon} style={{ color: ratingColor }} />{rating}</span>}
+      iconLeft={<EllipseIcon style={{ color: ratingColor }} />}
+      label={rating}
       customStyle={{
         borderColor: ratingColor,
         color: 'var(--color-gray-15)',

--- a/src/app/components/cds/media-cards/ItemReportStatus.js
+++ b/src/app/components/cds/media-cards/ItemReportStatus.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
+import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
+import FactCheckIcon from '../../../icons/fact_check.svg';
+
+const ItemReportStatus = ({ publishedAt, className }) => {
+  const formatTooltip = () => {
+    const label = (publishedAt ? (
+      <FormattedMessage
+        id="itemReportStatus.tooltipPublished"
+        description="Tooltip of a report status icon when the report is published"
+        defaultMessage="Published Fact-Check"
+      />
+    ) : (
+      <FormattedMessage
+        id="itemReportStatus.tooltipUnpublished"
+        description="Tooltip of a report status icon when the report is not published"
+        defaultMessage="Unpublished Fact-Check"
+      />
+    ));
+
+    return (
+      <>
+        <span>{label}</span>
+        { publishedAt && (
+          <ul>
+            <li>{Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' }).format(publishedAt)}</li>
+          </ul>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <Tooltip
+      arrow
+      title={formatTooltip()}
+      placement="top"
+    >
+      <div className={className}>
+        <ButtonMain
+          disabled
+          buttonProps={{
+            type: null,
+          }}
+          variant="contained"
+          size="small"
+          theme="text"
+          iconCenter={<FactCheckIcon />}
+          customStyle={{
+            color: (publishedAt ? 'var(--color-green-35)' : 'var(--color-gray-59)'),
+          }}
+        />
+      </div>
+    </Tooltip>
+  );
+};
+
+ItemReportStatus.defaultProps = {
+  className: null,
+  publishedAt: null,
+};
+
+ItemReportStatus.propTypes = {
+  className: PropTypes.string,
+  publishedAt: PropTypes.instanceOf(Date), // Timestamp
+};
+
+export default ItemReportStatus;

--- a/src/app/components/cds/media-cards/MediaCount.js
+++ b/src/app/components/cds/media-cards/MediaCount.js
@@ -30,7 +30,7 @@ const MediaCount = ({
             disabled
             size="small"
             theme="lightBeige"
-            iconLeft={mediaCount === 1 && mediaType ? <MediaTypeDisplayIcon mediaType={mediaType} /> : <MediaIcon />}
+            iconLeft={mediaCount === 1 && mediaType ? <MediaTypeDisplayIcon mediaType={mediaType} fontSize="unset" color="unset" /> : <MediaIcon />}
             variant="contained"
             label={getCompactNumber(intl.locale, mediaCount)}
             buttonProps={{

--- a/src/app/components/search/SearchResultsCards/ArticleCard.js
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.js
@@ -47,17 +47,15 @@ const ArticleCard = ({
             </Tooltip>
           </div>
         ) : null }
-        <div>
-          <SharedItemCardFooter
-            languageCode={languageCode}
-            tags={tags}
-            onChangeTags={onChangeTags}
-          />
-        </div>
+        <SharedItemCardFooter
+          languageCode={languageCode}
+          tags={tags}
+          onChangeTags={onChangeTags}
+        />
       </div>
       { (statusLabel || date) ?
         <div className={styles.cardRight}>
-          { statusLabel ? <ItemRating rating={statusLabel} ratingColor={statusColor} /> : null }
+          { statusLabel ? <ItemRating rating={statusLabel} ratingColor={statusColor} size="small" /> : null }
           { date ?
             <ItemDate
               date={new Date(date * 1000)}

--- a/src/app/components/search/SearchResultsCards/ArticleCard.js
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import cx from 'classnames/bind';
 import Card, { CardHoverContext } from '../../cds/media-cards/Card';
 import TeamAvatar from '../../team/TeamAvatar';
 import ItemDate from '../../cds/media-cards/ItemDate';
@@ -24,7 +25,7 @@ const ArticleCard = ({
   onChangeTags,
   variant,
 }) => (
-  <div className={`${styles.articleCard} article-card`}>
+  <div className={cx('article-card', styles.articleCard)}>
     <Card>
       <div className={styles.articleCardDescription}>
         <CardHoverContext.Consumer>

--- a/src/app/components/search/SearchResultsCards/ArticleCard.js
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.js
@@ -8,6 +8,7 @@ import ItemDate from '../../cds/media-cards/ItemDate';
 import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 import ItemRating from '../../cds/media-cards/ItemRating';
 import ItemDescription from '../../cds/media-cards/ItemDescription';
+import ItemReportStatus from '../../cds/media-cards/ItemReportStatus';
 import SharedItemCardFooter from './SharedItemCardFooter';
 import styles from './ArticleCard.module.css';
 
@@ -22,6 +23,7 @@ const ArticleCard = ({
   teamName,
   languageCode,
   tags,
+  publishedAt,
   onChangeTags,
   variant,
 }) => (
@@ -54,14 +56,17 @@ const ArticleCard = ({
           onChangeTags={onChangeTags}
         />
       </div>
-      { (statusLabel || date) ?
+      { (statusLabel || date || variant === 'fact-check') ?
         <div className={styles.cardRight}>
-          { statusLabel ? <ItemRating rating={statusLabel} ratingColor={statusColor} size="small" /> : null }
-          { date ?
+          <div className={styles.cardRightTop}>
+            { statusLabel && <ItemRating className={styles.cardRightTopRating} rating={statusLabel} ratingColor={statusColor} size="small" /> }
+            { variant === 'fact-check' && <ItemReportStatus className={styles.cardRightTopPublished} publishedAt={publishedAt ? new Date(publishedAt * 1000) : null} /> }
+          </div>
+          { date &&
             <ItemDate
               date={new Date(date * 1000)}
               tooltipLabel={<FormattedMessage id="factCheckCard.dateLabel" defaultMessage="Published at" description="Date tooltip label for fact-check cards" />}
-            /> : null
+            />
           }
         </div> : null
       }
@@ -78,6 +83,8 @@ ArticleCard.defaultProps = {
   languageCode: null,
   tags: [],
   variant: 'explainer',
+  statusLabel: null,
+  publishedAt: null,
 };
 
 ArticleCard.propTypes = {
@@ -85,12 +92,13 @@ ArticleCard.propTypes = {
   summary: PropTypes.string,
   url: PropTypes.string,
   date: PropTypes.number.isRequired, // Timestamp
-  statusLabel: PropTypes.string.isRequired,
+  statusLabel: PropTypes.string,
   statusColor: PropTypes.string,
   teamAvatar: PropTypes.string, // URL
   teamName: PropTypes.string,
   languageCode: PropTypes.string,
   tags: PropTypes.arrayOf(PropTypes.string),
+  publishedAt: PropTypes.number, // Timestamp
   onChangeTags: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['explainer', 'fact-check']),
 };

--- a/src/app/components/search/SearchResultsCards/ArticleCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.module.css
@@ -8,6 +8,7 @@
     flex: 1 1 auto;
     flex-direction: column;
     gap: 6px;
+    overflow: hidden;
   }
 
   .cardRight {

--- a/src/app/components/search/SearchResultsCards/ArticleCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.module.css
@@ -18,12 +18,23 @@
     text-align: right;
     width: 150px;
 
-    > div {
-      width: 100%;
+    .cardRightTop {
+      display: flex;
+      gap: 3px;
+      justify-content: flex-end;
+      width: 150px;
 
-      button,
-      button span {
-        max-width: 100%;
+      .cardRightTopRating {
+        width: calc(100% - 33px);
+
+        button,
+        button span {
+          max-width: 100%;
+        }
+      }
+
+      .cardRightTopPublished {
+        flex: 0 0 30px;
       }
     }
   }

--- a/src/app/components/search/SearchResultsCards/ArticleCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.module.css
@@ -1,5 +1,6 @@
 .articleCard {
   display: block;
+  min-width: 500px;
 
   .articleCardDescription {
     align-items: flex-start;

--- a/src/app/components/search/SearchResultsCards/ArticleCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.module.css
@@ -4,13 +4,26 @@
   .articleCardDescription {
     align-items: flex-start;
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
     gap: 6px;
-    width: calc(100% - 170px);
   }
 
   .cardRight {
-    min-width: 150px;
+    align-items: end;
+    display: flex;
+    flex: 0 0 150px;
+    flex-direction: column;
     text-align: right;
+    width: 150px;
+
+    > div {
+      width: 100%;
+
+      button,
+      button span {
+        max-width: 100%;
+      }
+    }
   }
 }

--- a/src/app/components/search/SearchResultsCards/ClusterCard.js
+++ b/src/app/components/search/SearchResultsCards/ClusterCard.js
@@ -51,11 +51,11 @@ const ClusterCard = ({
         className={cx({ [styles.listItemUnread]: isUnread })}
         cardUrl={cardUrl}
       >
-        { onCheckboxChange && (
-          <div className={styles.checkbox}>
-            <Checkbox checked={isChecked} onChange={onCheckboxChange} />
-          </div>)}
         <div className={styles.clusterCardLeft}>
+          { onCheckboxChange && (
+            <div className={styles.checkbox}>
+              <Checkbox checked={isChecked} onChange={onCheckboxChange} />
+            </div>)}
           <ItemThumbnail
             picture={mediaThumbnail?.media?.picture}
             maskContent={mediaThumbnail?.show_warning_cover}

--- a/src/app/components/search/SearchResultsCards/ItemCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ItemCard.module.css
@@ -20,18 +20,37 @@
   .clusterCardLeft {
     align-self: center;
     display: flex;
-    flex-wrap: wrap;
-    gap: 0 16px;
-    grid-gap: 0 16px;
+    flex: 0 0 auto;
+    gap: 0 8px;
     justify-content: space-between;
   }
 
   .sharedItemCardMiddle {
     align-items: flex-start;
     display: flex;
-    flex: 1 0 0;
+    flex: 1 1 auto;
     flex-direction: column;
     gap: 6px;
+    overflow: hidden;
+  }
+
+  .clusterCardRight {
+    align-items: end;
+    background: var(--color-blue-90);
+    display: flex;
+    flex: 0 0 150px;
+    flex-direction: column;
+    text-align: right;
+    width: 150px;
+
+    > div {
+      width: 100%;
+
+      button,
+      button span {
+        max-width: 100%;
+      }
+    }
   }
 
   .bulletSeparator > div {

--- a/src/app/components/search/SearchResultsCards/ItemCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ItemCard.module.css
@@ -1,5 +1,6 @@
 .itemCard {
   background-color: transparent;
+  min-width: 500px;
   position: relative;
 
   .listItemUnread {

--- a/src/app/components/search/SearchResultsCards/ItemCard.module.css
+++ b/src/app/components/search/SearchResultsCards/ItemCard.module.css
@@ -36,7 +36,6 @@
 
   .clusterCardRight {
     align-items: end;
-    background: var(--color-blue-90);
     display: flex;
     flex: 0 0 150px;
     flex-direction: column;

--- a/src/app/components/search/SearchResultsCards/index.js
+++ b/src/app/components/search/SearchResultsCards/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames/bind';
 import ArticleCard from './ArticleCard';
 import styles from './SearchResultsCards.module.css';
 
 const SearchResultsCards = ({ projectMedias, team }) => (
-  <div className={`${styles.searchResultsCards} search-results-cards`}>
+  <div className={cx('search-results-cards', styles.searchResultsCards)}>
     { projectMedias.map((projectMedia) => {
       const values = projectMedia.feed_columns_values;
       const status = team.verification_statuses.statuses.find(s => s.id === values.status) || {};

--- a/src/app/components/search/SearchResultsTable/ItemThumbnail.js
+++ b/src/app/components/search/SearchResultsTable/ItemThumbnail.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames/bind';
 import VisibilityOffIcon from '../../../icons/visibility_off.svg';
 import EmptyMediaIcon from '../../../icons/empty_media.svg';
 import styles from './ItemThumbnail.module.css';
@@ -12,8 +13,8 @@ const ItemThumbnail = ({
 }) => {
   if (!type && !picture) {
     return (
-      <div className={`${styles.thumbnail} ${styles.container} ${styles.emptyMedia}`}>
-        <div className={`${styles.iconContainer}`}>
+      <div className={cx(styles.thumbnail, styles.container, styles.emptyMedia)}>
+        <div className={styles.iconContainer}>
           <EmptyMediaIcon />
         </div>
       </div>
@@ -35,7 +36,7 @@ const ItemThumbnail = ({
             />
           }
         >
-          <div className={`${styles.thumbnail} ${styles.container}`}>
+          <div className={cx(styles.thumbnail, styles.container)}>
             <div className={styles.iconContainer}>
               <img
                 className={styles.thumbnail}
@@ -60,7 +61,7 @@ const ItemThumbnail = ({
           />
         }
       >
-        <div className={`${styles.thumbnail} ${styles.container}`}>
+        <div className={cx(styles.thumbnail, styles.container)}>
           <div className={styles.iconContainer}>
             <MediaTypeDisplayIcon mediaType={mediaType} className={styles.mediaIcon} fontSize="var(--iconSizeDefault)" />
           </div>
@@ -69,8 +70,8 @@ const ItemThumbnail = ({
     );
   }
   return (
-    <div className={`${styles.thumbnail} ${styles.container} ${styles.contentScreen}`}>
-      <div className={`${styles.iconContainer}`}>
+    <div className={cx(styles.thumbnail, styles.container, styles.contentScreen)}>
+      <div className={styles.iconContainer}>
         <VisibilityOffIcon className={styles.visibilityOffIcon} />
       </div>
     </div>


### PR DESCRIPTION
## Description

- A long URL was not being treated very well on the cards allowing the content to push off screen, this PR addresses that by improving the truncating
- Makes some things more consistent across card types
- simplifies some css settings
- add ItemReportStatus.js from other epic PR and use in article card in sandbox

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

sandbox

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
