### PR TITLE
fix incorrect styles on saving new list dialog [CV2-5231]

### DIFF
--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/sort-prop-types */
+/* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { commitMutation, graphql } from 'react-relay/compat';
@@ -9,6 +9,7 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import { FormattedMessage, FormattedHTMLMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import cx from 'classnames/bind';
 import { can } from '../Can';
 import { withSetFlashMessage } from '../FlashMessage';
 import TextField from '../cds/inputs/TextField';
@@ -333,7 +334,7 @@ const SaveList = ({
                       { operation === 'CREATE' ?
                         <TextField
                           autoFocus
-                          className="new-list__title"
+                          className={cx('new-list__title'), styles['save-new-list-title']}
                           disabled={operation === 'UPDATE'}
                           placeholder={intl.formatMessage(messages.saveList)}
                           onChange={(e) => { setTitle(e.target.value); }}

--- a/src/app/components/search/SaveList.js
+++ b/src/app/components/search/SaveList.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { commitMutation, graphql } from 'react-relay/compat';
@@ -334,7 +333,7 @@ const SaveList = ({
                       { operation === 'CREATE' ?
                         <TextField
                           autoFocus
-                          className={cx('new-list__title'), styles['save-new-list-title']}
+                          className={cx('new-list__title', styles['save-new-list-title'])}
                           disabled={operation === 'UPDATE'}
                           placeholder={intl.formatMessage(messages.saveList)}
                           onChange={(e) => { setTitle(e.target.value); }}
@@ -367,26 +366,26 @@ SaveList.defaultProps = {
 };
 
 SaveList.propTypes = {
-  intl: intlShape.isRequired,
-  team: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    dbid: PropTypes.number.isRequired,
-    slug: PropTypes.string.isRequired,
-    permissions: PropTypes.string.isRequired,
-  }).isRequired,
-  page: PropTypes.oneOf(['all-items', 'assigned-to-me', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
-  query: PropTypes.object.isRequired,
   feedTeam: PropTypes.shape({
     id: PropTypes.string.isRequired,
     filters: PropTypes.object,
     feedFilters: PropTypes.object,
     shared: PropTypes.bool,
   }), // may be null
+  intl: intlShape.isRequired,
+  page: PropTypes.oneOf(['all-items', 'assigned-to-me', 'tipline-inbox', 'imported-fact-checks', 'suggested-matches', 'unmatched-media', 'published', 'list', 'feed', 'spam', 'trash']).isRequired, // FIXME Define listing types as a global constant
+  query: PropTypes.object.isRequired,
   savedSearch: PropTypes.shape({
     id: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     filters: PropTypes.string.isRequired,
   }),
+  team: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    dbid: PropTypes.number.isRequired,
+    slug: PropTypes.string.isRequired,
+    permissions: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default withSetFlashMessage(injectIntl(SaveList));

--- a/src/app/components/search/search.module.css
+++ b/src/app/components/search/search.module.css
@@ -239,5 +239,12 @@
 }
 
 .save-new-list {
-  border: solid 2px;
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  width: 100%;
+
+  .save-new-list-title {
+    flex: 1 1 auto;
+  }
 }


### PR DESCRIPTION
## Description

I think I missed adding a commit in a previous PR and didn't notice the inclusion of just the testing css. see CV2-5231 for details.
This PR:
- Remove testing styles
- Add in missing save list styles
- Sort prop types and remove eslint disable

References: CV2-5231

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)


## Things to pay attention to during code review

### BEFORE
<img width="565" alt="Screenshot 2024-09-06 at 3 13 13 PM" src="https://github.com/user-attachments/assets/196e88a7-6f05-4308-a535-3cd989a32fd4">
<img width="567" alt="Screenshot 2024-09-06 at 3 13 08 PM" src="https://github.com/user-attachments/assets/1848153b-68bb-416d-9eb4-70f62578311c">

### AFTER
<img width="562" alt="Screenshot 2024-09-06 at 3 12 28 PM" src="https://github.com/user-attachments/assets/6508b689-c869-45d1-ba10-18b0351d35e3">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
