### PR TITLE
add the article type to the article media card list

### DIFF
--- a/localization/react-intl/src/app/components/article/MediaArticlesCard.json
+++ b/localization/react-intl/src/app/components/article/MediaArticlesCard.json
@@ -1,7 +1,22 @@
 [
   {
-    "id": "articlesSidebarCard.tooltip",
-    "description": "Tooltip message displayed on explainer cards on item page.",
-    "defaultMessage": "Add article to this media cluster"
+    "id": "articlesSidebarCard.factcheckTooltip",
+    "description": "Tooltip message displayed on explainer cards on item page for fact-check type articles.",
+    "defaultMessage": "Add Claim & Fact-Check article to this media cluster"
+  },
+  {
+    "id": "articlesSidebarCard.explainerTooltip",
+    "description": "Tooltip message displayed on explainer cards on item page for explainer type articles.",
+    "defaultMessage": "Add Explainer article to this media cluster"
+  },
+  {
+    "id": "articlesSidebarCard.factCheck",
+    "description": "Type description of a fact-check article card.",
+    "defaultMessage": "Claim & Fact-Check"
+  },
+  {
+    "id": "articlesSidebarCard.explainer",
+    "description": "Type description of an explainer article card.",
+    "defaultMessage": "Explainer"
   }
 ]

