### PR TITLE
Fix crash in shared feed when project media team is null; Add ErrorBo…

### DIFF
--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -21,6 +21,7 @@ import PenderCard from '../PenderCard';
 import AspectRatio from '../layout/AspectRatio'; // eslint-disable-line no-unused-vars
 import { getMediaType } from '../../helpers';
 import styles from './media.module.css';
+import ErrorBoundary from '../error/ErrorBoundary';
 
 const MediaCardLarge = ({
   inModal,
@@ -168,31 +169,33 @@ const MediaCardLargeContainer = createFragmentContainer(MediaCardLarge, graphql`
 `);
 
 const MediaCardLargeQueryRenderer = ({ projectMediaId }) => (
-  <QueryRenderer
-    environment={Relay.Store}
-    query={graphql`
-      query MediaCardLargeQuery($ids: String!) {
-        project_media(ids: $ids) {
-          ...MediaCardLarge_projectMedia
+  <ErrorBoundary component="MediaCardLargeQueryRenderer">
+    <QueryRenderer
+      environment={Relay.Store}
+      query={graphql`
+        query MediaCardLargeQuery($ids: String!) {
+          project_media(ids: $ids) {
+            ...MediaCardLarge_projectMedia
+          }
         }
-      }
-    `}
-    variables={{
-      ids: `${projectMediaId},,`,
-    }}
-    render={({ error, props }) => {
-      if (!error && !props) {
-        return (<MediasLoading theme="grey" variant="inline" size="small" />);
-      }
+      `}
+      variables={{
+        ids: `${projectMediaId},,`,
+      }}
+      render={({ error, props }) => {
+        if (!error && !props) {
+          return (<MediasLoading theme="grey" variant="inline" size="small" />);
+        }
 
-      if (!error && props) {
-        return <MediaCardLargeContainer inModal projectMedia={props.project_media} />;
-      }
+        if (!error && props) {
+          return <MediaCardLargeContainer inModal projectMedia={props.project_media} />;
+        }
 
-      // TODO: We need a better error handling in the future, standardized with other components
-      return null;
-    }}
-  />
+        // TODO: We need a better error handling in the future, standardized with other components
+        return null;
+      }}
+    />
+  </ErrorBoundary>
 );
 
 export default MediaCardLargeContainer;

--- a/src/app/components/media/WebPageMediaCard.js
+++ b/src/app/components/media/WebPageMediaCard.js
@@ -15,7 +15,7 @@ class WebPageMediaCard extends Component {
     const { projectMedia: { team }, projectMedia: { media: { metadata } } } = this.props;
     const embed = metadata;
     if (!embed.html) return false;
-    if (!team.get_embed_whitelist) return false;
+    if (!team?.get_embed_whitelist) return false;
     return team.get_embed_whitelist.split(',').some((domain) => {
       const url = new URL(embed.url);
       return url.hostname.indexOf(domain.trim()) > -1;


### PR DESCRIPTION
…undary

## Description

Fixes crash in shared feed when project media team is null.
Alsso add `ErrorBoundary` around `MediaCardLargeQueryRenderer`.

This was a permissions issue when a user attempted to load a webpage type media from a shared feed.

References: CV2-5047

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

See CV2-5047 for reproduction steps.
Reproduced the issue manually locally. Verified that being an Check admin the issue doesn't happen.
Also verified that the applied fix stopped the issue for non-Check-admin and non-members of the media-owning-team.

## Things to pay attention to during code review

The fragment for `WebPageMediaCard` queries `team` from `project_media` which the current user cannot read if not a member of the peroject_media-owning team. This is another indication that fragmentContainers should be probably context-specific.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
