### PR TITLE
Article review updates

### DIFF
--- a/localization/react-intl/src/app/components/article/MediaArticleCard.json
+++ b/localization/react-intl/src/app/components/article/MediaArticleCard.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "mediaArticleCard.unpublishedAlertContent",
+    "description": "Description of the alert message displayed on articles list when an unpublished claim & fact-check is added",
+    "defaultMessage": "This Fact-Check will not be returned to Tipline users until it is published"
+  },
+  {
     "id": "mediaArticleCard.factCheck",
     "description": "Title in an article card on item page.",
     "defaultMessage": "Fact-Check"
@@ -18,10 +23,5 @@
     "id": "mediaArticleCard.editButton",
     "description": "Label for edit button",
     "defaultMessage": "Edit Article"
-  },
-  {
-    "id": "mediaArticleCard.unpublishedAlertContent",
-    "description": "Description of the alert message displayed on articles list when an unpublished claim & fact-check is added",
-    "defaultMessage": "This Fact-Check will not be returned to Tipline users until it is published"
   }
 ]

--- a/src/app/components/article/MediaArticleCard.js
+++ b/src/app/components/article/MediaArticleCard.js
@@ -33,6 +33,21 @@ const MediaArticleCard = ({
 }) => (
   <div className={cx('article-card', styles.articleCard, styles.mediaArticleCardWrapper)}>
     <Card className={styles.mediaArticleCard}>
+      { variant === 'fact-check' && !publishedAt ?
+        <Alert
+          className={styles.mediaArticleCardAlert}
+          variant="warning"
+          contained
+          content={
+            <FormattedMessage
+              id="mediaArticleCard.unpublishedAlertContent"
+              defaultMessage="This Fact-Check will not be returned to Tipline users until it is published"
+              description="Description of the alert message displayed on articles list when an unpublished claim & fact-check is added"
+            />
+          }
+        />
+        : null
+      }
       <div className={styles.mediaArticleCardContent}>
         <div className={styles.mediaArticleCardDescription}>
           <div className={cx('typography-body2-bold', styles.articleCardHeader)}>
@@ -113,21 +128,6 @@ const MediaArticleCard = ({
           ),
         ]}
       />
-      { variant === 'fact-check' && !publishedAt ?
-        <Alert
-          className={styles.mediaArticleCardAlert}
-          variant="warning"
-          contained
-          content={
-            <FormattedMessage
-              id="mediaArticleCard.unpublishedAlertContent"
-              defaultMessage="This Fact-Check will not be returned to Tipline users until it is published"
-              description="Description of the alert message displayed on articles list when an unpublished claim & fact-check is added"
-            />
-          }
-        />
-        : null
-      }
     </Card>
   </div>
 );

--- a/src/app/components/media/MediaTags.js
+++ b/src/app/components/media/MediaTags.js
@@ -5,7 +5,6 @@ import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';
 import { browserHistory } from 'react-router';
 import mergeWith from 'lodash.mergewith';
-import CheckArchivedFlags from '../../CheckArchivedFlags';
 import { can } from '../Can';
 import { searchQueryFromUrl, urlFromSearchQuery } from '../search/Search';
 import TagList from '../cds/menus-lists-dialogs/TagList';
@@ -43,11 +42,7 @@ const MediaTagsComponent = ({ projectMedia, setFlashMessage }) => {
     }
   };
 
-  const readOnly =
-    !can(projectMedia.permissions, 'update ProjectMedia') ||
-    projectMedia.is_secondary ||
-    projectMedia.suggested_main_item?.dbid ||
-    projectMedia.archived === CheckArchivedFlags.TRASHED;
+  const readOnly = !can(projectMedia.permissions, 'update ProjectMedia');
 
   const onFailure = (transaction) => {
     const message = getErrorMessage(transaction, <GenericUnknownErrorMessage />);
@@ -175,8 +170,6 @@ const MediaTags = parentProps => (
       query MediaTagsQuery($ids: String!) {
         project_media(ids: $ids) {
           dbid
-          archived
-          is_secondary
           permissions
           team {
             slug
@@ -187,9 +180,6 @@ const MediaTags = parentProps => (
                 }
               }
             }
-          }
-          suggested_main_item {
-            dbid
           }
           tags(last: 100) {
             edges {


### PR DESCRIPTION
## Description

- Move the article publication status to top of card. I meant to do this in my previous PR but forgot
- Remove restrictions to tagging a media cluster, leaving only the permissions restriction

References: CV2-5000

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing

## Things to pay attention to during code review

- will add a PR comment about one this to note

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
