### PR TITLE
Fixing "bug 13" and "bug 19" (details below)

### DIFF
--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -15,7 +15,7 @@ const MediaArticlesDisplay = ({ projectMedia, onUpdate }) => {
   const explainerItems = projectMedia.explainer_items.edges.map(edge => edge.node);
   const hasExplainer = (explainerItems.length > 0);
   const factCheck = projectMedia.fact_check;
-  const hasFactCheck = Boolean(factCheck);
+  const hasFactCheck = (factCheck && factCheck.id);
   let publishedAt = null; // FIXME: It would be better if it came from the backend
   if (hasFactCheck && factCheck.report_status === 'published') {
     publishedAt = projectMedia.fact_check_published_on;

--- a/src/app/components/media/ItemTitle.js
+++ b/src/app/components/media/ItemTitle.js
@@ -40,7 +40,7 @@ const ItemTitleComponent = ({
   const fallbackTitle = claimTitle || factCheckTitle || projectMedia.title;
 
   React.useEffect(() => {
-    if ((titleField === 'claim_title' && claimTitle === '') || (titleField === 'fact_check_title' && factCheckTitle === '')) {
+    if ((titleField === 'claim_title' && !claimTitle) || (titleField === 'fact_check_title' && !factCheckTitle)) {
       setTitleField('custom_title');
       setCustomTitle(projectMedia.title);
     } else if (!titleField) {


### PR DESCRIPTION
## Description

- Bug 13: Auto-refresh the item title fields when the title field is "claim title" and the fact-check is removed from an item
- Bug 19: Make sure that the application doesn't crash when the item status is changed and the item has explainers but no fact-check (the issue was related to the optimistic response)

Reference: CV2-5000.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually (see description).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)