### PR TITLE
Moar articles review cleanup

### DIFF
--- a/localization/react-intl/src/app/components/article/ArticleForm.json
+++ b/localization/react-intl/src/app/components/article/ArticleForm.json
@@ -67,7 +67,7 @@
   {
     "id": "articleForm.noClaimDescript",
     "description": "Message overlay to tell the user they must complete additional fields to unlock this area",
-    "defaultMessage": "Start by adding Claim information for this Fact-Check"
+    "defaultMessage": "Start by adding Claim information<br />for this Fact-Check"
   },
   {
     "id": "mediaFactCheck.factCheck",

--- a/localization/react-intl/src/app/components/article/RemoveArticleButton.json
+++ b/localization/react-intl/src/app/components/article/RemoveArticleButton.json
@@ -10,6 +10,11 @@
     "defaultMessage": "Article successfully removed from item."
   },
   {
+    "id": "removeArticleButton.tooltip",
+    "description": "Tooltip message displayed on remove article button.",
+    "defaultMessage": "Remove article from media cluster"
+  },
+  {
     "id": "removeArticleButton.confirmationDialogTitle",
     "description": "Title displayed on a confirmation modal when a user tries to remove an article.",
     "defaultMessage": "Are you sure you want to remove this article?"

--- a/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
+++ b/localization/react-intl/src/app/components/drawer/Projects/ProjectsComponent.json
@@ -6,8 +6,8 @@
   },
   {
     "id": "projectsComponent.allItems",
-    "description": "Label for the 'All items' list displayed on the left sidebar",
-    "defaultMessage": "All"
+    "description": "Label for the 'All media' list displayed on the left sidebar",
+    "defaultMessage": "All Media"
   },
   {
     "id": "projectsComponent.assignedToMe",

--- a/localization/react-intl/src/app/components/media/BulkActionsMenu.json
+++ b/localization/react-intl/src/app/components/media/BulkActionsMenu.json
@@ -82,6 +82,6 @@
   {
     "id": "bulkActionsMenu.action",
     "description": "Button for popping the actions menu. User has to pick which action to perform upon currently selected items.",
-    "defaultMessage": "Action"
+    "defaultMessage": "Bulk Change [{count}]"
   }
 ]

--- a/localization/react-intl/src/app/components/search/AllItems.json
+++ b/localization/react-intl/src/app/components/search/AllItems.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "search.allClaimsTitle",
-    "description": "Page title for listing all items in check",
-    "defaultMessage": "All items"
+    "description": "Page title for listing all media items in check",
+    "defaultMessage": "All Media"
   }
 ]

