### PR TITLE
Use a different GraphQL field for the list of workspaces.

### DIFF
--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -216,28 +216,26 @@ const PaginatedUserWorkspaces = createPaginationContainer(
   props => (
     <UserWorkspacesComponent
       currentTeam={props.root.current_team_id}
-      numberOfTeams={props.root.team_users_count}
+      numberOfTeams={props.root.accessible_teams_count}
       pageSize={props.pageSize}
       relay={props.relay}
-      teams={props.root.team_users.edges.map(n => n.node.team) || []}
-      totalCount={props.root.team_users?.totalCount}
+      teams={props.root.accessible_teams.edges.map(edge => edge.node) || []}
+      totalCount={props.root.accessible_teams?.totalCount}
     />
   ),
   {
     root: graphql`
       fragment PaginatedUserWorkspaces_root on Me {
         current_team_id
-        team_users_count(status: "member")
-        team_users(first: $pageSize, after: $after, status: "member") @connection(key: "PaginatedUserWorkspaces_team_users"){
+        accessible_teams_count
+        accessible_teams(first: $pageSize, after: $after) @connection(key: "PaginatedUserWorkspaces_accessible_teams") {
           edges {
             node {
-              team {
-                dbid
-                name
-                avatar
-                slug
-                members_count
-              }
+              dbid
+              name
+              avatar
+              slug
+              members_count
             }
           }
           pageInfo {
@@ -252,7 +250,7 @@ const PaginatedUserWorkspaces = createPaginationContainer(
   {
     direction: 'forward',
     query: userWorkspacesQuery,
-    getConnectionFromProps: props => props.root.team_users,
+    getConnectionFromProps: props => props.root.accessible_teams,
     getFragmentVariables: (previousVars, pageSize) => ({
       ...previousVars,
       pageSize,


### PR DESCRIPTION
## Description

This new field returns `TeamType` objects and different behaviors for super-admins and non-super-admins.

References: CV2-4938 and CV2-4704.

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

The behavior should be the same for non-super-admins. For super-admins, it should list all workspaces.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
