### PR TITLE
minor search style alignment for articles [CV2-5053]

### DIFF
--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
-import cx from 'classnames/bind';
 import ArticleFilters from './ArticleFilters';
 import { ClaimFactCheckFormQueryRenderer } from './ClaimFactCheckForm';
 import { ExplainerFormQueryRenderer } from './ExplainerForm';
@@ -24,7 +23,6 @@ import {
 } from '../../urlHelpers';
 import MediasLoading from '../media/MediasLoading';
 import PageTitle from '../PageTitle';
-import styles from './Articles.module.css';
 import searchStyles from '../search/search.module.css';
 import searchResultsStyles from '../search/SearchResults.module.css';
 
@@ -138,22 +136,24 @@ const ArticlesComponent = ({
   return (
     <PageTitle prefix={title} teamName={team.name}>
       <div className={searchResultsStyles['search-results-header']}>
-        <div className={searchResultsStyles.searchResultsTitleWrapper}>
-          <div className={searchResultsStyles.searchHeaderSubtitle}>
-            &nbsp;
-          </div>
-          <div className={cx(searchResultsStyles.searchHeaderTitle, styles.articlesHeader)}>
-            <h6>
-              {icon}
-              {title}
-            </h6>
-            <div>
-              <SearchField
-                handleClear={() => { handleChangeFilters({ ...filters, text: null }); }}
-                searchText={filters.text}
-                setParentSearchText={(text) => { handleChangeFilters({ ...filters, text }); }}
-              />
+        <div className="search__list-header-filter-row">
+          <div className={searchResultsStyles.searchResultsTitleWrapper}>
+            <div className={searchResultsStyles.searchHeaderSubtitle}>
+              &nbsp;
             </div>
+            <div className={searchResultsStyles.searchHeaderTitle}>
+              <h6>
+                {icon}
+                {title}
+              </h6>
+            </div>
+          </div>
+          <div className={searchStyles['search-form']}>
+            <SearchField
+              handleClear={() => { handleChangeFilters({ ...filters, text: null }); }}
+              searchText={filters.text}
+              setParentSearchText={(text) => { handleChangeFilters({ ...filters, text }); }}
+            />
           </div>
         </div>
       </div>

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -141,9 +141,3 @@
     }
   }
 }
-
-.articlesHeader {
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-}


### PR DESCRIPTION
## Description

Just a small PR to align the css classes from the tipline lists to articles list, now that there is search we don't need specific styles for articles and can reuse classes from the tipline lists

References: CV2-5053

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual verification

## Things to pay attention to during code review

The search box gets a little larger because now it matches the space used in the tipline area:
<img width="1773" alt="Screenshot 2024-08-30 at 10 19 08 PM" src="https://github.com/user-attachments/assets/588451b8-3fe6-42cb-96bf-d3b6a82e4ada">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
