### PR TITLE
Fix item history crash when multiselect annotation response field val…

### DIFF
--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -4,22 +4,18 @@ import { defineMessages, FormattedMessage, FormattedHTMLMessage, injectIntl, int
 import config from 'config'; // eslint-disable-line require-path-exists/exists
 import { Link } from 'react-router';
 import cx from 'classnames/bind';
-import { withSetFlashMessage } from '../FlashMessage';
-import { FormattedGlobalMessage } from '../MappedMessage';
 import ParsedText from '../ParsedText';
 import TimeBefore from '../TimeBefore';
 import ProfileLink from '../layout/ProfileLink';
 import DatetimeTaskResponse from '../task/DatetimeTaskResponse';
 import { languageLabel } from '../../LanguageRegistry';
 import {
-  getErrorMessage,
   getStatus,
   getStatusStyle,
   emojify,
   parseStringUnixTimestamp,
   safelyParseJSON,
 } from '../../helpers';
-import { stringHelper } from '../../customHelpers';
 import CheckArchivedFlags from '../../CheckArchivedFlags';
 import styles from './Annotation.module.css';
 
@@ -44,22 +40,9 @@ const messages = defineMessages({
 // TODO Fix a11y issues
 /* eslint jsx-a11y/click-events-have-key-events: 0 */
 class Annotation extends Component {
-  fail = (transaction) => {
-    const message = getErrorMessage(
-      transaction,
-      (
-        <FormattedGlobalMessage
-          messageKey="unknownError"
-          values={{ supportEmail: stringHelper('SUPPORT_EMAIL') }}
-        />
-      ),
-    );
-    this.props.setFlashMessage(message, 'error');
-  };
-
   static renderTaskResponse(type, object) {
     if (type === 'multiple_choice') {
-      const response = JSON.parse(object.value);
+      const response = safelyParseJSON(object.value, {});
       const selected = response.selected || [];
       if (response.other) {
         selected.push(response.other);
@@ -742,10 +725,11 @@ class Annotation extends Component {
 }
 
 Annotation.propTypes = {
-  // https://github.com/yannickcr/eslint-plugin-react/issues/1389
-  // eslint-disable-next-line react/no-typos
-  setFlashMessage: PropTypes.func.isRequired,
+  annotation: PropTypes.object.isRequired, // FIXME: specify shape
+  team: PropTypes.shape({
+    verification_statuses: PropTypes.object,
+  }).isRequired,
   intl: intlShape.isRequired,
 };
 
-export default withSetFlashMessage(injectIntl(Annotation));
+export default injectIntl(Annotation);

--- a/src/app/components/annotations/Annotation.test.js
+++ b/src/app/components/annotations/Annotation.test.js
@@ -30,17 +30,37 @@ const annotation = {
   },
 };
 
+const annotationMultiSelect = {
+  ...annotation,
+  task: {
+    type: 'multiple_choice',
+    fieldset: 'metadata',
+  },
+  event_type: 'create_dynamicannotationfield',
+  object_after: '{"id":123456,"annotation_id":2923453,"field_name":"response_multiple_choice","annotation_type":"task_response_multiple_choice","field_type":"select","value":""}',
+};
+
 describe('<Annotation />', () => {
   it('Renders report edited event', () => {
     const wrapper = mountWithIntl((
       <Annotation
-        annotated={{}}
-        annotatedType="ProjectMedia"
         annotation={annotation}
         team={{}}
       />
     ));
     expect(wrapper.find('.annotation__default').hostNodes()).toHaveLength(1);
     expect(wrapper.find('.test-annotation__default-content').hostNodes().html()).toMatch('Fact-check report edited by');
+  });
+
+  it('Should not crash when rendering malformed multi select annotation response', () => {
+    const wrapper = mountWithIntl((
+      <Annotation
+        annotation={annotationMultiSelect}
+        team={{}}
+      />
+    ));
+
+    expect(wrapper.find('.annotation__metadata-filled').hostNodes()).toHaveLength(1);
+    expect(wrapper.find('.annotation__metadata-filled').hostNodes().html()).toMatch('edited by');
   });
 });


### PR DESCRIPTION
## Description

Fix item history crash when multiselect annotation response field value is an invalid json. Also some cleanup of dead code.

References: CV2-4772

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

TDD'd it with witnesses during Check-web audit call

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
