### PR TITLE
Refactoring the "Manage Media" button on the item page.

### DIFF
--- a/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
+++ b/localization/react-intl/src/app/components/media/Similarity/MediaSimilarityBarAdd.json
@@ -1,52 +1,22 @@
 [
   {
-    "id": "mediaSimilarityBarAdd.addSimilarToThisTitle",
-    "description": "Dialog title for importing media from other items.",
-    "defaultMessage": "Import media from other items"
+    "id": "mediaSimilarityBarAdd.mergedSuccessfully",
+    "description": "Banner displayed when items are merged successfully.",
+    "defaultMessage": "Items merged successfully."
   },
   {
-    "id": "mediaSimilarityBarAdd.addThisToSimilarTitle",
-    "description": "Dialog title for exporting media to other item.",
-    "defaultMessage": "Export all media to another item"
+    "id": "mediaSimilarityBarAdd.mergeItems",
+    "description": "Label for the Merge Items button.",
+    "defaultMessage": "Merge Items"
   },
   {
-    "id": "mediaSimilarityBarAdd.savedSuccessfully",
-    "description": "Banner displayed when similar item is added successfully",
-    "defaultMessage": "Similar item added successfully"
+    "id": "mediaSimilarityBarAdd.mergeItemsTitle",
+    "description": "Dialog title for merging items.",
+    "defaultMessage": "Find other media to merge with this item"
   },
   {
-    "id": "mediaSimilarityBarAdd.addSimilar",
-    "description": "Label to the similarity menu that allows importing and exporting media",
-    "defaultMessage": "Manage media"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.addSimilarToThis",
-    "description": "Menu item for importing (one or more) media matched as similar",
-    "defaultMessage": "Add media to this fact-check"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.exportTooltip",
-    "description": "Tooltip message for exporting media menu option",
-    "defaultMessage": "Media from this item cannot be exported if this item is attached to a main item or if its report is published"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.addThisToSimilar",
-    "description": "Menu option for exporting media from this item to another",
-    "defaultMessage": "Move all media to another fact-check"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.addToImportedReport",
-    "description": "Menu option for adding the current media to an imported fact-check",
-    "defaultMessage": "Move all media to an imported fact-check"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.addAsSimilar",
-    "description": "Button label to commit action of exporting media",
-    "defaultMessage": "Export all media"
-  },
-  {
-    "id": "mediaSimilarityBarAdd.addSimilarItem",
-    "description": "Button label to commit action of importing media from one or more items into the current one",
-    "defaultMessage": "{count, plural, one {Import all media from one item} other {Import all media from # items}}"
+    "id": "mediaSimilarityBarAdd.mergeItemsButton",
+    "description": "Button label to commit action of merging items.",
+    "defaultMessage": "{count, plural, one {Merge Selected Item} other {Merge # Selected Items}}"
   }
 ]

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -163,7 +163,7 @@ class MediaComponent extends Component {
           <React.Fragment>
             <div className={cx('media__column', styles['media-item-medias'])}>
               <div className={styles['media-item-content']}>
-                { (linkPrefix && !isSuggestedOrSimilar) ? <MediaSimilarityBar projectMedia={projectMedia} setShowTab={setShowTab} /> : null }
+                { (linkPrefix && !isSuggestedOrSimilar) ? <MediaSimilarityBar projectMedia={projectMedia} /> : null }
                 { this.state.openMediaDialog ?
                   <MediaAndRequestsDialogComponent
                     projectMediaId={projectMedia.dbid}

--- a/src/app/components/media/Similarity/MediaSimilarityBar.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBar.js
@@ -6,7 +6,7 @@ import { QueryRenderer, graphql } from 'react-relay/compat';
 import MediaSimilarityBarComponent from './MediaSimilarityBarComponent';
 import { can } from '../../Can';
 
-const MediaSimilarityBar = ({ projectMedia, setShowTab }) => {
+const MediaSimilarityBar = ({ projectMedia }) => {
   const ids = `${projectMedia.dbid},0,${projectMedia.team.dbid}`; // Project ID doesn't matter
 
   return (
@@ -75,9 +75,6 @@ const MediaSimilarityBar = ({ projectMedia, setShowTab }) => {
               hasMain={props.project_media.hasMain}
               confirmedMainItemId={props.project_media.confirmedMainItem.id}
               canAdd={can(props.project_media.permissions, 'update ProjectMedia')}
-              isBlank={props.project_media.type === 'Blank'}
-              isPublished={props.project_media.report_status === 'published'}
-              setShowTab={setShowTab}
             />
           );
         }
@@ -94,7 +91,6 @@ MediaSimilarityBar.propTypes = {
       dbid: PropTypes.number.isRequired,
     }).isRequired,
   }).isRequired,
-  setShowTab: PropTypes.func.isRequired, // React useState setter
 };
 
 export default MediaSimilarityBar;

