### PR TITLE
Show lock icon in status select component when changing status is not…

### DIFF
--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -61,6 +61,7 @@ const ArticleForm = ({
   const isPublished = article.report_status === 'published';
   const readOnly = isPublished;
   const publishedAt = isPublished ? article.updated_at : null;
+  const isStatusLocked = article.claim_description?.project_media?.last_status_obj?.locked || false;
 
   React.useEffect(() => {
     setLanguage(language || defaultArticleLanguage);
@@ -144,7 +145,7 @@ const ArticleForm = ({
               <div className={styles['article-rating-wrapper']}>
                 { articleType === 'fact-check' && statuses &&
                   <RatingSelector
-                    disabled={isPublished}
+                    disabled={isPublished || isStatusLocked}
                     status={status}
                     statuses={statuses}
                     onStatusChange={handleStatusChange}
@@ -581,6 +582,9 @@ export default createFragmentContainer(ArticleForm, graphql`
         context
         project_media {
           dbid
+          last_status_obj {
+            locked
+          }
         }
       }
     }

--- a/src/app/components/cds/inputs/RatingSelector.js
+++ b/src/app/components/cds/inputs/RatingSelector.js
@@ -8,6 +8,7 @@ import ChatBubbleIcon from '../../../icons/chat_bubble.svg';
 import ChatBubbleFilledIcon from '../../../icons/chat_bubble_filled.svg';
 import ChevronDownIcon from '../../../icons/chevron_down.svg';
 import EllipseIcon from '../../../icons/ellipse.svg';
+import LockIcon from '../../../icons/lock.svg';
 import styles from './RatingSelector.module.css';
 
 const RatingSelector = ({
@@ -41,7 +42,7 @@ const RatingSelector = ({
         size="default"
         onClick={e => setAnchorEl(e.currentTarget)}
         iconLeft={currentStatus.should_send_message ? <ChatBubbleFilledIcon style={{ color: currentStatus?.style?.color }} /> : <EllipseIcon style={{ color: currentStatus?.style?.color }} />}
-        iconRight={<ChevronDownIcon />}
+        iconRight={!disabled ? <ChevronDownIcon /> : <LockIcon style={{ color: currentStatus?.style?.color }} />}
         label={currentStatus.label}
       />
       <Popover

--- a/src/app/components/media/MediaStatusCommon.js
+++ b/src/app/components/media/MediaStatusCommon.js
@@ -33,7 +33,7 @@ class MediaStatusCommon extends Component {
   state = {};
 
   canUpdate() {
-    return (!this.props.readonly && can(this.props.media.permissions || '{}', 'update Status'))
+    return (!this.props.readonly && can(this.props.media.permissions || '{}', 'update Status') && !this.props.media.last_status_obj?.locked)
       || this.props.quickAdd;
   }
 


### PR DESCRIPTION
… allowed

## Description

- Fetch and evaluate `project_media.last_status_obj.locked` in article form
- Update RatingSelector to display lock icon if disabled
- Also update `MediaStatusCommon` as I noticed the Report editor was inconsistently allowing changing status when media status is locked

References: TICKET-ID-1, TICKET-ID-2, …, TICKET-ID-N

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually

## Things to pay attention to during code review

I also made sure `MediaStatusCommon` is always consistent if `project_media.last_status_obj.locked`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
