### PR TITLE
increase article explainer char limit to 4096

### DIFF
--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -436,7 +436,7 @@ const ArticleForm = ({
                           error={summaryError}
                           label={<FormattedMessage defaultMessage="Summary" description="Label for article summary field" id="articleForm.explainerSummary" />}
                           maxChars={4096 - articleTitle.length - url.length}
-                          maxHeight="350px"
+                          maxHeight="500px"
                           name="summary"
                           placeholder={placeholder}
                           required

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -435,12 +435,13 @@ const ArticleForm = ({
                           }}
                           error={summaryError}
                           label={<FormattedMessage defaultMessage="Summary" description="Label for article summary field" id="articleForm.explainerSummary" />}
-                          maxChars={900 - articleTitle.length - url.length}
+                          maxChars={4096 - articleTitle.length - url.length}
+                          maxHeight="350px"
                           name="summary"
                           placeholder={placeholder}
                           required
                           rows="1"
-                          value={truncateLength(summary, 900 - articleTitle.length - url.length - 3)}
+                          value={truncateLength(summary, 4096 - articleTitle.length - url.length - 3)}
                           onBlur={(e) => {
                             const newValue = e.target.value.trim();
                             if (newValue.length) {


### PR DESCRIPTION
## Description

Small PR in advance of a bigger design change around articles character count limits to increase from 900 to 4096 for explainers only because they are sent as text messages on whats app and we can send a max of 4096. Also limited the height of the textbox as not to make the layout too challenging when lots of text is entered

References: CV2-5052

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

just visual

## Things to pay attention to during code review

### AFTER - Editing
<img width="634" alt="Screenshot 2024-09-26 at 2 41 47 PM" src="https://github.com/user-attachments/assets/6b8ed818-b361-41c4-9c7d-cd35080ae7e0">

### AFTER - Creating
<img width="623" alt="Screenshot 2024-09-26 at 2 41 56 PM" src="https://github.com/user-attachments/assets/fb963c44-f19d-4e10-b749-9e8c080a21a0">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
