### PR TITLE
Fixing two auto-refresh issues.

### DIFF
--- a/src/app/components/article/RemoveArticleButton.js
+++ b/src/app/components/article/RemoveArticleButton.js
@@ -28,6 +28,15 @@ const removeClaimDescriptionMutation = graphql`
   mutation RemoveArticleButtonUpdateClaimDescriptionMutation($input: UpdateClaimDescriptionInput!) {
     updateClaimDescription(input: $input) {
       claim_description {
+        project_media_was {
+          title
+          claim_description {
+            description
+            fact_check {
+              title
+            }
+          }
+        }
         project_media {
           articles_count
           report_status

--- a/src/app/relay/mutations/UpdateStatusMutation.js
+++ b/src/app/relay/mutations/UpdateStatusMutation.js
@@ -27,6 +27,9 @@ class UpdateStatusMutation extends Relay.Mutation {
           last_status
           last_status_obj
           dynamic_annotation_report_design
+          fact_check {
+            rating
+          }
         }
       }`;
     default:
@@ -45,6 +48,9 @@ class UpdateStatusMutation extends Relay.Mutation {
           last_status_obj: {
             id: this.props.annotation.status_id,
             content: JSON.stringify(optimisticContent),
+          },
+          fact_check: {
+            rating: this.props.annotation.status,
           },
         },
       };


### PR DESCRIPTION
## Description

(1) Auto-refresh fact-check rating when item status is updated.

(2) Auto-refresh item title when fact-check is removed after updating the claim title.

Reference: CV2-5000.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Things to pay attention to during code review

Depends on Check API branch of the same name.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