--- a/localization/react-intl/src/app/components/search/SearchResults.json
+++ b/localization/react-intl/src/app/components/search/SearchResults.json
@@ -25,11 +25,6 @@
     "defaultMessage": "{count, plural, one {1 / 1} other {{from} - {to} / #}}"
   },
   {
-    "id": "searchResults.withSelection",
-    "description": "Label for number of selected items",
-    "defaultMessage": "{selectedCount, plural, one {(# selected)} other {(# selected)}}"
-  },
-  {
     "id": "search.nextPage",
     "description": "Pagination button to go to next page",
     "defaultMessage": "Next page"

--- a/localization/react-intl/src/app/components/task/Tasks.json
+++ b/localization/react-intl/src/app/components/task/Tasks.json
@@ -2,7 +2,7 @@
   {
     "id": "tasks.blankAnnotation",
     "description": "A message that appears when the Annotation menu is opened but no Annotation fields have been created in the project settings.",
-    "defaultMessage": "No annotation fields"
+    "defaultMessage": "No Workspace Annotations"
   },
   {
     "id": "tasks.goToSettings",

--- a/localization/react-intl/src/app/components/team/TeamMetadataRender.json
+++ b/localization/react-intl/src/app/components/team/TeamMetadataRender.json
@@ -27,6 +27,6 @@
   {
     "id": "teamMetadataRender.blankAnnotations",
     "description": "Text for empty annotations",
-    "defaultMessage": "No annotation fields"
+    "defaultMessage": "No Workspace Annotations"
   }
 ]

--- a/localization/react-intl/src/app/components/team/TeamTags/TeamTagsComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamTags/TeamTagsComponent.json
@@ -30,6 +30,11 @@
     "defaultMessage": "Next page"
   },
   {
+    "id": "teamTagsComponent.blank",
+    "description": "Message displayed when there are no tags in the workspace",
+    "defaultMessage": "No Workspace Tags"
+  },
+  {
     "id": "teamTagsComponent.tableHeaderName",
     "description": "Column header in tags table.",
     "defaultMessage": "Name"

--- a/localization/react-intl/src/app/components/user/UserPrivacy.json
+++ b/localization/react-intl/src/app/components/user/UserPrivacy.json
@@ -35,24 +35,19 @@
     "defaultMessage": "Please review our {ppLink} to learn how {appName} uses and stores your information."
   },
   {
-    "id": "userPrivacy.seeInformationText",
-    "description": "Description of what the app will do when the user requests their information",
-    "defaultMessage": "We will send you a file with the content and data you created and generated on {appName}. This can be kept for your records or transferred to another service."
+    "id": "userPrivacy.userRequests",
+    "description": "Title for area instructing how to request data from Check",
+    "defaultMessage": "User Information Requests"
   },
   {
-    "id": "userPrivacy.seeInformationButton",
-    "description": "Button text for the user to see their privacy information",
-    "defaultMessage": "See my information"
+    "id": "userPrivacy.seeInformationText",
+    "description": "Description of what the app will do when the user requests their information",
+    "defaultMessage": "Request a file with the content and data you created and generated on {appName} by contacting <a href=\"mailto:{privacyEmail}?subject=Send information\">{privacyEmail}</a>."
   },
   {
     "id": "userPrivacy.stopProcessingText",
     "description": "Help text to tell the user how they can request a change to their privacy settings",
-    "defaultMessage": "You can request {appName} to stop processing your information under certain conditions."
-  },
-  {
-    "id": "userPrivacy.stopProcessingButton",
-    "description": "Button text for the user to request a change to their privacy settings",
-    "defaultMessage": "Request to stop processing"
+    "defaultMessage": "Request {appName} to stop processing your information under certain conditions by contacting <a href=\"mailto:{privacyEmail}?subject=Stop processing\">{privacyEmail}</a>."
   },
   {
     "id": "userPrivacy.connectedAccounts",

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { graphql, createFragmentContainer } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+import { FormattedMessage, FormattedHTMLMessage, FormattedDate } from 'react-intl';
 import Slideout from '../cds/slideout/Slideout';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import IconReport from '../../icons/fact_check.svg';
@@ -258,16 +258,12 @@ const ArticleForm = ({
           }
           <div className={styles['article-form-container']}>
             { claimDescriptionMissing && articleType === 'fact-check' ?
-              <div className={styles['article-form-no-claim-overlay']}>
-                <div className={styles['article-form-no-claim-container']}>
-                  <div className="typography-subtitle2">
-                    <FormattedMessage
-                      id="articleForm.noClaimDescript"
-                      defaultMessage="Start by adding Claim information for this Fact-Check"
-                      description="Message overlay to tell the user they must complete additional fields to unlock this area"
-                    />
-                  </div>
-                </div>
+              <div className={styles['article-form-no-claim-container']}>
+                <FormattedHTMLMessage
+                  id="articleForm.noClaimDescript"
+                  defaultMessage="Start by adding Claim information<br />for this Fact-Check"
+                  description="Message overlay to tell the user they must complete additional fields to unlock this area"
+                />
               </div>
               : null
             }

--- a/src/app/components/article/ArticleForm.module.css
+++ b/src/app/components/article/ArticleForm.module.css
@@ -4,17 +4,6 @@
   position: relative;
 }
 
-.article-form-no-claim-overlay {
-  background: rgba(255 255 255 / .8);
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  top: 0;
-  z-index: 10;
-}
-
 .article-rating-wrapper {
   display: flex;
   gap: 4px;
@@ -22,10 +11,33 @@
 }
 
 .article-form-no-claim-container {
+  bottom: 0;
   color: var(--color-blue-32);
-  margin: 0 20px;
+  left: 0;
   position: absolute;
-  top: 30%;
+  right: 0;
+  text-align: center;
+  top: 0;
+
+  span {
+    @mixin typography-subtitle2;
+    display: block;
+    margin: 80px 0 0;
+    position: relative;
+    z-index: 11;
+  }
+
+  &::after {
+    background-color: rgba(255 255 255 / .85);
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    top: 0;
+    z-index: 10;
+  }
 }
 
 .article-form-info {

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -1,13 +1,53 @@
 .articlesSidebar {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   overflow-y: auto;
-  padding: 16px;
+  position: relative;
   width: 100%;
+
+  &::after {
+    background-color: var(--color-beige-86);
+    content: '';
+    display: block;
+    height: 2px;
+    left: 0;
+    position: absolute;
+    right: 16px;
+    top: 62px;
+    z-index: 1;
+  }
 
   .articlesSidebarTopBar {
     background: var(--color-white-100);
     display: flex;
     gap: 16px;
+    height: 62px;
     justify-content: flex-end;
+    padding: 16px;
+  }
+
+  .articlesSidebarNoArticleWrapper {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 16px;
+    overflow-y: auto;
+    padding: 0 16px 16px;
+    width: 100%;
+
+    &::before {
+      background-color: var(--color-white-100);
+      content: '';
+      display: block;
+      flex-shrink: 0;
+      height: 2px;
+      left: 0;
+      margin: auto -16px 0;
+      position: relative;
+      right: 0;
+      z-index: 2;
+    }
   }
 
   .articlesSidebarNoArticle {

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -1,7 +1,10 @@
 .articlesSidebar {
+  overflow-y: auto;
   padding: 16px;
+  width: 100%;
 
   .articlesSidebarTopBar {
+    background: var(--color-white-100);
     display: flex;
     gap: 16px;
     justify-content: flex-end;
@@ -14,11 +17,6 @@
     margin: 16px 0 32px;
     padding: 16px;
     text-align: center;
-  }
-
-  .articlesSidebarListComponent {
-    max-height: 400px;
-    overflow: auto;
   }
 
   .articlesSidebarList {

--- a/src/app/components/article/ChooseExistingArticleButton.js
+++ b/src/app/components/article/ChooseExistingArticleButton.js
@@ -51,6 +51,8 @@ const ChooseExistingArticleButton = ({ teamSlug, onAdd }) => {
       { openSlideout && (
         <Slideout
           title={title}
+          showCancel
+          footer
           content={
             <div className={styles.contentWrapper}>
               <FormattedMessage

--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -133,7 +133,7 @@ const MediaArticlesComponent = ({
       { hasArticle ? (
         <MediaArticlesDisplay projectMedia={projectMedia} />
       ) : (
-        <>
+        <div className={cx('typography-body1', styles.articlesSidebarNoArticleWrapper)}>
           <div className={cx('typography-body1', styles.articlesSidebarNoArticle)}>
             <DescriptionIcon style={{ fontSize: 'var(--font-size-h4)' }} />
             <div>
@@ -152,7 +152,7 @@ const MediaArticlesComponent = ({
             />
           </div>
           <MediaArticlesTeamArticles teamSlug={team.slug} onAdd={handleConfirmAdd} />
-        </>
+        </div>
       )}
 
       {/* Confirm dialog for replacing fact-check */}

--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -151,9 +151,7 @@ const MediaArticlesComponent = ({
               description="Message displayed on articles sidebar when an item has no articles."
             />
           </div>
-          <div className={styles.articlesSidebarListComponent}>
-            <MediaArticlesTeamArticles teamSlug={team.slug} onAdd={handleConfirmAdd} />
-          </div>
+          <MediaArticlesTeamArticles teamSlug={team.slug} onAdd={handleConfirmAdd} />
         </>
       )}
 

--- a/src/app/components/article/MediaArticlesDisplay.module.css
+++ b/src/app/components/article/MediaArticlesDisplay.module.css
@@ -1,8 +1,24 @@
 .mediaArticlesDisplay {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 16px;
-  margin-top: 16px;
+  overflow-y: auto;
+  padding: 0 16px 16px;
+  width: 100%;
+
+  &::before {
+    background-color: var(--color-white-100);
+    content: '';
+    display: block;
+    flex-shrink: 0;
+    height: 2px;
+    left: 0;
+    margin: auto -16px 0;
+    position: relative;
+    right: 0;
+    z-index: 2;
+  }
 }
 
 .explainerCard:hover {

--- a/src/app/components/article/RemoveArticleButton.js
+++ b/src/app/components/article/RemoveArticleButton.js
@@ -63,7 +63,6 @@ const RemoveArticleWrapperButton = ({ disabled, children }) => {
     return (
       <Tooltip
         key="remove-article-button"
-        placement="top"
         title={
           <FormattedMessage
             id="removedArticleButton.tooltip"
@@ -153,12 +152,27 @@ const RemoveArticleButton = ({
   return (
     <>
       <RemoveArticleWrapperButton disabled={disabled}>
-        <ButtonMain
-          size="small"
-          theme="text"
-          iconCenter={<IconClose />}
-          onClick={() => setOpenDialog(true)}
-        />
+        <Tooltip
+          disableHoverListener={disabled}
+          key="remove-article-button"
+          title={
+            <FormattedMessage
+              id="removeArticleButton.tooltip"
+              defaultMessage="Remove article from media cluster"
+              description="Tooltip message displayed on remove article button."
+            />
+          }
+          arrow
+        >
+          <span>
+            <ButtonMain
+              size="small"
+              theme="text"
+              iconCenter={<IconClose />}
+              onClick={() => setOpenDialog(true)}
+            />
+          </span>
+        </Tooltip>
       </RemoveArticleWrapperButton>
       <ConfirmProceedDialog
         open={openDialog}

--- a/src/app/components/cds/slideout/Slideout.js
+++ b/src/app/components/cds/slideout/Slideout.js
@@ -111,7 +111,7 @@ const Slideout = ({
 
 Slideout.defaultProps = {
   content: null,
-  footer: true,
+  footer: false,
   showCancel: false,
   cancelProps: {},
   mainActionButton: null,

--- a/src/app/components/cds/slideout/Slideout.test.js
+++ b/src/app/components/cds/slideout/Slideout.test.js
@@ -7,6 +7,7 @@ describe('<Slideout />', () => {
     const wrapper = mountWithIntl(<Slideout
       title="Slideout Title"
       content="Slideout content"
+      footer
       showCancel
       onClose={() => {}}
     />);

--- a/src/app/components/drawer/DrawerRail.js
+++ b/src/app/components/drawer/DrawerRail.js
@@ -61,7 +61,6 @@ const messages = defineMessages({
 const DrawerRail = (props) => {
   const testPath = window.location.pathname;
   const isSettingsPage = /[^/]+\/settings?/.test(testPath);
-  const isMediaPage = /\/media\/[0-9]+/.test(testPath);
   const isArticlePage = /[^/]+\/articles?/.test(testPath);
   const isFeedPage = /^\/[^/]+\/feed(s)?($|\/)/.test(testPath);
   const teamRegex = window.location.pathname.match(/^\/([^/]+)/);
@@ -95,7 +94,7 @@ const DrawerRail = (props) => {
 
   useEffect(() => {
     if (!!team && (currentUserIsMember || !team.private)) {
-      if (isMediaPage || !teamSlug) {
+      if (!teamSlug) {
         onDrawerOpenChange(false);
         window.storage.set('drawer.isOpen', false);
       } else if (window.storage.getValue('drawer.isOpen')) {

--- a/src/app/components/drawer/Projects/ProjectsComponent.js
+++ b/src/app/components/drawer/Projects/ProjectsComponent.js
@@ -105,7 +105,7 @@ const ProjectsComponent = ({
             >
               <CategoryIcon className={styles.listIcon} />
               <div className={styles.listLabel}>
-                <FormattedMessage tagName="span" id="projectsComponent.allItems" defaultMessage="All" description="Label for the 'All items' list displayed on the left sidebar" />
+                <FormattedMessage tagName="span" id="projectsComponent.allItems" defaultMessage="All Media" description="Label for the 'All media' list displayed on the left sidebar" />
               </div>
               <div title={team.medias_count} className={styles.listItemCount}>
                 <small>

--- a/src/app/components/media/BulkActionsMenu.js
+++ b/src/app/components/media/BulkActionsMenu.js
@@ -294,8 +294,11 @@ const BulkActionsMenu = ({
           label={
             <FormattedMessage
               id="bulkActionsMenu.action"
-              defaultMessage="Action"
+              defaultMessage="Bulk Change [{count}]"
               description="Button for popping the actions menu. User has to pick which action to perform upon currently selected items."
+              values={{
+                count: selectedMedia?.length,
+              }}
             />
           }
         />

--- a/src/app/components/search/AllItems.js
+++ b/src/app/components/search/AllItems.js
@@ -15,7 +15,7 @@ export default function AllItems({ routeParams }) {
       <Search
         searchUrlPrefix={`/${routeParams.team}/all-items`}
         mediaUrlPrefix={`/${routeParams.team}/media`}
-        title={<FormattedMessage id="search.allClaimsTitle" defaultMessage="All items" description="Page title for listing all items in check" />}
+        title={<FormattedMessage id="search.allClaimsTitle" defaultMessage="All Media" description="Page title for listing all media items in check" />}
         query={safelyParseJSON(routeParams.query, defaultQuery)}
         defaultQuery={defaultQuery}
         icon={<CategoryIcon />}

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -595,19 +595,6 @@ function SearchResultsComponent({
                       count,
                     }}
                   />
-                  {filteredSelectedProjectMediaIds.length ?
-                    <FormattedMessage
-                      id="searchResults.withSelection"
-                      defaultMessage="{selectedCount, plural, one {(# selected)} other {(# selected)}}"
-                      description="Label for number of selected items"
-                      values={{
-                        selectedCount: filteredSelectedProjectMediaIds.length,
-                      }}
-                    >
-                      {txt => <span className={styles['search-selected']}>{txt}</span>}
-                    </FormattedMessage>
-                    : null
-                  }
                 </span>
                 <Tooltip title={
                   <FormattedMessage id="search.nextPage" defaultMessage="Next page" description="Pagination button to go to next page" />

--- a/src/app/components/task/Tasks.js
+++ b/src/app/components/task/Tasks.js
@@ -29,7 +29,7 @@ const Tasks = ({
     return (
       <React.Fragment>
         <BlankState>
-          <FormattedMessage id="tasks.blankAnnotation" defaultMessage="No annotation fields" description="A message that appears when the Annotation menu is opened but no Annotation fields have been created in the project settings." />
+          <FormattedMessage id="tasks.blankAnnotation" defaultMessage="No Workspace Annotations" description="A message that appears when the Annotation menu is opened but no Annotation fields have been created in the project settings." />
         </BlankState>
         { !isBrowserExtension ?
           <div>

--- a/src/app/components/team/TeamMetadataRender.js
+++ b/src/app/components/team/TeamMetadataRender.js
@@ -78,7 +78,7 @@ function TeamMetadataRender({ team, about }) {
           <BlankState>
             <FormattedMessage
               id="teamMetadataRender.blankAnnotations"
-              defaultMessage="No annotation fields"
+              defaultMessage="No Workspace Annotations"
               description="Text for empty annotations"
             />
           </BlankState>

--- a/src/app/components/team/TeamTags/TeamTagsComponent.js
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames/bind';
 import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import BlankState from '../../layout/BlankState';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import Tooltip from '../../cds/alerts-and-prompts/Tooltip';
 import NextIcon from '../../../icons/chevron_right.svg';
@@ -21,15 +21,6 @@ import MediasLoading from '../../media/MediasLoading';
 import styles from './TeamTagsComponent.module.css';
 import Can from '../../Can';
 import settingsStyles from '../Settings.module.css';
-
-const useStyles = makeStyles({
-  teamTagsTableCell: {
-    borderBottom: 0,
-  },
-  teamTagsNewTagButton: {
-    whiteSpace: 'nowrap',
-  },
-});
 
 const TeamTagsComponent = ({
   teamId,
@@ -46,7 +37,6 @@ const TeamTagsComponent = ({
   setSearchTerm,
 }) => {
   const teamSlug = window.location.pathname.match(/^\/([^/]+)/)[1];
-  const classes = useStyles();
   const [showCreateTag, setShowCreateTag] = React.useState(false);
   const [cursor, setCursor] = React.useState(0);
   const [isPaginationLoading, setIsPaginationLoading] = React.useState(false);
@@ -81,7 +71,6 @@ const TeamTagsComponent = ({
               theme="brand"
               size="default"
               onClick={() => { setShowCreateTag(true); }}
-              className={classes.teamTagsNewTagButton}
               label={
                 <FormattedMessage
                   id="teamTagsComponent.newTag"
@@ -169,67 +158,77 @@ const TeamTagsComponent = ({
         </div>
       }
       <div className={cx(settingsStyles['setting-details-wrapper'])}>
-        <div className={settingsStyles['setting-content-container']}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell className={styles['table-col-head-name']}>
-                  <FormattedMessage
-                    id="teamTagsComponent.tableHeaderName"
-                    defaultMessage="Name"
-                    description="Column header in tags table."
-                  />
-                </TableCell>
-                <TableCell className={styles['table-col-head-updated']}>
-                  <FormattedMessage
-                    id="teamTagsComponent.tableHeaderUpdatedAt"
-                    defaultMessage="Updated"
-                    description="Column header in tags table."
-                  />
-                </TableCell>
-                <TableCell className={styles['table-col-head-items']}>
-                  <FormattedMessage
-                    id="teamTagsComponent.tableHeaderTagsCount"
-                    defaultMessage="Items"
-                    description="Column header in tags table."
-                  />
-                </TableCell>
-                <TableCell padding="checkbox" className={styles['table-col-head-action']} />
-              </TableRow>
-            </TableHead>
-            { isPaginationLoading && <MediasLoading size="medium" theme="grey" variant="inline" /> }
-            <TableBody className={isPaginationLoading && styles['tags-hide']}>
-              { tags.slice(cursor, cursor + pageSize).map(tag => (
-                <TableRow key={tag.id} className="team-tags__row">
-                  <TableCell className={classes.teamTagsTableCell}>
-                    {tag.text}
+        {totalTags === 0 ?
+          <BlankState>
+            <FormattedMessage
+              id="teamTagsComponent.blank"
+              defaultMessage="No Workspace Tags"
+              description="Message displayed when there are no tags in the workspace"
+            />
+          </BlankState>
+          :
+          <div className={settingsStyles['setting-content-container']}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell className={styles['table-col-head-name']}>
+                    <FormattedMessage
+                      id="teamTagsComponent.tableHeaderName"
+                      defaultMessage="Name"
+                      description="Column header in tags table."
+                    />
                   </TableCell>
-                  <TableCell className={classes.teamTagsTableCell}>
-                    <TimeBefore date={tag.updated_at} />
+                  <TableCell className={styles['table-col-head-updated']}>
+                    <FormattedMessage
+                      id="teamTagsComponent.tableHeaderUpdatedAt"
+                      defaultMessage="Updated"
+                      description="Column header in tags table."
+                    />
                   </TableCell>
-                  <TableCell className={classes.teamTagsTableCell}>
-                    <a href={`/${teamSlug}/all-items/%7B"tags"%3A%5B"${tag.text}"%5D%7D`} target="_blank" rel="noopener noreferrer">
-                      {tag.tags_count}
-                    </a>
+                  <TableCell className={styles['table-col-head-items']}>
+                    <FormattedMessage
+                      id="teamTagsComponent.tableHeaderTagsCount"
+                      defaultMessage="Items"
+                      description="Column header in tags table."
+                    />
                   </TableCell>
-                  <TableCell className={classes.teamTagsTableCell}>
-                    <Can permissions={permissions} permission="create TagText">
-                      <TeamTagsActions
-                        tag={tag}
-                        teamId={teamId}
-                        teamDbid={teamDbid}
-                        rules={rules}
-                        rulesSchema={rulesSchema}
-                        relay={relay}
-                        pageSize={pageSize}
-                      />
-                    </Can>
-                  </TableCell>
+                  <TableCell padding="checkbox" className={styles['table-col-head-action']} />
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+              </TableHead>
+              { isPaginationLoading && <MediasLoading size="medium" theme="grey" variant="inline" /> }
+              <TableBody className={isPaginationLoading && styles['tags-hide']}>
+                { tags.slice(cursor, cursor + pageSize).map(tag => (
+                  <TableRow key={tag.id} className="team-tags__row">
+                    <TableCell>
+                      {tag.text}
+                    </TableCell>
+                    <TableCell>
+                      <TimeBefore date={tag.updated_at} />
+                    </TableCell>
+                    <TableCell>
+                      <a href={`/${teamSlug}/all-items/%7B"tags"%3A%5B"${tag.text}"%5D%7D`} target="_blank" rel="noopener noreferrer">
+                        {tag.tags_count}
+                      </a>
+                    </TableCell>
+                    <TableCell>
+                      <Can permissions={permissions} permission="create TagText">
+                        <TeamTagsActions
+                          tag={tag}
+                          teamId={teamId}
+                          teamDbid={teamDbid}
+                          rules={rules}
+                          rulesSchema={rulesSchema}
+                          relay={relay}
+                          pageSize={pageSize}
+                        />
+                      </Can>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        }
       </div>
       { showCreateTag ?
         <SaveTag

--- a/src/app/components/user/UserPrivacy.js
+++ b/src/app/components/user/UserPrivacy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { graphql, commitMutation } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import { FormattedMessage, FormattedHTMLMessage, defineMessages, injectIntl } from 'react-intl';
 import Relay from 'react-relay/classic';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import SettingsHeader from '../team/SettingsHeader';
@@ -33,11 +33,6 @@ const messages = defineMessages({
 const UserPrivacy = (props, context) => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [message, setMessage] = React.useState(false);
-
-  const handleSubmit = (subject) => {
-    const email = 'privacy@meedan.com';
-    window.location.href = `mailto:${email}?subject=${subject}`;
-  };
 
   const handleOpenDialog = () => {
     setDialogOpen(true);
@@ -140,46 +135,30 @@ const UserPrivacy = (props, context) => {
             }}
           />
           <div className={styles['user-setting-content-container-inner']}>
-            <FormattedMessage
-              tagName="p"
-              id="userPrivacy.seeInformationText"
-              defaultMessage="We will send you a file with the content and data you created and generated on {appName}. This can be kept for your records or transferred to another service."
-              description="Description of what the app will do when the user requests their information"
-              values={{ appName }}
-            />
-            <ButtonMain
-              buttonProps={{
-                id: 'user-privacy__see-info',
-              }}
-              size="default"
-              variant="contained"
-              theme="brand"
-              onClick={handleSubmit.bind(this, 'Send information')}
-              label={
-                <FormattedMessage id="userPrivacy.seeInformationButton" defaultMessage="See my information" description="Button text for the user to see their privacy information" />
-              }
-            />
-          </div>
-          <div className={styles['user-setting-content-container-inner']}>
-            <FormattedMessage
-              tagName="p"
-              id="userPrivacy.stopProcessingText"
-              defaultMessage="You can request {appName} to stop processing your information under certain conditions."
-              description="Help text to tell the user how they can request a change to their privacy settings"
-              values={{ appName }}
-            />
-            <ButtonMain
-              buttonProps={{
-                id: 'user-privacy__stop-processing',
-              }}
-              size="default"
-              variant="contained"
-              theme="brand"
-              onClick={handleSubmit.bind(this, 'Stop processing')}
-              label={
-                <FormattedMessage id="userPrivacy.stopProcessingButton" defaultMessage="Request to stop processing" description="Button text for the user to request a change to their privacy settings" />
-              }
-            />
+            <FormattedMessage id="userPrivacy.userRequests" tagName="strong" defaultMessage="User Information Requests" description="Title for area instructing how to request data from Check" />
+            <br />
+            <ul className="bulleted-list">
+              <FormattedHTMLMessage
+                tagName="li"
+                id="userPrivacy.seeInformationText"
+                defaultMessage='Request a file with the content and data you created and generated on {appName} by contacting <a href="mailto:{privacyEmail}?subject=Send information">{privacyEmail}</a>.'
+                description="Description of what the app will do when the user requests their information"
+                values={{
+                  appName,
+                  privacyEmail: stringHelper('PRIVACY_EMAIL'),
+                }}
+              />
+              <FormattedHTMLMessage
+                tagName="li"
+                id="userPrivacy.stopProcessingText"
+                defaultMessage='Request {appName} to stop processing your information under certain conditions by contacting <a href="mailto:{privacyEmail}?subject=Stop processing">{privacyEmail}</a>.'
+                description="Help text to tell the user how they can request a change to their privacy settings"
+                values={{
+                  appName,
+                  privacyEmail: stringHelper('PRIVACY_EMAIL'),
+                }}
+              />
+            </ul>
           </div>
         </div>
         <div className={styles['user-setting-content-container']}>

--- a/src/app/customHelpers.js
+++ b/src/app/customHelpers.js
@@ -7,6 +7,7 @@ const customStrings = {
     CONTACT_HUMAN_URL: 'https://meedan.typeform.com/to/Tvf0b8',
     PP_URL: 'https://meedan.com/legal/privacy-policy',
     SUPPORT_EMAIL: 'check@meedan.com',
+    PRIVACY_EMAIL: 'privacy@meedan.com',
     TOS_URL: 'https://meedan.com/legal/terms-of-service',
     LOGO_URL: '/images/logo/check.svg',
   },

--- a/test/spec/annotation_spec.rb
+++ b/test/spec/annotation_spec.rb
@@ -7,10 +7,10 @@ shared_examples 'annotation' do
     wait_for_selector("//span[contains(text(), 'annotation')]", :xpath)
 
     # Create annotation
-    expect(@driver.page_source.include?('No annotation fields')).to be(true)
+    expect(@driver.page_source.include?('No Workspace Annotations')).to be(true)
     expect(@driver.page_source.include?('my metadata')).to be(false)
     create_annotation(tab_class: '.team-settings__metadata-tab', task_type_class: '.edit-task-dialog__menu-item-free_text', task_name: 'my metadata')
-    expect(@driver.page_source.include?('No annotation fields')).to be(false)
+    expect(@driver.page_source.include?('No Workspace Annotations')).to be(false)
     expect(@driver.page_source.include?('my metadata')).to be(true)
 
     # Edit annotation


### PR DESCRIPTION
## Description

- Cleanup empty state on tags settings list
- Simplify the privacy requests area, no need for buttons
- Add tooltip on remove articles button in list on media cluster page
- Move the count of selected items in a list for bulk changes to the bulk actions button for clarity
- Add cancel button to existing article slideout
- Make footer default false for slideout with no actions in footer
- Add an indicator like the side navigation to the articles list to show when the area is scrolling
- Stop hiding side navigation on media item cluster pages now that we have 2 columns

References: CV2-4441 , CV2-4874

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

reviewing

## Things to pay attention to during code review

### TAGS EMPTY BEFORE
<img width="1240" alt="Screenshot 2024-07-17 at 9 30 32 AM" src="https://github.com/user-attachments/assets/e17fcb61-23d9-4a81-85bb-6b3540f67c94">

### TAGS EMPTY AFTER
<img width="1256" alt="Screenshot 2024-07-17 at 9 34 51 AM" src="https://github.com/user-attachments/assets/02b92386-ec48-4d0a-b1e6-6b2fafafb54f">

### PRIVACY AFTER
<img width="912" alt="Screenshot 2024-07-17 at 10 05 35 AM" src="https://github.com/user-attachments/assets/387e41a0-baeb-4d49-a686-dc0d05c786a8">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
