### PR TITLE
Fix flaky test

### DIFF
--- a/test/spec/source_spec.rb
+++ b/test/spec/source_spec.rb
@@ -74,7 +74,10 @@ shared_examples 'source' do
     @driver.action.send_keys(:enter).perform
     wait_for_selector('#source_primary__link-input').send_keys('https://www.bbc.com/portuguese')
     wait_for_selector('.source__edit-save-button').click
-    wait_for_selector_none('.source__edit-cancel-button')
+    @driver.navigate.refresh
+    wait_for_selector('.media-card-large')
+    wait_for_selector('.media-tab__source').click
+    wait_for_selector('#source__name-input')
     expect(wait_for_selector('.source__name').text == 'BBC').to be(true)
     expect(wait_for_selector('#main_source__link').attribute('value') == 'https://www.bbc.com/portuguese').to be(true)
   end


### PR DESCRIPTION
## Description

Try to fix the source flaky test by refreshing the page, looks like sometimes the source information was not being displayed without a refresh on the tests

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
