### PR TITLE
Updating the logic to define which tab to show as enabled first in the item page

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -22,6 +22,38 @@ import PageTitle from '../PageTitle';
 import { withPusher, pusherShape } from '../../pusher';
 import styles from './media.module.css';
 
+const setInitialTab = (projectMedia) => {
+  let initialTab = 'articles';
+  const articlesCount = projectMedia.articles_count;
+  const suggestionsCount = projectMedia.suggested_similar_items_count;
+  const requestsCount = projectMedia.requests_count;
+
+  if (articlesCount === 0 && requestsCount === 0 && suggestionsCount === 0) {
+    initialTab = 'articles';
+  }
+
+  if (articlesCount >= 1 && requestsCount >= 0 && suggestionsCount === 0) {
+    initialTab = 'articles';
+  }
+
+  if (articlesCount === 0 && requestsCount >= 1 && suggestionsCount === 0) {
+    initialTab = 'requests';
+  }
+
+  if (articlesCount >= 1 && requestsCount >= 0 && suggestionsCount >= 1) {
+    initialTab = 'suggestions';
+  }
+
+  if (articlesCount === 0 && requestsCount === 0 && suggestionsCount >= 1) {
+    initialTab = 'suggestions';
+  }
+
+  return initialTab;
+};
+
+// eslint-disable-next-line import/no-unused-modules
+export { setInitialTab }; // For unit test
+
 class MediaComponent extends Component {
   static handleSuperAdminMaskSession(value) {
     sessionStorage.setItem('superAdminMaskSession', value);
@@ -30,22 +62,7 @@ class MediaComponent extends Component {
   constructor(props) {
     super(props);
 
-    const { team_bots: teamBots } = this.props.projectMedia.team;
-    const enabledBots = teamBots.edges.map(b => b.node.login);
-    const showRequests = (enabledBots.indexOf('smooch') > -1 || this.props.projectMedia.requests_count > 0);
-
-    let initialTab = 'metadata';
-    if (showRequests && this.props.view !== 'similarMedia') {
-      initialTab = 'articles';
-      if (this.props.projectMedia.suggested_similar_items_count > 0 && !this.props.projectMedia.is_suggested) {
-        initialTab = 'suggestedMedia';
-      }
-    } else if (this.props.view === 'similarMedia') {
-      initialTab = 'suggestedMedia';
-    }
-    if (this.props.projectMedia.is_suggested || this.props.projectMedia.is_confirmed_similar_to_another_item) {
-      initialTab = 'requests';
-    }
+    const initialTab = setInitialTab(this.props.projectMedia);
 
     this.state = {
       showTab: initialTab,

--- a/src/app/components/media/MediaComponent.test.js
+++ b/src/app/components/media/MediaComponent.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { setInitialTab } from './MediaComponent';
 
 describe('<MediaComponent />', () => {

--- a/src/app/components/media/MediaComponent.test.js
+++ b/src/app/components/media/MediaComponent.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { setInitialTab } from './MediaComponent';
+
+describe('<MediaComponent />', () => {
+  it('should have the initial tab as Articles for new items', () => {
+    const projectMedia = {
+      articles_count: 0,
+      requests_count: 0,
+      suggested_similar_items_count: 0,
+    };
+    const initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('articles');
+  });
+
+  it('should have the initial tab as Articles when there is article applied but no suggestions', () => {
+    const projectMedia = {
+      articles_count: 1,
+      requests_count: 0,
+      suggested_similar_items_count: 0,
+    };
+    let initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('articles');
+    projectMedia.requests_count = 5;
+    initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('articles');
+  });
+
+  it('should have the initial tab as Requests for items with requests but no articles and no suggestions', () => {
+    const projectMedia = {
+      articles_count: 0,
+      requests_count: 1,
+      suggested_similar_items_count: 0,
+    };
+    const initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('requests');
+  });
+
+  it('should have the initial tab as Suggestions for items with suggestions and articles', () => {
+    const projectMedia = {
+      articles_count: 1,
+      requests_count: 1,
+      suggested_similar_items_count: 1,
+    };
+    const initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('suggestions');
+  });
+
+  it('should have the initial tab as Suggestions for items with suggestions and no articles', () => {
+    const projectMedia = {
+      articles_count: 0,
+      requests_count: 0,
+      suggested_similar_items_count: 1,
+    };
+    const initialTab = setInitialTab(projectMedia);
+    expect(initialTab).toBe('suggestions');
+  });
+});


### PR DESCRIPTION
## Description

* Articles: If there are no requests, suggestions and articles; or if there are articles and no suggestions.
* Requests: No article, no suggestion and one or more requests.
* Suggestions: If there are suggestions.

Includes unit tests.

Fixes CV2-5133.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Added unit tests for all cases.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
