### PR TITLE
replace final material button with ButtonMain cds component [CV2-3353]

### DIFF
--- a/localization/react-intl/src/app/components/UploadFile.json
+++ b/localization/react-intl/src/app/components/UploadFile.json
@@ -2,27 +2,27 @@
   {
     "id": "uploadFile.message",
     "description": "Message to the user describing the requirements for uploading an image",
-    "defaultMessage": "<p>Drop an image file here, or click to upload a file</p><p>Max File Size: <strong>{upload_max_size}</strong></p><p>Allowed Extensions: <strong>{upload_extensions}</strong></p><p>Allowed Dimensions: <strong>{upload_min_dimensions} and {upload_max_dimensions} pixels</strong></p>"
+    "defaultMessage": "<p>Click or drag an image here to upload.</p><p>Max File Size: <strong>{upload_max_size}</strong></p><p>Allowed Extensions: <strong>{upload_extensions}</strong></p><p>Allowed Dimensions: <strong>{upload_min_dimensions} and {upload_max_dimensions} pixels</strong></p>"
   },
   {
     "id": "uploadFile.videoMessage",
     "description": "Message to the user describing the requirements for uploading a video",
-    "defaultMessage": "<p>Drop a video file here, or click to upload a file</p><p>Max File Size: <strong>{video_max_size}</strong></p><p>Allowed Extensions: <strong>{video_extensions}</strong></p>"
+    "defaultMessage": "<p>Click or drag a video file here to upload.</p><p>Max File Size: <strong>{video_max_size}</strong></p><p>Allowed Extensions: <strong>{video_extensions}</strong></p>"
   },
   {
     "id": "uploadFile.audioMessage",
     "description": "Message to the user describing the requirements for uploading an audio file",
-    "defaultMessage": "<p>Drop an audio file here, or click to upload a file</p><p>Max File Size: <strong>{audio_max_size}</strong></p><p>Allowed Extensions: <strong>{audio_extensions}</strong></p>"
+    "defaultMessage": "<p>Click or drag an audio file here to upload.</p><p>Max File Size: <strong>{audio_max_size}</strong></p><p>Allowed Extensions: <strong>{audio_extensions}</strong></p>"
   },
   {
     "id": "uploadFile.fileMessage",
     "description": "Message to the user describing the requirements for uploading a file using this component",
-    "defaultMessage": "Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
+    "defaultMessage": "<>Click or drag a file here to upload.</><p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
   },
   {
     "id": "uploadFile.imageVideoAudioMessage",
     "description": "Message to the user describing the requirements for uploading an image, video, or audio file using this component",
-    "defaultMessage": "<p>Drop a file here, or click to upload a file</p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
+    "defaultMessage": "<p>Click or drag a file here to upload.</p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
   },
   {
     "id": "uploadFile.invalidExtension",

--- a/localization/react-intl/src/app/components/article/ArticleForm.json
+++ b/localization/react-intl/src/app/components/article/ArticleForm.json
@@ -57,7 +57,7 @@
   {
     "id": "articleForm.reportDesignerTooltipTwo",
     "description": "Tooltip for the report designer button",
-    "defaultMessage": "Fact-Check Title, Summary, and Language are required in order to to publish a Fact-Check report"
+    "defaultMessage": "Fact-Check Title, Summary, and Language are required in order to publish a Fact-Check report"
   },
   {
     "id": "articleForm.reportDesignerTooltipThree",

--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": "smoochBotIntegrations.title",
-    "description": "Title of Settings tab in the tipline settings page",
-    "defaultMessage": "Messaging services"
-  },
-  {
     "id": "smoochBotIntegrations.phoneNumber",
     "description": "Label showing the whatsapp phone number connected to this bot",
     "defaultMessage": "Connected phone number: {link}"

--- a/src/app/components/UploadFile.js
+++ b/src/app/components/UploadFile.js
@@ -16,7 +16,7 @@ const UploadMessage = ({ about, type }) => {
   switch (type) {
   case 'image': return (
     <FormattedHTMLMessage
-      defaultMessage="<p>Drop an image file here, or click to upload a file</p><p>Max File Size: <strong>{upload_max_size}</strong></p><p>Allowed Extensions: <strong>{upload_extensions}</strong></p><p>Allowed Dimensions: <strong>{upload_min_dimensions} and {upload_max_dimensions} pixels</strong></p>"
+      defaultMessage="<p>Click or drag an image here to upload.</p><p>Max File Size: <strong>{upload_max_size}</strong></p><p>Allowed Extensions: <strong>{upload_extensions}</strong></p><p>Allowed Dimensions: <strong>{upload_min_dimensions} and {upload_max_dimensions} pixels</strong></p>"
       description="Message to the user describing the requirements for uploading an image"
       id="uploadFile.message"
       tagName="div"
@@ -30,7 +30,7 @@ const UploadMessage = ({ about, type }) => {
   );
   case 'video': return (
     <FormattedHTMLMessage
-      defaultMessage="<p>Drop a video file here, or click to upload a file</p><p>Max File Size: <strong>{video_max_size}</strong></p><p>Allowed Extensions: <strong>{video_extensions}</strong></p>"
+      defaultMessage="<p>Click or drag a video file here to upload.</p><p>Max File Size: <strong>{video_max_size}</strong></p><p>Allowed Extensions: <strong>{video_extensions}</strong></p>"
       description="Message to the user describing the requirements for uploading a video"
       id="uploadFile.videoMessage"
       tagName="div"
@@ -42,7 +42,7 @@ const UploadMessage = ({ about, type }) => {
   );
   case 'audio': return (
     <FormattedHTMLMessage
-      defaultMessage="<p>Drop an audio file here, or click to upload a file</p><p>Max File Size: <strong>{audio_max_size}</strong></p><p>Allowed Extensions: <strong>{audio_extensions}</strong></p>"
+      defaultMessage="<p>Click or drag an audio file here to upload.</p><p>Max File Size: <strong>{audio_max_size}</strong></p><p>Allowed Extensions: <strong>{audio_extensions}</strong></p>"
       description="Message to the user describing the requirements for uploading an audio file"
       id="uploadFile.audioMessage"
       tagName="div"
@@ -55,7 +55,7 @@ const UploadMessage = ({ about, type }) => {
 
   case 'file': return (
     <FormattedMessage
-      defaultMessage="Drop a file here, or click to upload a file (max size: {file_max_size}, allowed extensions: {file_extensions})"
+      defaultMessage="<>Click or drag a file here to upload.</><p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
       description="Message to the user describing the requirements for uploading a file using this component"
       id="uploadFile.fileMessage"
       tagName="div"
@@ -68,7 +68,7 @@ const UploadMessage = ({ about, type }) => {
 
   case 'image+video+audio': return (
     <FormattedHTMLMessage
-      defaultMessage="<p>Drop a file here, or click to upload a file</p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
+      defaultMessage="<p>Click or drag a file here to upload.</p><p>Max File Size: <strong>{file_max_size}</strong></p><p>Allowed Extensions: <strong>{file_extensions}</strong></p>"
       description="Message to the user describing the requirements for uploading an image, video, or audio file using this component"
       id="uploadFile.imageVideoAudioMessage"
       tagName="div"

--- a/src/app/components/UploadFile.test.js
+++ b/src/app/components/UploadFile.test.js
@@ -24,7 +24,7 @@ describe('<UploadFileComponent />', () => {
       onChange={() => {}}
       onError={() => {}}
     />);
-    expect(wrapper.html()).toMatch('Drop an audio file here, or click to upload a file');
+    expect(wrapper.html()).toMatch('Click or drag an audio file here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-without-file').hostNodes()).toHaveLength(1);
   });
 
@@ -36,7 +36,7 @@ describe('<UploadFileComponent />', () => {
       onChange={() => {}}
       onError={() => {}}
     />);
-    expect(wrapper.html()).toMatch('Drop a video file here, or click to upload a file');
+    expect(wrapper.html()).toMatch('Click or drag a video file here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-without-file').hostNodes()).toHaveLength(1);
   });
 
@@ -48,7 +48,7 @@ describe('<UploadFileComponent />', () => {
       onChange={() => {}}
       onError={() => {}}
     />);
-    expect(wrapper.html()).toMatch('Drop an image file here, or click to upload a file');
+    expect(wrapper.html()).toMatch('Click or drag an image here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-without-file').hostNodes()).toHaveLength(1);
   });
 
@@ -60,7 +60,7 @@ describe('<UploadFileComponent />', () => {
       onChange={() => {}}
       onError={() => {}}
     />);
-    expect(wrapper.html()).toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.html()).toMatch('Click or drag a file here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-without-file').hostNodes()).toHaveLength(1);
   });
 
@@ -73,7 +73,7 @@ describe('<UploadFileComponent />', () => {
       onError={() => {}}
     />);
     //
-    expect(wrapper.html()).toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.html()).toMatch('Click or drag a file here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-without-file').hostNodes()).toHaveLength(1);
   });
 
