### PR TITLE
Article cards tag picker should list workspace tags

### DIFF
--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -31,6 +31,7 @@ const ArticlesComponent = ({
   filters,
   onChangeSearchParams,
   statuses,
+  teamTags,
   articles,
   articlesCount,
   updateMutation,
@@ -160,6 +161,7 @@ const ArticlesComponent = ({
                 languageCode={article.language !== 'und' ? article.language : null}
                 date={article.updated_at}
                 tags={article.tags}
+                tagOptions={teamTags}
                 statusColor={currentStatus ? currentStatus.style?.color : null}
                 statusLabel={currentStatus ? currentStatus.label : null}
                 publishedAt={article.claim_description?.project_media?.report_status === 'published' && article.claim_description?.project_media?.published ? parseInt(article.claim_description?.project_media?.published, 10) : null}
@@ -183,6 +185,7 @@ ArticlesComponent.defaultProps = {
   filterOptions: [],
   filters: {},
   statuses: {},
+  teamTags: null,
   articles: [],
   articlesCount: 0,
 };
@@ -204,6 +207,7 @@ ArticlesComponent.propTypes = {
     label: PropTypes.string.isRequired, // Localizable string
   })),
   statuses: PropTypes.object,
+  teamTags: PropTypes.arrayOf(PropTypes.string),
   articlesCount: PropTypes.number,
   articles: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
@@ -277,6 +281,13 @@ const Articles = ({
           ) {
             team(slug: $slug) {
               verification_statuses
+              tag_texts(last: 50) {
+                edges {
+                  node {
+                    text
+                  }
+                }
+              }
               articles_count(article_type: $type, user_ids: $users, tags: $tags, updated_at: $updatedAt, language: $language)
               articles(
                 first: $pageSize, article_type: $type, offset: $offset, sort: $sort, sort_type: $sortType,
@@ -342,6 +353,7 @@ const Articles = ({
                 articles={props.team.articles.edges.map(edge => edge.node)}
                 articlesCount={props.team.articles_count}
                 statuses={props.team.verification_statuses}
+                teamTags={props.team.tag_texts.edges.length > 0 ? props.team.tag_texts.edges.map(tag => tag.node.text) : null}
                 onChangeSearchParams={handleChangeSearchParams}
                 updateMutation={updateMutation}
               />

--- a/src/app/components/cds/menus-lists-dialogs/TagList.js
+++ b/src/app/components/cds/menus-lists-dialogs/TagList.js
@@ -52,7 +52,7 @@ const TagList = ({
 
   // MultiSelector requires an options array of objects with label and tag
   const options = teamTags || tags.map(tag => ({ label: tag, value: tag }));
-  const selected = tags;
+  const selected = [...tags];
 
   const handleAddNew = (value) => {
     if (value.trim() === '') {

--- a/src/app/components/search/SearchResultsCards/ArticleCard.js
+++ b/src/app/components/search/SearchResultsCards/ArticleCard.js
@@ -22,6 +22,7 @@ const ArticleCard = ({
   teamName,
   languageCode,
   tags,
+  tagOptions,
   publishedAt,
   onChangeTags,
   variant,
@@ -53,6 +54,7 @@ const ArticleCard = ({
           <SharedItemCardFooter
             languageCode={languageCode}
             tags={tags}
+            tagOptions={tagOptions}
             onChangeTags={onChangeTags}
           />
         </div>
@@ -83,6 +85,7 @@ ArticleCard.defaultProps = {
   teamName: null,
   languageCode: null,
   tags: [],
+  tagOptions: null,
   variant: 'explainer',
   statusLabel: null,
   publishedAt: null,
@@ -99,6 +102,7 @@ ArticleCard.propTypes = {
   teamName: PropTypes.string,
   languageCode: PropTypes.string,
   tags: PropTypes.arrayOf(PropTypes.string),
+  tagOptions: PropTypes.arrayOf(PropTypes.string),
   publishedAt: PropTypes.number, // Timestamp
   onChangeTags: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['explainer', 'fact-check']),

--- a/src/app/components/search/SearchResultsCards/SharedItemCardFooter.js
+++ b/src/app/components/search/SearchResultsCards/SharedItemCardFooter.js
@@ -21,6 +21,7 @@ const SharedItemCardFooter = ({
   languageCode,
   lastRequestDate,
   tags,
+  tagOptions,
   onChangeTags,
   channels,
   onSeeMore,
@@ -32,7 +33,7 @@ const SharedItemCardFooter = ({
       languageCode && (
         <Language languageCode={languageCode} />
       ),
-      tags && onChangeTags && <TagList tags={tags} setTags={onChangeTags} />,
+      tags && onChangeTags && <TagList tags={tags} setTags={onChangeTags} options={tagOptions ? tagOptions.map(tag => ({ label: tag, value: tag })) : null} />,
       mediaCount !== null && (
         <MediaCount
           mediaCount={mediaCount}
@@ -76,6 +77,7 @@ SharedItemCardFooter.defaultProps = {
   languageCode: null,
   lastRequestDate: null,
   tags: null,
+  tagOptions: null,
   onChangeTags: null,
   channels: null,
   onSeeMore: null,
@@ -89,6 +91,7 @@ SharedItemCardFooter.propTypes = {
   languageCode: PropTypes.string,
   lastRequestDate: PropTypes.instanceOf(Date),
   tags: PropTypes.arrayOf(PropTypes.string),
+  tagOptions: PropTypes.arrayOf(PropTypes.string),
   onChangeTags: PropTypes.func,
   channels: PropTypes.exact({
     main: PropTypes.number,


### PR DESCRIPTION
## Description

The tag pickers in the article cards (explainers and fact-checks) in their respective list views now display the tags from the workspace. These tag pickers were empty.

Fixes CV2-4734.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. Make sure your workspace has some tags. Open the articles lists. The tag pickers in the cards should list the workspace tags as options.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
