### PR TITLE
Add loading icon to TagPicker

### DIFF
--- a/src/app/components/cds/menus-lists-dialogs/TagPicker.js
+++ b/src/app/components/cds/menus-lists-dialogs/TagPicker.js
@@ -14,6 +14,7 @@ const TagPicker = ({
   customCreateLabel,
   hasMore,
   loadMore,
+  loading,
   options: teamTags,
   readOnly,
   saving,
@@ -98,6 +99,7 @@ const TagPicker = ({
               }
               hasMore={hasMore}
               inputPlaceholder={placeholder}
+              loadingIcon={loading && <MediasLoading size="small" theme="white" variant="inline" />}
               notFoundLabel={
                 <FormattedMessage
                   defaultMessage="No tags found"

--- a/src/app/components/media/TeamTagsQueryRenderer.js
+++ b/src/app/components/media/TeamTagsQueryRenderer.js
@@ -52,6 +52,8 @@ const TeamTagsQueryRenderer = ({
       render={({ error, props }) => {
         if (error) return null;
 
+        const loading = Boolean(!error && !props);
+
         // TODO: This "merge selected tags with plainTagsTexts" logic is identical
         // to `SearchFieldTag` component. Evaluate reusing TeamTagsQueryRenderer there.
 
@@ -75,6 +77,7 @@ const TeamTagsQueryRenderer = ({
           <TagPicker
             hasMore={hasMore}
             loadMore={handleLoadMore}
+            loading={loading}
             options={plainTagsTexts.map(t => ({ label: t, value: t }))}
             readOnly={readOnly}
             searchTerm={keyword}


### PR DESCRIPTION
## Description

Pass the loading state to the `TagPicker` so it sets the `loadingIcon` prop for `MultiSelector`

References: CV2-2502

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

![image](https://github.com/user-attachments/assets/37f9cacc-c233-4fc2-9e10-0776dbacc4bd)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
