### PR TITLE
fix/cv2-5174 add search score dropdown option

### DIFF
--- a/localization/react-intl/src/app/components/cds/inputs/ListSort.json
+++ b/localization/react-intl/src/app/components/cds/inputs/ListSort.json
@@ -40,6 +40,11 @@
     "defaultMessage": "Report (status)"
   },
   {
+    "id": "searchResults.sortScore",
+    "description": "Label for sort criteria option displayed in a drop-down in listing pages",
+    "defaultMessage": "Search: Best Match"
+  },
+  {
     "id": "searchResults.sortSubmitted",
     "description": "Label for sort criteria option displayed in a drop-down in listing pages",
     "defaultMessage": "Submitted (date)"

--- a/src/app/components/cds/inputs/ListSort.js
+++ b/src/app/components/cds/inputs/ListSort.js
@@ -50,6 +50,11 @@ const sortLabels = defineMessages({
     defaultMessage: 'Report (status)',
     description: 'Label for sort criteria option displayed in a drop-down in listing pages',
   },
+  sortScore: {
+    id: 'searchResults.sortScore',
+    defaultMessage: 'Search: Best Match',
+    description: 'Label for sort criteria option displayed in a drop-down in listing pages',
+  },
   sortSubmitted: {
     id: 'searchResults.sortSubmitted',
     defaultMessage: 'Submitted (date)',

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -706,6 +706,11 @@ const SearchFields = ({
     { value: 'recent_activity', label: intl.formatMessage(sortLabels.sortUpdated) },
   ];
 
+  // if searching for a keyword, default sort by score but only show option when searching
+  if (stateQuery.keyword && stateQuery.keyword.length > 0) {
+    listSortOptions.unshift({ value: 'score', label: intl.formatMessage(sortLabels.sortScore) });
+  }
+
   return (
     <div className={styles['filters-wrapper']}>
       <ListSort

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable relay/unused-fields, react/sort-prop-types */
+/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';
@@ -801,31 +801,31 @@ SearchFields.defaultProps = {
 };
 
 SearchFields.propTypes = {
+  appliedQuery: PropTypes.object.isRequired,
+  defaultQuery: PropTypes.object.isRequired,
   feedTeam: PropTypes.shape({
     id: PropTypes.string.isRequired,
     filters: PropTypes.object,
     feedFilters: PropTypes.object,
   }),
+  handleSubmit: PropTypes.func.isRequired,
+  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash', 'assigned-to-me']).isRequired, // FIXME Define listing types as a global constant
+  readOnlyFields: PropTypes.arrayOf(PropTypes.string),
   savedSearch: PropTypes.shape({
+    filters: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
-    filters: PropTypes.string.isRequired,
   }),
-  stateQuery: PropTypes.object.isRequired,
-  appliedQuery: PropTypes.object.isRequired,
-  defaultQuery: PropTypes.object.isRequired,
   setStateQuery: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired, // onChange({ ... /* query */ }) => undefined
+  stateQuery: PropTypes.object.isRequired,
   team: PropTypes.shape({
-    id: PropTypes.string.isRequired,
     dbid: PropTypes.number.isRequired,
-    slug: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
     permissions: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
     verification_statuses: PropTypes.object.isRequired,
   }).isRequired,
-  handleSubmit: PropTypes.func.isRequired,
-  readOnlyFields: PropTypes.arrayOf(PropTypes.string),
-  page: PropTypes.oneOf(['all-items', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash', 'assigned-to-me']).isRequired, // FIXME Define listing types as a global constant
+  onChange: PropTypes.func.isRequired, // onChange({ ... /* query */ }) => undefined
 };
 
 SearchFields.contextTypes = {


### PR DESCRIPTION
## Description

When the user performs a keyword search, the default label is now Search: Best Match. This label is only added when there is a keyword being searched.  This fixes the default option being Fact Check Published On because 'score' wasn't a dropdown option. 

References: CV2-5174

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested in ui 

## Things to pay attention to during code review

Search: Best Match only appears when searching 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [x] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