@@ -85,7 +85,7 @@ describe('<UploadFileComponent />', () => {
       onChange={() => {}}
       onError={() => {}}
     />);
-    expect(wrapper.html()).not.toMatch('Drop a file here, or click to upload a file');
+    expect(wrapper.html()).not.toMatch('Click or drag a file here to upload.');
     expect(wrapper.find('.int-uploadfile__dropzone-with-file').hostNodes()).toHaveLength(1);
   });
 });

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -207,7 +207,7 @@ const ArticleForm = ({
                       title={
                         <>
                           {!article.claim_description?.project_media?.dbid && <FormattedMessage defaultMessage="Assign this Fact Check to a media item to be able to edit and publish a report" description="Tooltip for the report designer button" id="articleForm.reportDesignerTooltip" />}
-                          {article.claim_description?.project_media?.dbid && factCheckFieldsMissing && <FormattedMessage defaultMessage="Fact-Check Title, Summary, and Language are required in order to to publish a Fact-Check report" description="Tooltip for the report designer button" id="articleForm.reportDesignerTooltipTwo" />}
+                          {article.claim_description?.project_media?.dbid && factCheckFieldsMissing && <FormattedMessage defaultMessage="Fact-Check Title, Summary, and Language are required in order to publish a Fact-Check report" description="Tooltip for the report designer button" id="articleForm.reportDesignerTooltipTwo" />}
                           {article.claim_description?.project_media?.dbid && !factCheckFieldsMissing && <FormattedMessage defaultMessage="Go to Fact-Check report editor" description="Tooltip for the report designer button" id="articleForm.reportDesignerTooltipThree" />}
                         </>
                       }

--- a/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.js
+++ b/src/app/components/cds/buttons-checkboxes-chips/ButtonMain.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 // DESIGNS: https://www.figma.com/file/rnSPSHDgFncxjXsZQuEVKd/Design-System?type=design&node-id=139-6525&mode=design&t=ZVq51pKdIKdWZicO-4
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -81,18 +80,18 @@ ButtonMain.defaultProps = {
 };
 
 ButtonMain.propTypes = {
+  buttonProps: PropTypes.object,
   className: PropTypes.string,
+  customStyle: PropTypes.object,
+  disabled: PropTypes.bool,
+  iconCenter: PropTypes.element,
+  iconLeft: PropTypes.element,
+  iconRight: PropTypes.element,
   label: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   size: PropTypes.oneOf(['default', 'small', 'large']),
   theme: PropTypes.oneOf(['info', 'lightInfo', 'text', 'lightText', 'error', 'lightError', 'validation', 'lightValidation', 'alert', 'lightAlert', 'black', 'white', 'beige', 'lightBeige']),
-  iconLeft: PropTypes.element,
-  iconRight: PropTypes.element,
-  iconCenter: PropTypes.element,
   title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   variant: PropTypes.oneOf(['contained', 'outlined', 'text']),
-  disabled: PropTypes.bool,
-  customStyle: PropTypes.object,
-  buttonProps: PropTypes.object,
   onClick: PropTypes.func,
 };
 

--- a/src/app/components/team/SmoochBot/SmoochBot.module.css
+++ b/src/app/components/team/SmoochBot/SmoochBot.module.css
@@ -58,3 +58,7 @@
     }
   }
 }
