### PR TITLE
Remove last use of material alert component in favor of CDS

### DIFF
--- a/src/app/components/task/EditTaskAlert.js
+++ b/src/app/components/task/EditTaskAlert.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import Box from '@material-ui/core/Box';
-import Alert from '@material-ui/lab/Alert';
-import AlertTitle from '@material-ui/lab/AlertTitle';
-
+import Alert from '../cds/alerts-and-prompts/Alert';
+import styles from './Task.module.css';
 
 const EditTaskAlert = ({
   showAlert,
@@ -13,48 +11,53 @@ const EditTaskAlert = ({
   if (!showAlert) return null;
 
   return (
-    <Box mt={2}>
-      <Alert severity="warning">
-        <AlertTitle>
-          <FormattedMessage
-            id="tasks.editFieldWithAnswersTitle"
-            defaultMessage="{number, plural, one {Editing field with # existing response} other {Editing field with # existing responses}}"
-            description="Title of warning when user tries to edit an annotation field that already has collected responses"
-            values={{ number: task.tasks_with_answers_count }}
-          />
-        </AlertTitle>
-        { diff.deleted.map(deletedOption => (
-          <div key={deletedOption}>
-            <FormattedMessage
-              id="tasks.deleteOptionWithAnswersBody"
-              defaultMessage='• "{deletedOption}" will be permanently deleted from existing responses.'
-              description="Body of warning when user tries to edit an annotation field that already has collected responses"
-              values={{ deletedOption }}
-            />
-          </div>
-        ))}
-        { Object.entries(diff.changed).map(([oldOption, newOption]) => (
-          <div key={oldOption}>
-            <FormattedMessage
-              id="tasks.changeOptionWithAnswersBody"
-              defaultMessage='• "{oldOption}" will be changed to "{newOption}" in existing responses.'
-              description="Body of warning when user tries to edit an annotation field that already has collected responses"
-              values={{ oldOption, newOption }}
-            />
-          </div>
-        ))}
-        { diff.added.length ? (
-          <div>
-            <FormattedMessage
-              id="tasks.addOptionWithAnswersBody"
-              defaultMessage="{number, plural, one {• # new option will be added to this field.} other {• # new options will be added to this field.}}"
-              description="Body of warning when user tries to edit an annotation field that already has collected responses"
-              values={{ number: diff.added.length }}
-            />
-          </div>
-        ) : null }
-      </Alert>
-    </Box>
+    <Alert
+      className={styles['edit-task-alert']}
+      icon
+      variant="warning"
+      title={
+        <FormattedMessage
+          id="tasks.editFieldWithAnswersTitle"
+          defaultMessage="{number, plural, one {Editing field with # existing response} other {Editing field with # existing responses}}"
+          description="Title of warning when user tries to edit an annotation field that already has collected responses"
+          values={{ number: task.tasks_with_answers_count }}
+        />
+      }
+      content={
+        <>
+          { diff.deleted.map(deletedOption => (
+            <div key={deletedOption}>
+              <FormattedMessage
+                id="tasks.deleteOptionWithAnswersBody"
+                defaultMessage='• "{deletedOption}" will be permanently deleted from existing responses.'
+                description="Body of warning when user tries to edit an annotation field that already has collected responses"
+                values={{ deletedOption }}
+              />
+            </div>
+          ))}
+          { Object.entries(diff.changed).map(([oldOption, newOption]) => (
+            <div key={oldOption}>
+              <FormattedMessage
+                id="tasks.changeOptionWithAnswersBody"
+                defaultMessage='• "{oldOption}" will be changed to "{newOption}" in existing responses.'
+                description="Body of warning when user tries to edit an annotation field that already has collected responses"
+                values={{ oldOption, newOption }}
+              />
+            </div>
+          ))}
+          { diff.added.length ? (
+            <div>
+              <FormattedMessage
+                id="tasks.addOptionWithAnswersBody"
+                defaultMessage="{number, plural, one {• # new option will be added to this field.} other {• # new options will be added to this field.}}"
+                description="Body of warning when user tries to edit an annotation field that already has collected responses"
+                values={{ number: diff.added.length }}
+              />
+            </div>
+          ) : null }
+        </>
+      }
+    />
   );
 };
 

--- a/src/app/components/task/Task.module.css
+++ b/src/app/components/task/Task.module.css
@@ -77,3 +77,7 @@
     max-width: 90px;
   }
 }
+
+.edit-task-alert {
+  margin: 16px 0 0;
+}


### PR DESCRIPTION
Replaces what I believe to be the last use of the material alert component in favor of the CDS alert component

References: CV2-3354

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual verification

## Things to pay attention to during code review

### BEFORE
<img width="606" alt="Screenshot 2024-07-25 at 2 18 47 PM" src="https://github.com/user-attachments/assets/72cacb97-fe39-47a0-b866-457d4ddafc94">

### AFTER
<img width="604" alt="Screenshot 2024-07-25 at 2 18 19 PM" src="https://github.com/user-attachments/assets/fe65da7c-2f1c-495e-b73c-c342d6400285">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