--- a/localization/react-intl/src/app/components/article/MediaArticlesCard.json
+++ b/localization/react-intl/src/app/components/article/MediaArticlesCard.json
@@ -1,21 +1,21 @@
 [
   {
-    "id": "articlesSidebarCard.factcheckTooltip",
-    "description": "Tooltip message displayed on explainer cards on item page for fact-check type articles.",
+    "id": "mediaArticlesCard.factcheckTooltip",
+    "description": "Tooltip message displayed on article cards on item page for fact-check type articles.",
     "defaultMessage": "Add Claim & Fact-Check article to this media cluster"
   },
   {
-    "id": "articlesSidebarCard.explainerTooltip",
-    "description": "Tooltip message displayed on explainer cards on item page for explainer type articles.",
+    "id": "mediaArticlesCard.explainerTooltip",
+    "description": "Tooltip message displayed on article cards on item page for explainer type articles.",
     "defaultMessage": "Add Explainer article to this media cluster"
   },
   {
-    "id": "articlesSidebarCard.factCheck",
+    "id": "mediaArticlesCard.factCheck",
     "description": "Type description of a fact-check article card.",
     "defaultMessage": "Claim & Fact-Check"
   },
   {
-    "id": "articlesSidebarCard.explainer",
+    "id": "mediaArticlesCard.explainer",
     "description": "Type description of an explainer article card.",
     "defaultMessage": "Explainer"
   }

--- a/localization/react-intl/src/app/components/article/MediaArticlesTeamArticles.json
+++ b/localization/react-intl/src/app/components/article/MediaArticlesTeamArticles.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "articlesSidebar.noResults",
+    "id": "mediaArticlesTeamArticles.noResults",
     "description": "Message displayed on articles sidebar when search returns no articles.",
     "defaultMessage": "No results matched your search."
   }

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -117,7 +117,7 @@
       padding: 5px;
 
       .articlesSidebarCardIcon {
-        color: var(--color-green-23);
+        color: var(--color-blue-54);
         font-weight: bold;
       }
     }

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -53,11 +53,16 @@
 
   .articlesSidebarNoArticle {
     border: 2px dashed var(--color-gray-88);
+    border-radius: 8px;
     color: var(--color-gray-75);
     font-style: italic;
     margin: 16px 0 32px;
     padding: 16px;
     text-align: center;
+
+    :global(.check-icon) {
+      font-size: var(--font-size-h4);
+    }
   }
 
   .articlesSidebarList {
@@ -72,36 +77,49 @@
     border-radius: 5px;
     cursor: pointer;
     display: flex;
+    flex-direction: column;
     gap: 3px;
     padding: 6px;
+
+    .articlesSidebarCardIcon {
+      align-items: center;
+      color: var(--color-gray-37);
+      display: flex;
+      flex-direction: row;
+      gap: 3px;
+
+      :global(.check-icon) {
+        font-size: var(--font-size-subtitle-1);
+      }
+    }
+
+    .articlesSidebarCardTitle {
+      -webkit-box-orient: vertical;
+      color: var(--color-gray-15);
+      display: -webkit-box; /* stylelint-disable-line */
+      -webkit-line-clamp: 2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .articlesSidebarCardCaption {
+      align-items: center;
+      display: flex;
+
+      svg {
+        font-size: var(--font-size-base);
+      }
+    }
 
     &:hover {
       border-color: var(--color-blue-54);
       border-width: 2px;
       padding: 5px;
-    }
-  }
 
-  .articlesSidebarCardIcon {
-    color: var(--color-gray-37);
-    font-size: var(--font-size-subtitle-1);
-  }
-
-  .articlesSidebarCardTitle {
-    -webkit-box-orient: vertical;
-    color: var(--color-gray-15);
-    display: -webkit-box; /* stylelint-disable-line */
-    -webkit-line-clamp: 2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .articlesSidebarCardCaption {
-    align-items: center;
-    display: flex;
-
-    svg {
-      font-size: var(--font-size-base);
+      .articlesSidebarCardIcon {
+        color: var(--color-green-23);
+        font-weight: bold;
+      }
     }
   }
 }

--- a/src/app/components/article/MediaArticlesCard.js
+++ b/src/app/components/article/MediaArticlesCard.js
@@ -49,8 +49,8 @@ const MediaArticlesCard = ({ article, team, onAdd }) => {
       placement="top"
       title={
         <>
-          { article.nodeType === 'FactCheck' && <FormattedMessage id="articlesSidebarCard.factcheckTooltip" defaultMessage="Add Claim & Fact-Check article to this media cluster" description="Tooltip message displayed on explainer cards on item page for fact-check type articles." /> }
-          { article.nodeType === 'Explainer' && <FormattedMessage id="articlesSidebarCard.explainerTooltip" defaultMessage="Add Explainer article to this media cluster" description="Tooltip message displayed on explainer cards on item page for explainer type articles." /> }
+          { article.nodeType === 'FactCheck' && <FormattedMessage id="mediaArticlesCard.factcheckTooltip" defaultMessage="Add Claim & Fact-Check article to this media cluster" description="Tooltip message displayed on article cards on item page for fact-check type articles." /> }
+          { article.nodeType === 'Explainer' && <FormattedMessage id="mediaArticlesCard.explainerTooltip" defaultMessage="Add Explainer article to this media cluster" description="Tooltip message displayed on article cards on item page for explainer type articles." /> }
         </>
       }
       arrow
@@ -60,8 +60,8 @@ const MediaArticlesCard = ({ article, team, onAdd }) => {
           { isHovered && <AddIcon /> }
           { article.nodeType === 'Explainer' && !isHovered && <BookIcon /> }
           { article.nodeType === 'FactCheck' && !isHovered && <FactCheckIcon /> }
-          { article.nodeType === 'FactCheck' && <FormattedMessage id="articlesSidebarCard.factCheck" tagName="small" defaultMessage="Claim & Fact-Check" description="Type description of a fact-check article card." /> }
-          { article.nodeType === 'Explainer' && <FormattedMessage id="articlesSidebarCard.explainer" tagName="small" defaultMessage="Explainer" description="Type description of an explainer article card." /> }
+          { article.nodeType === 'FactCheck' && <FormattedMessage id="mediaArticlesCard.factCheck" tagName="small" defaultMessage="Claim & Fact-Check" description="Type description of a fact-check article card." /> }
+          { article.nodeType === 'Explainer' && <FormattedMessage id="mediaArticlesCard.explainer" tagName="small" defaultMessage="Explainer" description="Type description of an explainer article card." /> }
         </div>
         <div className={cx('typography-body1', styles.articlesSidebarCardTitle)}>
           {article.title}

--- a/src/app/components/article/MediaArticlesCard.js
+++ b/src/app/components/article/MediaArticlesCard.js
@@ -48,11 +48,10 @@ const MediaArticlesCard = ({ article, team, onAdd }) => {
       key={article.id}
       placement="top"
       title={
-        <FormattedMessage
-          id="articlesSidebarCard.tooltip"
-          defaultMessage="Add article to this media cluster"
-          description="Tooltip message displayed on explainer cards on item page."
-        />
+        <>
+          { article.nodeType === 'FactCheck' && <FormattedMessage id="articlesSidebarCard.factcheckTooltip" defaultMessage="Add Claim & Fact-Check article to this media cluster" description="Tooltip message displayed on explainer cards on item page for fact-check type articles." /> }
+          { article.nodeType === 'Explainer' && <FormattedMessage id="articlesSidebarCard.explainerTooltip" defaultMessage="Add Explainer article to this media cluster" description="Tooltip message displayed on explainer cards on item page for explainer type articles." /> }
+        </>
       }
       arrow
     >
@@ -61,6 +60,8 @@ const MediaArticlesCard = ({ article, team, onAdd }) => {
           { isHovered && <AddIcon /> }
           { article.nodeType === 'Explainer' && !isHovered && <BookIcon /> }
           { article.nodeType === 'FactCheck' && !isHovered && <FactCheckIcon /> }
+          { article.nodeType === 'FactCheck' && <FormattedMessage id="articlesSidebarCard.factCheck" tagName="small" defaultMessage="Claim & Fact-Check" description="Type description of a fact-check article card." /> }
+          { article.nodeType === 'Explainer' && <FormattedMessage id="articlesSidebarCard.explainer" tagName="small" defaultMessage="Explainer" description="Type description of an explainer article card." /> }
         </div>
         <div className={cx('typography-body1', styles.articlesSidebarCardTitle)}>
           {article.title}

--- a/src/app/components/article/MediaArticlesTeamArticles.js
+++ b/src/app/components/article/MediaArticlesTeamArticles.js
@@ -22,7 +22,7 @@ const MediaArticlesTeamArticlesComponent = ({
         <DescriptionIcon />
         <FormattedMessage
           tagName="div"
-          id="articlesSidebar.noResults"
+          id="mediaArticlesTeamArticles.noResults"
           defaultMessage="No results matched your search."
           description="Message displayed on articles sidebar when search returns no articles."
         />

--- a/src/app/components/article/MediaArticlesTeamArticles.js
+++ b/src/app/components/article/MediaArticlesTeamArticles.js
@@ -19,14 +19,13 @@ const MediaArticlesTeamArticlesComponent = ({
   <>
     { textSearch && !articles.length ? (
       <div className={cx('typography-body1', styles.articlesSidebarNoArticle)}>
-        <DescriptionIcon style={{ fontSize: 'var(--font-size-h4)' }} />
-        <div>
-          <FormattedMessage
-            id="articlesSidebar.noResults"
-            defaultMessage="No results matched your search."
-            description="Message displayed on articles sidebar when search returns no articles."
-          />
-        </div>
+        <DescriptionIcon />
+        <FormattedMessage
+          tagName="div"
+          id="articlesSidebar.noResults"
+          defaultMessage="No results matched your search."
+          description="Message displayed on articles sidebar when search returns no articles."
+        />
       </div>
     ) : null }
     <div id="articles-sidebar-team-articles" className={styles.articlesSidebarList}>


### PR DESCRIPTION
## Description

There was QA feedback from Marwa to have a better/stronger indication of article type in the list when applying to media. This PR:
- Adds the article type to the list next to the icon
- Adds the article type to the tooltip message

References: CV2-4991

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?
manual verification

## Things to pay attention to during code review

### AFTER LIST
<img width="232" alt="Screenshot 2024-07-26 at 9 31 25 AM" src="https://github.com/user-attachments/assets/7977f8a8-0adf-441a-a7f1-51237f51ef1b">

### AFTER TOOLTIP
<img width="455" alt="Screenshot 2024-07-26 at 9 31 31 AM" src="https://github.com/user-attachments/assets/7788fb72-7d7e-4805-8c61-51a68ecb8992">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
