### PR TITLE
Fixes 3 bugs for the articles lists pages

### DIFF
--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -13,6 +13,7 @@ import { getStatus } from '../../helpers';
 import MediasLoading from '../media/MediasLoading';
 import PageTitle from '../PageTitle';
 import ArticleFilters from './ArticleFilters';
+import searchStyles from '../search/search.module.css';
 import searchResultsStyles from '../search/SearchResults.module.css';
 
 const pageSize = 50;
@@ -106,24 +107,28 @@ const ArticlesComponent = ({
         </div>
       </div>
       <div className={searchResultsStyles['search-results-top']}>
-        <ArticleFilters
-          type={type}
-          teamSlug={team.slug}
-          filterOptions={filterOptions}
-          currentFilters={{ ...filters, article_type: type }}
-          statuses={statuses.statuses}
-          onSubmit={handleChangeFilters}
-        />
+        <div className={searchStyles['filters-wrapper']}>
+          <ListSort
+            sort={sort}
+            sortType={sortType}
+            options={sortOptions}
+            onChange={handleChangeSort}
+            className={searchStyles['filters-sorting']}
+          />
+          <ArticleFilters
+            type={type}
+            teamSlug={team.slug}
+            filterOptions={filterOptions}
+            currentFilters={{ ...filters, article_type: type }}
+            statuses={statuses.statuses}
+            onSubmit={handleChangeFilters}
+          />
+        </div>
       </div>
       <div className={searchResultsStyles['search-results-wrapper']}>
         { articles.length > 0 ?
           <div className={searchResultsStyles['search-results-toolbar']}>
-            <ListSort
-              sort={sort}
-              sortType={sortType}
-              options={sortOptions}
-              onChange={handleChangeSort}
-            />
+            <div />
             <Paginator
               page={page}
               pageSize={pageSize}

--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -11,13 +11,14 @@ import Paginator from '../cds/inputs/Paginator';
 import ListSort from '../cds/inputs/ListSort';
 import { getStatus } from '../../helpers';
 import MediasLoading from '../media/MediasLoading';
+import PageTitle from '../PageTitle';
 import ArticleFilters from './ArticleFilters';
 import searchResultsStyles from '../search/SearchResults.module.css';
 
 const pageSize = 50;
 
 const ArticlesComponent = ({
-  teamSlug,
+  team,
   type,
   title,
   icon,
@@ -90,7 +91,7 @@ const ArticlesComponent = ({
   };
 
   return (
-    <React.Fragment>
+    <PageTitle prefix={title} team={team}>
       <div className={searchResultsStyles['search-results-header']}>
         <div className={searchResultsStyles.searchResultsTitleWrapper}>
           <div className={searchResultsStyles.searchHeaderSubtitle}>
@@ -107,7 +108,7 @@ const ArticlesComponent = ({
       <div className={searchResultsStyles['search-results-top']}>
         <ArticleFilters
           type={type}
-          teamSlug={teamSlug}
+          teamSlug={team.slug}
           filterOptions={filterOptions}
           currentFilters={{ ...filters, article_type: type }}
           statuses={statuses.statuses}
@@ -174,7 +175,7 @@ const ArticlesComponent = ({
           })}
         </div>
       </div>
-    </React.Fragment>
+    </PageTitle>
   );
 };
 
@@ -199,7 +200,10 @@ ArticlesComponent.propTypes = {
   sort: PropTypes.oneOf(['title', 'language', 'updated_at']),
   sortType: PropTypes.oneOf(['ASC', 'DESC']),
   filters: PropTypes.object,
-  teamSlug: PropTypes.string.isRequired,
+  team: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
+  }).isRequired,
   onChangeSearchParams: PropTypes.func.isRequired,
   updateMutation: PropTypes.object.isRequired,
   filterOptions: PropTypes.arrayOf(PropTypes.string),
@@ -281,6 +285,8 @@ const Articles = ({
             $report_status: [String], $verification_status: [String],
           ) {
             team(slug: $slug) {
+              slug
+              name
               verification_statuses
               tag_texts(last: 50) {
                 edges {
@@ -353,7 +359,7 @@ const Articles = ({
                 sortType={sortType}
                 sortOptions={sortOptions}
                 filterOptions={filterOptions}
-                teamSlug={teamSlug}
+                team={{ name: props.team.name, slug: props.team.slug }}
                 filters={filters}
                 articles={props.team.articles.edges.map(edge => edge.node)}
                 articlesCount={props.team.articles_count}

--- a/src/app/components/article/Articles.test.js
+++ b/src/app/components/article/Articles.test.js
@@ -15,7 +15,7 @@ describe('<Articles />', () => {
   const articlesProps = {
     title: <span>Title</span>,
     icon: <div />,
-    teamSlug: 'test',
+    team: { slug: 'test', name: 'Test' },
     updateMutation: {},
     onChangeSearchParams: () => {},
   };

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -266,6 +266,7 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
     project_id
     last_seen
     demand
+    articles_count
     requests_count
     picture
     show_warning_cover

--- a/src/app/components/media/MediaComponentRightPanel.js
+++ b/src/app/components/media/MediaComponentRightPanel.js
@@ -36,11 +36,14 @@ const MediaComponentRightPanel = ({
         { showArticles && (
           <Tab
             label={
-              <FormattedMessage
-                id="mediaComponent.articles"
-                defaultMessage="Articles"
-                description="Label for the Articles tab"
-              />
+              <span>
+                <FormattedMessage
+                  id="mediaComponent.articles"
+                  defaultMessage="Articles"
+                  description="Label for the Articles tab"
+                />
+                {projectMedia.articles_count > 0 && ` [${projectMedia.articles_count}]`}
+              </span>
             }
             value="articles"
             className="media-tab__articles"


### PR DESCRIPTION
## Description

Fixes 3 bugs related to the articles lists pages:

- Adding page title
- Adding number of articles to the articles tab on the item page
- Moving sorting on articles lists pages to be inline with filters

References: CV2-4889, CV2-4888 and CV2-4886.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Existing unit tests were fixed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
