### PR TITLE
Fixing typo: Tab key is "suggestedMedia", not "suggestions".

### DIFF
--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -41,11 +41,11 @@ const setInitialTab = (projectMedia) => {
   }
 
   if (articlesCount >= 1 && requestsCount >= 0 && suggestionsCount >= 1) {
-    initialTab = 'suggestions';
+    initialTab = 'suggestedMedia';
   }
 
   if (articlesCount === 0 && requestsCount === 0 && suggestionsCount >= 1) {
-    initialTab = 'suggestions';
+    initialTab = 'suggestedMedia';
   }
 
   return initialTab;

--- a/src/app/components/media/MediaComponent.test.js
+++ b/src/app/components/media/MediaComponent.test.js
@@ -41,7 +41,7 @@ describe('<MediaComponent />', () => {
       suggested_similar_items_count: 1,
     };
     const initialTab = setInitialTab(projectMedia);
-    expect(initialTab).toBe('suggestions');
+    expect(initialTab).toBe('suggestedMedia');
   });
 
   it('should have the initial tab as Suggestions for items with suggestions and no articles', () => {
@@ -51,6 +51,6 @@ describe('<MediaComponent />', () => {
       suggested_similar_items_count: 1,
     };
     const initialTab = setInitialTab(projectMedia);
-    expect(initialTab).toBe('suggestions');
+    expect(initialTab).toBe('suggestedMedia');
   });
 });


### PR DESCRIPTION
## Description

Fixing typo: Tab key is "suggestedMedia", not "suggestions".

Fixes CV2-5133.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Unit tests updated accordingly.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
