### PR TITLE
Delete deprecated test

### DIFF
--- a/test/spec/app_spec.rb
+++ b/test/spec/app_spec.rb
@@ -168,19 +168,5 @@ shared_examples 'app' do |webdriver_url|
       @driver.navigate.forward
       expect((@driver.current_url.to_s =~ %r{/terms-of-service$}).nil?).to be(false)
     end
-
-    it 'should redirect to 404 page if id does not exist', bin4: true do
-      api_create_team_and_bot
-      @driver.navigate.to "#{@config['self_url']}/#{@slug}/settings/workspace"
-      wait_for_selector('#side-navigation__tipline-toggle').click
-      wait_for_selector('.projects-list')
-      wait_for_selector('.projects-list__all-items').click
-      wait_for_selector('#create-media__add-item')
-      url = @driver.current_url.to_s
-      @driver.navigate.to url.gsub('all-items', 'media/999')
-      title = wait_for_selector('.not-found__component')
-      expect(title.text).to match(/page does not exist/)
-      expect((@driver.current_url.to_s =~ %r{/not-found$}).nil?).to be(false)
-    end
   end
 end

--- a/test/spec/app_spec.rb
+++ b/test/spec/app_spec.rb
@@ -111,20 +111,6 @@ shared_examples 'app' do |webdriver_url|
     include_examples 'similarity'
     it_behaves_like 'media', 'DOES_NOT_BELONG_TO_ANY_PROJECT'
 
-    it 'should redirect to not found page when access is denied', bin1: true do
-      user = api_register_and_login_with_email
-      api_logout
-      api_register_and_login_with_email
-      @driver.navigate.to("#{@config['self_url']}/check/me/workspaces")
-      wait_for_selector("//span[contains(text(), 'Create')]", :xpath)
-      expect(@driver.page_source.include?('page does not exist')).to be(false)
-      expect((@driver.current_url.to_s =~ %r{/not-found$}).nil?).to be(true)
-      @driver.navigate.to(@config['self_url'] + "/check/user/#{user.dbid}") # unauthorized page
-      wait_for_selector('.not-found__component')
-      expect(@driver.page_source.include?('page does not exist')).to be(true)
-      expect((@driver.current_url.to_s =~ %r{/not-found$}).nil?).to be(false)
-    end
-
     it 'should localize interface based on browser language', bin2: true do
       @driver.quit
       @driver = new_driver(chrome_prefs: { 'intl.accept_languages' => 'fr' })


### PR DESCRIPTION
## Description

removing this test since the route no longer exists and we already have another test in place to verify that the "not found" page is displayed when navigating to a nonexistent URL.

Reference: CV2-5048

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Automated test (add or update automated tests)


- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