+
+.smoochBotIntegrationButtonWarning {
+  color: var(--color-pink-53);
+}

--- a/src/app/components/team/SmoochBot/SmoochBot.module.css
+++ b/src/app/components/team/SmoochBot/SmoochBot.module.css
@@ -27,3 +27,34 @@
 .smoochbot-component-input {
   min-width: 500px;
 }
+
+.smoochbot-integration-buttons {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 16px;
+  margin: 0 0 16px;
+}
+
+.smoochbot-integration-button-label {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+
+  .smoochbot-integration-button-status {
+    @mixin typography-caption;
+    border: 1px solid transparent;
+    border-radius: var(--border-radius-small);
+    font-weight: bold;
+    padding: 3px;
+
+    &.smoochBotIntegrationButtonConnected {
+      background-color: var(--color-green-35);
+      color: var(--color-white-100);
+    }
+
+    &.smoochBotIntegrationButtonDisconnected {
+      border-color: var(--color-gray-15);
+      color: var(--color-gray-15);
+    }
+  }
+}

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -5,58 +5,20 @@ import { Store } from 'react-relay/classic';
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
-import Button from '@material-ui/core/Button';
 import cx from 'classnames/bind';
+import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
 import TextField from '../../cds/inputs/TextField';
 import SettingsHeader from '../SettingsHeader';
 import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
