### PR TITLE
Pass the exclusive-secrets and exclusive-env options during deployment.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ deploy_qa:
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62
     - pip install ecs-deploy==1.15.0
-    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
+    - ecs deploy ecs-qa  qa-check-web --image qa-check-web-c $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --exclusive-secrets --exclusive-env -e qa-check-web-c APP check-web -e qa-check-web-c DEPLOY_ENV qa --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/web:$CI_COMMIT_SHA"
     - sh scripts/clear-cf-cache.sh
   only:
@@ -87,7 +87,7 @@ deploy_live:
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62
     - pip install ecs-deploy==1.15.0
-    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --timeout 3600
+    - ecs deploy ecs-live  live-check-web --image live-check-web-c $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA -r arn:aws:iam::848416313321:role/ECSSecretsAccessRole --exclusive-secrets --exclusive-env -e live-check-web-c APP check-web -e live-check-web-c DEPLOY_ENV live --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/web:$CI_COMMIT_SHA"
     - sh scripts/clear-cf-cache.sh
   only:


### PR DESCRIPTION
## Description

This change brings check-web into harmony with the usual deployment mode using exclusive secrets and env settings during deployment.

This is also a fix for legacy presence of the GithubToken-Plain secret from the Configurator days.

References: CV2-5414

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Security mitigation or enhancement

## How has this been tested?

These options have been tested in check-api, alegre, pender without issue. 

## Things to pay attention to during code review

We'll want to give this a good run in QA before merge to master just to be sure there's no lingering reference to old secrets anywhere during initialization and start up.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I've made sure my branch is runnable and given good testing steps in the PR description
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] My changes generate no new warnings