--- a/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilarityBarComponent.js
@@ -21,8 +21,6 @@ const MediaSimilarityBarComponent = ({
   hasMain,
   confirmedMainItemId,
   canAdd,
-  isBlank,
-  isPublished,
 }) => {
   const classes = useStyles();
 
@@ -41,9 +39,7 @@ const MediaSimilarityBarComponent = ({
           <MediaSimilarityBarAdd
             projectMediaId={confirmedMainItemId}
             projectMediaDbid={projectMediaDbid}
-            canBeAddedToSimilar={!hasMain && !isPublished}
-            similarCanBeAddedToIt={!hasMain}
-            canBeAddedToImported={!isBlank}
+            canMerge={!hasMain}
           /> : null }
       </Box>
     </Box>
@@ -54,8 +50,6 @@ MediaSimilarityBarComponent.defaultProps = {
   confirmedMainItemId: null,
   hasMain: false,
   canAdd: false,
-  isBlank: false,
-  isPublished: false,
 };
 
 MediaSimilarityBarComponent.propTypes = {
@@ -64,8 +58,6 @@ MediaSimilarityBarComponent.propTypes = {
   hasMain: PropTypes.bool,
   confirmedMainItemId: PropTypes.string, // GraphQL base64 ID
   canAdd: PropTypes.bool,
-  isBlank: PropTypes.bool,
-  isPublished: PropTypes.bool,
 };
 
 export default MediaSimilarityBarComponent;

--- a/test/spec/similarity_spec.rb
+++ b/test/spec/similarity_spec.rb
@@ -3,7 +3,6 @@ shared_examples 'similarity' do
     api_create_team_claims_sources_and_redirect_to_all_items({ count: 3 })
     verbose_wait 2 # Wait for the items to be indexed in ElasticSearch
     wait_for_selector('.search__results-heading')
-    all_items_url = @driver.current_url.to_s
     wait_for_selector('.cluster-card').click
     wait_for_selector('#media-similarity__add-button').click
 

--- a/test/spec/similarity_spec.rb
+++ b/test/spec/similarity_spec.rb
@@ -12,15 +12,6 @@ shared_examples 'similarity' do
     wait_for_selector('.media__relationship')
     expect(@driver.find_elements(:css, '.media__relationship').size).to eq 1
     expect(@driver.page_source.include?('Media')).to be(true)
-    @driver.navigate.to all_items_url
-    wait_for_selector('.search__results-heading')
-    wait_for_selector_list('.cluster-card').last.click
-
-    # List similar items
-    wait_for_selector('.media__relationship')
-    wait_for_selector_none('.media-tab__metadata"')
-    expect(@driver.find_elements(:css, '.media__relationship').size).to eq 2
-    expect(@driver.page_source.include?('Media')).to be(true)
   end
 
   it 'should pin and remove similarity items', bin4: true do

--- a/test/spec/similarity_spec.rb
+++ b/test/spec/similarity_spec.rb
@@ -1,13 +1,13 @@
 shared_examples 'similarity' do
   it 'should import and export items', bin4: true do
     api_create_team_claims_sources_and_redirect_to_all_items({ count: 3 })
-    verbose_wait 2 # wait for the items to be indexed in the Elasticsearch
+    verbose_wait 2 # Wait for the items to be indexed in ElasticSearch
     wait_for_selector('.search__results-heading')
     all_items_url = @driver.current_url.to_s
     wait_for_selector('.cluster-card').click
     wait_for_selector('#media-similarity__add-button').click
-    # import similarity item
-    wait_for_selector('#import-fact-check__button').click
+
+    # Merge similar items
     add_related_item('Claim 0')
     wait_for_selector('.media__relationship')
     expect(@driver.find_elements(:css, '.media__relationship').size).to eq 1
@@ -15,13 +15,8 @@ shared_examples 'similarity' do
     @driver.navigate.to all_items_url
     wait_for_selector('.search__results-heading')
     wait_for_selector_list('.cluster-card').last.click
-    # export similarity item
-    wait_for_selector('#media-similarity__add-button').click
-    wait_for_selector('#export-fact-check__button').click
-    add_related_item('Claim 2')
-    wait_for_selector('.media-similarity__menu-icon')
-    expect(@driver.page_source.include?('Media')).to be(true)
-    # list similar items
+
+    # List similar items
     wait_for_selector('.media__relationship')
     wait_for_selector_none('.media-tab__metadata"')
     expect(@driver.find_elements(:css, '.media__relationship').size).to eq 2


### PR DESCRIPTION
## Description

Replace the "Manage Media" drop-down by a single "Merge Items" buttons, with copy changes.

Reference: CV2-5014.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Things to pay attention to during code review

![CV2-5014-2-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4132d3ea-f552-4848-971f-8bdd19b5666f)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)