+import smoochBotStyles from './SmoochBot.module.css';
 
-const useStyles = makeStyles(theme => ({
-  smoochBotIntegrationButton: {
-    margin: theme.spacing(1),
-    background: 'var(--color-gray-88)',
-    minWidth: 255,
-    justifyContent: 'space-between',
-    '&:hover': {
-      background: 'var(--color-gray-88)',
-    },
-  },
-  smoochBotIntegrationButtonIcon: {
-    color: 'var(--color-white-100)',
-    padding: theme.spacing(0.5),
-    display: 'flex',
-    borderRadius: theme.spacing(1),
-  },
-  smoochBotIntegrationButtonLabel: {
-    textAlign: 'left',
-    width: '100%',
-    whiteSpace: 'nowrap',
-  },
-  smoochBotIntegrationButtonFlag: {
-    border: '1px solid transparent',
-    borderRadius: 3,
-    padding: theme.spacing(0.5),
-    fontSize: '10px !important',
-    fontWeight: 'bold',
-    minWidth: 80,
-  },
-  smoochBotIntegrationButtonConnected: {
-    color: 'var(--color-white-100)',
-    backgroundColor: 'var(--color-green-35)',
-  },
-  smoochBotIntegrationButtonDisconnected: {
-    color: 'var(--color-gray-15)',
-    borderColor: 'var(--color-gray-15)',
-  },
+const useStyles = makeStyles({
   smoochBotIntegrationButtonWarning: {
     color: 'var(--color-pink-53)',
   },
-  smoochBotIntegrationButtonHeader: {
-    marginBottom: 0,
-  },
-}));
+});
 
 const messages = defineMessages({
   confirmationMessage: {
@@ -232,46 +194,43 @@ const SmoochBotIntegrationButton = ({
 
   return (
     <React.Fragment>
-      <Button
-        className={classes.smoochBotIntegrationButton}
+      <ButtonMain
         disabled={disabled || (readOnly && !online)}
-        endIcon={
-          (!readOnly || online) ?
-            <span
-              className={cx(
-                'typography-caption',
-                classes.smoochBotIntegrationButtonFlag,
-                {
-                  [classes.smoochBotIntegrationButtonConnected]: online,
-                  [classes.smoochBotIntegrationButtonDisconnected]: !online,
-                })
-              }
-            >
-              { online ?
-                <FormattedMessage
-                  defaultMessage="Online"
-                  description="Status of bot when its online"
-                  id="smoochBotIntegrationButton.online"
-                /> :
-                <FormattedMessage
-                  defaultMessage="Connect"
-                  description="Status of bot when its not connected"
-                  id="smoochBotIntegrationButton.connect"
-                /> }
-            </span> : null
+        iconLeft={icon}
+        label={
+          <div className={smoochBotStyles['smoochbot-integration-button-label']}>
+            {label}
+            {
+              (!readOnly || online) ?
+                <div
+                  className={cx(
+                    smoochBotStyles['smoochbot-integration-button-status'],
+                    {
+                      [smoochBotStyles.smoochBotIntegrationButtonConnected]: online,
+                      [smoochBotStyles.smoochBotIntegrationButtonDisconnected]: !online,
+                    })
+                  }
+                >
+                  { online ?
+                    <FormattedMessage
+                      defaultMessage="Online"
+                      description="Status of bot when its online"
+                      id="smoochBotIntegrationButton.online"
+                    /> :
+                    <FormattedMessage
+                      defaultMessage="Connect"
+                      description="Status of bot when its not connected"
+                      id="smoochBotIntegrationButton.connect"
+                    /> }
+                </div> : null
+            }
+          </div>
         }
-        startIcon={
-          <Box className={classes.smoochBotIntegrationButtonIcon}>
-            {icon}
-          </Box>
-        }
+        size="default"
+        theme="lightText"
         variant="contained"
         onClick={handleClick}
-      >
-        <Box className={classes.smoochBotIntegrationButtonLabel}>
-          {label}
-        </Box>
-      </Button>
+      />
 
       <ConfirmProceedDialog
         body={(
@@ -293,7 +252,6 @@ const SmoochBotIntegrationButton = ({
         proceedLabel={<FormattedMessage defaultMessage="Disconnect from this account" description="Button label to disconnect a bot from an account" id="smoochBotIntegrationButton.disconnect" />}
         title={
           <SettingsHeader
-            className={classes.smoochBotIntegrationButtonHeader}
             helpUrl={helpUrl}
             title={
               <FormattedMessage
@@ -355,7 +313,6 @@ const SmoochBotIntegrationButton = ({
         }
         title={
           <SettingsHeader
-            className={classes.smoochBotIntegrationButtonHeader}
             helpUrl={helpUrl}
             title={
               <FormattedMessage

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrationButton.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { commitMutation, graphql } from 'react-relay/compat';
 import { Store } from 'react-relay/classic';
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from 'react-intl';
-import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import cx from 'classnames/bind';
 import ButtonMain from '../../cds/buttons-checkboxes-chips/ButtonMain';
@@ -13,12 +12,6 @@ import ConfirmProceedDialog from '../../layout/ConfirmProceedDialog';
 import { withSetFlashMessage } from '../../FlashMessage';
 import { getErrorMessageForRelayModernProblem } from '../../../helpers';
 import smoochBotStyles from './SmoochBot.module.css';
-
-const useStyles = makeStyles({
-  smoochBotIntegrationButtonWarning: {
-    color: 'var(--color-pink-53)',
-  },
-});
 
 const messages = defineMessages({
   confirmationMessage: {
@@ -51,7 +44,6 @@ const SmoochBotIntegrationButton = ({
   type,
   url,
 }) => {
-  const classes = useStyles();
   const [openFormDialog, setOpenFormDialog] = React.useState(false);
   const [openInfoDialog, setOpenInfoDialog] = React.useState(false);
   const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
@@ -331,7 +323,7 @@ const SmoochBotIntegrationButton = ({
       <ConfirmProceedDialog
         body={
           permanentDisconnection ?
-            <strong className={classes.smoochBotIntegrationButtonWarning}>
+            <strong className={smoochBotStyles.smoochBotIntegrationButtonWarning}>
               <FormattedMessage
                 defaultMessage="Warning! Disconnecting a WhatsApp number is permanent. You will not be able to reconnect it after it is disconnected."
                 description="Explanation displayed on the confirmation modal when a tipline administrator wants to disconnect a WhatsApp number."

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
@@ -40,7 +40,7 @@ const SmoochBotIntegrations = ({ enabledIntegrations, installationId, settings }
 
   return (
     <React.Fragment>
-      <Box display="flex" flexWrap="wrap" justifyContent="space-between">
+      <div className={smoochBotStyles['smoochbot-integration-buttons']}>
         <SmoochBotIntegrationButton
           disabled={!isEnabled}
           helpUrl="https://help.checkmedia.org/en/articles/8772777-setup-your-tipline-bot#h_ec472becaf"
@@ -351,7 +351,7 @@ const SmoochBotIntegrations = ({ enabledIntegrations, installationId, settings }
           type="instagram"
           url={settings.smooch_facebook_authorization_url.replace('authorize/facebook', 'authorize/instagram')}
         />
-      </Box>
+      </div>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Description

Noticed while reviewing tickets we only had one instance of mat button left. This PR completes the process. Since internally we are the primary users of this button I didn't worry too much about retaining the styles perfectly. See the screenshots below.

References: CV2-3353

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

### BEFORE
<img width="617" alt="Screenshot 2024-10-01 at 2 50 17 PM" src="https://github.com/user-attachments/assets/8631174a-6fa0-4d25-ab16-68bcbc289845">

### AFTER
<img width="618" alt="Screenshot 2024-10-01 at 2 49 52 PM" src="https://github.com/user-attachments/assets/8bf69205-419f-46a9-8e97-ff465e8b45e3">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [x] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
