### PR TITLE
Make sure that weekdays displayed in newsletter scheduler are the same regardless the current user timezone

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -19,6 +19,17 @@ import settingsStyles from '../Settings.module.css';
 
 const timezones = getTimeZoneOptions();
 
+const getWeekDays = (locale) => {
+  const weekDays = {};
+  const { format } = new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' });
+  weekDays.labels = [...Array(7).keys()].map(day => format(new Date(`2021-08-0${day + 1}T00:00:00Z`)));
+  weekDays.values = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  return weekDays;
+};
+
+// eslint-disable-next-line import/no-unused-modules
+export { getWeekDays }; // For unit test
+
 const NewsletterScheduler = ({
   type,
   timezone,
@@ -36,9 +47,9 @@ const NewsletterScheduler = ({
   disabled,
   intl,
 }) => {
-  const { format } = new Intl.DateTimeFormat(intl.locale, { weekday: 'short' });
-  const weekDaysLabels = [...Array(7).keys()].map(day => format(new Date(Date.UTC(2021, 5, day))));
-  const weekDaysValues = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const weekDays = getWeekDays(intl.locale);
+  const weekDaysLabels = weekDays.labels;
+  const weekDaysValues = weekDays.values;
 
   return (
     <div className={`${styles['newsletter-scheduler']} ${scheduled ? styles['newsletter-scheduled'] : styles['newsletter-paused']}`}>

--- a/src/app/components/team/Newsletter/NewsletterScheduler.test.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.test.js
@@ -1,0 +1,20 @@
+import { getWeekDays } from './NewsletterScheduler';
+
+describe('<NewsletterScheduler />', () => {
+  it('returns localized week day', () => {
+    const firstDayOfWeek = getWeekDays('pt-BR').labels[0];
+    expect(firstDayOfWeek).toBe('dom.');
+  });
+
+  it('returns days of the week starting by Sunday for America timezone', () => {
+    process.env.TZ = 'America/New_York';
+    const firstDayOfWeek = getWeekDays('en-US').labels[0];
+    expect(firstDayOfWeek).toBe('Sun');
+  });
+
+  it('returns days of the week starting by Sunday for India timezone', () => {
+    process.env.TZ = 'Asia/Calcutta';
+    const firstDayOfWeek = getWeekDays('en-US').labels[0];
+    expect(firstDayOfWeek).toBe('Sun');
+  });
+});


### PR DESCRIPTION
## Description

Previously, the implementation was using `new Date(x, y, z)`, which takes into account the current user timezone. So, for a user browsing using timezone Asia/Calcutta, for example, the weekdays displayed in the newsletter scheduler started by Monday. For another timezone, for example America/New_York, the weekdays started by Sunday. The fix is to pass the UTC timezone to `new Date()`. This PR also includes unit tests that reproduce this issue.

Fixes: CV2-4845.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

TDD. Unit tests added.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
