### PR TITLE
Fixing status value used in report introduction preview.

### DIFF
--- a/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerPreview.js
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import ReportDesignerImagePreview from './ReportDesignerImagePreview';
 import { formatDate } from './reportDesignerHelpers';
+import { getStatus } from '../../../helpers';
 import WarningIcon from '../../../icons/report_problem.svg';
 import ParsedText from '../../ParsedText';
 
@@ -73,7 +74,18 @@ function previewIntroduction(data, media, defaultReport) {
     } else {
       introduction = introduction.replace(/{{query_date}}/g, formatDate(new Date(), data.language));
     }
-    introduction = introduction.replace(/{{status}}/g, data.status_label);
+    let status = null;
+    try {
+      status = getStatus(
+        media.team.verification_statuses,
+        media.last_status,
+        data.language,
+        media.team.language,
+      ).label;
+    } catch {
+      status = data.status_label;
+    }
+    introduction = introduction.replace(/{{status}}/g, status);
   }
   return introduction;
 }


### PR DESCRIPTION
## Description

In the report designer page, use the item status (not the customized report status label) when previewing the report introduction. This is consistent with what the backend does.

Fixes CV2-5187.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually: Changing the item status in the report designer page should reflect correctly in the introduction preview.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 