### PR TITLE
update multiselect loader position

### DIFF
--- a/src/app/components/cds/menus-lists-dialogs/TagPicker.js
+++ b/src/app/components/cds/menus-lists-dialogs/TagPicker.js
@@ -99,7 +99,7 @@ const TagPicker = ({
               }
               hasMore={hasMore}
               inputPlaceholder={placeholder}
-              loadingIcon={loading && <MediasLoading size="small" theme="white" variant="inline" />}
+              loadingIcon={loading && <MediasLoading size="small" theme="grey" variant="inline" />}
               notFoundLabel={
                 <FormattedMessage
                   defaultMessage="No tags found"

--- a/src/app/components/layout/MultiSelector.js
+++ b/src/app/components/layout/MultiSelector.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -336,15 +335,15 @@ MultiSelector.propTypes = {
     color: PropTypes.string,
     parent: PropTypes.string,
   })).isRequired,
+  resetLabel: PropTypes.node,
   selected: PropTypes.arrayOf(PropTypes.string).isRequired,
   submitLabel: PropTypes.node.isRequired,
+  toggleAllLabel: PropTypes.node,
   onDismiss: PropTypes.func,
   onScrollBottom: PropTypes.func,
   onSearchChange: PropTypes.func,
   onSelectChange: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
-  toggleAllLabel: PropTypes.node,
-  resetLabel: PropTypes.node,
 };
 
 export default MultiSelector;

--- a/src/app/components/layout/MultiSelector.js
+++ b/src/app/components/layout/MultiSelector.js
@@ -209,6 +209,11 @@ class MultiSelector extends React.Component {
             </div>
           }
         </div>
+        { this.props.loadingIcon &&
+          <div className={styles['multiselector-scroller-loader']}>
+            { this.props.loadingIcon }
+          </div>
+        }
         <div className={styles['multiselector-scroller']}>
           <InfiniteScroll
             hasMore={hasMore}
@@ -265,7 +270,6 @@ class MultiSelector extends React.Component {
                 </div>
               }
             </FormGroup>
-            { this.props.loadingIcon }
           </InfiniteScroll>
         </div>
         { this.props.children }

--- a/src/app/components/layout/MultiSelector.module.css
+++ b/src/app/components/layout/MultiSelector.module.css
@@ -20,6 +20,16 @@
     }
   }
 
+  .multiselector-scroller-loader {
+    background-color: var(--overlayWhite);
+    height: 100%;
+    left: 0;
+    max-height: 320px;
+    position: absolute;
+    right: 0;
+    z-index: 1;
+  }
+
   .multiselector-scroller {
     background-color: var(--color-gray-96);
     height: 320px;

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -252,7 +252,7 @@ const CustomSelectDropdown = ({
               allowSearch={allowSearch}
               hasMore={hasMore}
               inputPlaceholder={inputPlaceholder || placeholder}
-              loadingIcon={loading && <MediasLoading size="small" theme="white" variant="inline" />}
+              loadingIcon={loading && <MediasLoading size="small" theme="grey" variant="inline" />}
               notFoundLabel={!loading && inputPlaceholder ? (
                 <FormattedMessage
                   defaultMessage="No results matching {keyword}."

--- a/src/app/components/search/MultiSelectFilter.js
+++ b/src/app/components/search/MultiSelectFilter.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -300,31 +299,31 @@ MultiSelectFilter.defaultProps = {
 };
 
 MultiSelectFilter.propTypes = {
+  allowSearch: PropTypes.bool,
   error: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
   ])),
-  allowSearch: PropTypes.bool,
   extraInputs: PropTypes.node,
+  icon: PropTypes.element.isRequired,
+  inputPlaceholder: PropTypes.string,
+  label: PropTypes.node.isRequired,
+  loading: PropTypes.bool,
+  oneOption: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
   ])).isRequired,
-  label: PropTypes.node.isRequired,
-  icon: PropTypes.element.isRequired,
-  loading: PropTypes.bool,
-  onChange: PropTypes.func,
-  onRemove: PropTypes.func,
+  readOnly: PropTypes.bool,
   selected: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.string,
   ]),
+  onChange: PropTypes.func,
+  onRemove: PropTypes.func,
   onScrollBottom: PropTypes.func,
   onToggleOperator: PropTypes.func,
-  readOnly: PropTypes.bool,
   onType: PropTypes.func,
-  inputPlaceholder: PropTypes.string,
-  oneOption: PropTypes.bool,
 };
 
 export default MultiSelectFilter;

--- a/src/app/styles/css/mixins/variables.css
+++ b/src/app/styles/css/mixins/variables.css
@@ -115,6 +115,8 @@
 
   --grayShadow: rgb(0 0 0 / .15);
 
+  --overlayWhite: rgb(255 255 255 / .7);
+
   --overlayLight: rgb(34 34 34 / .7);
 
   /* https://facebookbrand.com/facebookapp/advertisers-and-partners/ */


### PR DESCRIPTION
## Description

Updates the loader position of the multi selector so it always appear on top of the list.
Sorts prop types while here

References: CV2-2502

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

### AFTER
<img width="508" alt="Screenshot 2024-09-20 at 3 54 48 PM" src="https://github.com/user-attachments/assets/1b1a6237-73f3-4925-9e22-15dbef3af793">

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [x] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
