### PR TITLE
Use a different field to get the total number of workspaces that a user belons to

### DIFF
--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -216,7 +216,7 @@ const PaginatedUserWorkspaces = createPaginationContainer(
   props => (
     <UserWorkspacesComponent
       currentTeam={props.root.current_team_id}
-      numberOfTeams={props.root.number_of_teams}
+      numberOfTeams={props.root.team_users_count}
       pageSize={props.pageSize}
       relay={props.relay}
       teams={props.root.team_users.edges.map(n => n.node.team) || []}
@@ -226,8 +226,8 @@ const PaginatedUserWorkspaces = createPaginationContainer(
   {
     root: graphql`
       fragment PaginatedUserWorkspaces_root on Me {
-        number_of_teams
         current_team_id
+        team_users_count(status: "member")
         team_users(first: $pageSize, after: $after, status: "member") @connection(key: "PaginatedUserWorkspaces_team_users"){
           edges {
             node {


### PR DESCRIPTION
## Description

Use a different field to get the total number of workspaces that a user belons to.

Fixes CV2-4938.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Things to pay attention to during code review

Requires the Check API branch with the same name as this one.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)