### PR TITLE
Bug fix: Make sure that sorting parameters for the "Unmatched Media" list can be overwritten.

### DIFF
--- a/src/app/components/team/UnmatchedMedia.js
+++ b/src/app/components/team/UnmatchedMedia.js
@@ -10,14 +10,14 @@ const defaultFilters = {
 };
 
 const UnmatchedMedia = ({ routeParams }) => {
-  const defaultQuery = {
-    ...defaultFilters,
+  const defaultSort = {
     sort: 'recent_activity',
     sort_type: 'DESC',
   };
   const query = {
+    ...defaultSort,
     ...safelyParseJSON(routeParams.query, {}),
-    ...defaultQuery,
+    ...defaultFilters,
   };
 
   return (
@@ -28,7 +28,7 @@ const UnmatchedMedia = ({ routeParams }) => {
       icon={<UnmatchedIcon />}
       teamSlug={routeParams.team}
       query={query}
-      defaultQuery={defaultQuery}
+      defaultQuery={{ ...defaultFilters, ...defaultSort }}
       hideFields={['feed_fact_checked_by', 'cluster_teams', 'cluster_published_reports']}
       readOnlyFields={['unmatched']}
       page="unmatched-media"


### PR DESCRIPTION
## Description

Bug fix: Make sure that sorting parameters for the "Unmatched Media" list can be overwritten.

Fixes CV2-4727.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

![CV2-4727](https://github.com/meedan/check-web/assets/117518/0ae79938-abb3-4772-9dcb-c3c8c3e0f186)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)


[CV2-4727]: https://meedan.atlassian.net/browse/CV2-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