### PR TITLE
Display "Media Cluster" link in the fact-check slideout for fact-checks that are applied to media clusters

### DIFF
--- a/localization/react-intl/src/app/components/article/ArticleForm.json
+++ b/localization/react-intl/src/app/components/article/ArticleForm.json
@@ -30,6 +30,11 @@
     "defaultMessage": "Last Published:"
   },
   {
+    "id": "articleForm.mediaCluster",
+    "description": "Label for the link to the media cluster that this fact-check is applied to.",
+    "defaultMessage": "Media Cluster:"
+  },
+  {
     "id": "articleForm.reportDesignerTooltip",
     "description": "Tooltip for the report designer button",
     "defaultMessage": "Assign this Fact Check to a media item to be able to edit and publish a report"
@@ -80,9 +85,9 @@
     "defaultMessage": "Fact-check"
   },
   {
-    "id": "articleForm.reportPublishedTitle",
-    "description": "Title of alert box in article form.",
-    "defaultMessage": "Report is published"
+    "id": "articleForm.reportPublishedLabel",
+    "description": "Label of alert button in article form.",
+    "defaultMessage": "Update Report"
   },
   {
     "id": "articleForm.reportPublishedBody",
@@ -90,9 +95,9 @@
     "defaultMessage": "To make edits, pause this report. This will stop the report from being sent out to users until it is published again"
   },
   {
-    "id": "articleForm.reportPublishedLabel",
-    "description": "Label of alert button in article form.",
-    "defaultMessage": "Update Report"
+    "id": "articleForm.reportPublishedTitle",
+    "description": "Title of alert box in article form.",
+    "defaultMessage": "Report is published"
   },
   {
     "id": "articleForm.explainerTitleInputPlaceholder",

--- a/src/app/components/ExternalLink.js
+++ b/src/app/components/ExternalLink.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { truncateLength } from '../helpers';
@@ -9,10 +8,13 @@ const ExternalLink = ({
   maxUrlLength,
   readable,
   style,
+  title,
   url,
 }) => {
   let displayUrl = url;
-  if (readable) {
+  if (title) {
+    displayUrl = title;
+  } else if (readable) {
     displayUrl = displayUrl.replace(/^https?:\/\/(www\.)?/, '');
   }
   displayUrl = maxUrlLength ? truncateLength(displayUrl, maxUrlLength) : displayUrl;
@@ -26,17 +28,19 @@ const ExternalLink = ({
 
 ExternalLink.propTypes = {
   children: PropTypes.node,
-  url: PropTypes.string.isRequired,
   maxUrlLength: PropTypes.number,
-  style: PropTypes.object,
   readable: PropTypes.bool,
+  style: PropTypes.object,
+  title: PropTypes.string,
+  url: PropTypes.string.isRequired,
 };
 
 ExternalLink.defaultProps = {
-  style: {},
   children: null,
   maxUrlLength: null,
   readable: false,
+  style: {},
+  title: null,
 };
 
 export default ExternalLink;

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -17,6 +17,7 @@ import inputStyles from '../../styles/css/inputs.module.css';
 import { safelyParseJSON, truncateLength } from '../../helpers';
 import RatingSelector from '../cds/inputs/RatingSelector';
 import Alert from '../cds/alerts-and-prompts/Alert.js';
+import ExternalLink from '../ExternalLink';
 import styles from './ArticleForm.module.css';
 
 const ArticleForm = ({
@@ -126,6 +127,15 @@ const ArticleForm = ({
                       />
                     </div>
                   }
+                  { articleType === 'fact-check' && article.claim_description?.project_media && article.claim_description?.project_media?.type !== 'Blank' &&
+                    <div className="typography-subtitle2">
+                      <FormattedMessage
+                        defaultMessage="Media Cluster:"
+                        description="Label for the link to the media cluster that this fact-check is applied to."
+                        id="articleForm.mediaCluster"
+                      />
+                    </div>
+                  }
                 </div>
                 <div className={styles['article-form-info-content']}>
                   { article.updated_at &&
@@ -136,6 +146,11 @@ const ArticleForm = ({
                   { publishedAt && articleType === 'fact-check' &&
                     <div className="typography-body2">
                       <FormattedDate day="numeric" month="long" value={new Date(publishedAt * 1000)} year="numeric" />
+                    </div>
+                  }
+                  { articleType === 'fact-check' && article.claim_description?.project_media && article.claim_description?.project_media?.type !== 'Blank' &&
+                    <div className="typography-body2">
+                      <ExternalLink maxUrlLength={50} title={article.claim_description?.project_media.title} url={article.claim_description?.project_media.full_url} />
                     </div>
                   }
                 </div>
@@ -583,6 +598,9 @@ export default createFragmentContainer(ArticleForm, graphql`
         context
         project_media {
           dbid
+          title
+          type
+          full_url
           last_status_obj {
             locked
           }


### PR DESCRIPTION
## Description

Display "Media Cluster" link in the fact-check slideout for fact-checks that are applied to media clusters.

Reference: CV2-4902.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually.

## Things to pay attention to during code review

![Captura de tela de 2024-08-27 11-29-19](https://github.com/user-attachments/assets/0f932b54-2d83-4d7d-822c-3b47688fd3ae)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 