### PR TITLE
claim info on media article cards [CV2-5445]

### DIFF
--- a/src/app/components/article/ArticleCard.module.css
+++ b/src/app/components/article/ArticleCard.module.css
@@ -18,12 +18,13 @@
 
     .mediaArticleCard {
       flex-direction: column;
-      gap: 3px;
+      gap: 6px;
 
       .articleCardHeader {
-        align-items: flex-start;
+        align-items: center;
         display: flex;
         gap: 3px;
+        height: 30px;
 
         .articleIcon {
           font-size: var(--font-size-subtitle-1);

--- a/src/app/components/article/MediaArticleCard.js
+++ b/src/app/components/article/MediaArticleCard.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames/bind';
@@ -185,21 +184,22 @@ MediaArticleCard.defaultProps = {
 };
 
 MediaArticleCard.propTypes = {
-  id: PropTypes.string.isRequired,
   claimSummary: PropTypes.string,
   claimTitle: PropTypes.string,
-  title: PropTypes.string.isRequired,
-  url: PropTypes.string,
   date: PropTypes.instanceOf(Date).isRequired,
-  statusLabel: PropTypes.string,
-  statusColor: PropTypes.string,
-  summary: PropTypes.string,
+  id: PropTypes.string.isRequired,
   languageCode: PropTypes.string,
   publishedAt: PropTypes.number, // Timestamp
+  removeDisabled: PropTypes.bool,
+  statusColor: PropTypes.string,
+  statusLabel: PropTypes.string,
+  summary: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string,
   variant: PropTypes.oneOf(['explainer', 'fact-check']),
   onClick: PropTypes.func,
   onRemove: PropTypes.func,
-  removeDisabled: PropTypes.bool,
+
 };
 
 export default MediaArticleCard;

--- a/src/app/components/article/MediaArticleCard.js
+++ b/src/app/components/article/MediaArticleCard.js
@@ -6,12 +6,12 @@ import { FormattedMessage } from 'react-intl';
 import RemoveArticleButton from './RemoveArticleButton';
 import Alert from '../cds/alerts-and-prompts/Alert';
 import Card from '../cds/media-cards/Card';
-import EllipseIcon from '../../icons/ellipse.svg';
 import FactCheckIcon from '../../icons/fact_check.svg';
 import BookIcon from '../../icons/book.svg';
 import BulletSeparator from '../layout/BulletSeparator';
 import Language from '../cds/media-cards/Language';
 import LastRequestDate from '../cds/media-cards/LastRequestDate';
+import ItemRating from '../cds/media-cards/ItemRating';
 import ArticleUrl from '../cds/media-cards/ArticleUrl';
 import ItemReportStatus from '../cds/media-cards/ItemReportStatus';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
@@ -19,6 +19,8 @@ import cardStyles from '../cds/media-cards/Card.module.css';
 import styles from './ArticleCard.module.css';
 
 const MediaArticleCard = ({
+  claimSummary,
+  claimTitle,
   date,
   id,
   languageCode,
@@ -61,7 +63,6 @@ const MediaArticleCard = ({
               { variant === 'fact-check' && <FormattedMessage defaultMessage="Claim & Fact-Check" description="Title in an article card on item page." id="mediaArticleCard.factCheck" /> }
               { variant === 'explainer' && <FormattedMessage defaultMessage="Explainer" description="Title in an article card on item page." id="mediaArticleCard.explainer" /> }
             </div>
-            { statusLabel && <div><EllipseIcon style={{ color: statusColor }} /> {statusLabel}</div> }
           </div>
           <div
             className={cx(
@@ -70,18 +71,39 @@ const MediaArticleCard = ({
             )}
           >
             <div className={cardStyles.cardSummaryContent}>
-              <h6 className={cx(cardStyles.cardTitle)}>
-                { url ?
-                  <ArticleUrl linkText={title} showIcon={false} title={title} url={url} variant={variant} />
-                  :
-                  <>
-                    {title}
-                  </>
-                }
-              </h6>
-              <div className={cardStyles.cardDescription}>
-                {summary}
-              </div>
+              { variant === 'fact-check' &&
+                <div
+                  className={cx(
+                    [cardStyles.cardSummaryClaimContent],
+                    {
+                      [cardStyles.cardSummaryClaimFactCheck]: title || summary,
+                    })
+                  }
+                >
+                  <h6 className={cx(cardStyles.cardTitle)}>
+                    {claimTitle}
+                  </h6>
+                  <div className={cardStyles.cardDescription}>
+                    {claimSummary}
+                  </div>
+                </div>
+              }
+              { title &&
+                <h6 className={cx(cardStyles.cardTitle)}>
+                  { url ?
+                    <ArticleUrl linkText={title} showIcon={false} title={title} url={url} variant={variant} />
+                    :
+                    <>
+                      {title}
+                    </>
+                  }
+                </h6>
+              }
+              { summary &&
+                <div className={cardStyles.cardDescription}>
+                  {summary}
+                </div>
+              }
             </div>
           </div>
         </div>
@@ -92,13 +114,22 @@ const MediaArticleCard = ({
       <BulletSeparator
         className={styles.mediaArticleCardFooter}
         details={[
-          variant === 'fact-check' && (<ItemReportStatus
-            displayLabel
-            isPublished={Boolean(publishedAt)}
-            publishedAt={publishedAt ? new Date(publishedAt * 1000) : null}
-            theme="lightText"
-            tooltip={false}
-          />),
+          statusLabel && (
+            <ItemRating
+              rating={statusLabel}
+              ratingColor={statusColor}
+              size="small"
+            />
+          ),
+          variant === 'fact-check' && (
+            <ItemReportStatus
+              displayLabel
+              isPublished={Boolean(publishedAt)}
+              publishedAt={publishedAt ? new Date(publishedAt * 1000) : null}
+              theme="lightText"
+              tooltip={false}
+            />
+          ),
           languageCode && (
             <Language
               languageCode={languageCode}
@@ -139,6 +170,8 @@ const MediaArticleCard = ({
 );
 
 MediaArticleCard.defaultProps = {
+  claimSummary: null,
+  claimTitle: null,
   url: null,
   languageCode: null,
   variant: 'explainer',
@@ -153,6 +186,8 @@ MediaArticleCard.defaultProps = {
 
 MediaArticleCard.propTypes = {
   id: PropTypes.string.isRequired,
+  claimSummary: PropTypes.string,
+  claimTitle: PropTypes.string,
   title: PropTypes.string.isRequired,
   url: PropTypes.string,
   date: PropTypes.instanceOf(Date).isRequired,

--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql, createFragmentContainer } from 'react-relay/compat';
+import cx from 'classnames/bind';
 import MediaArticleCard from './MediaArticleCard';
 import ClaimFactCheckForm from './ClaimFactCheckForm';
 import ExplainerForm from './ExplainerForm';
@@ -75,9 +76,13 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
 
         return (
           <div
-            className={styles.explainerCard}
+            className={cx(
+              [styles.explainerCard],
+              {
+                [styles.explainerCardDimmed]: hasFactCheck && hasExplainer,
+              })
+            }
             key={explainerItem.id}
-            style={{ opacity: ((hasFactCheck && hasExplainer) ? 0.15 : 1) }}
           >
             <MediaArticleCard
               date={new Date(explainer.updated_at * 1000)}

--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -30,6 +30,8 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
     <div className={styles.mediaArticlesDisplay}>
       { hasFactCheck ?
         <MediaArticleCard
+          claimSummary={factCheck.claim_description.context}
+          claimTitle={factCheck.claim_description.description}
           date={new Date(factCheck.updated_at * 1000)}
           id={factCheck.claim_description.id}
           key={factCheck.id}
@@ -38,8 +40,8 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
           removeDisabled={projectMedia.type === 'Blank'}
           statusColor={currentStatus ? currentStatus.style?.color : null}
           statusLabel={currentStatus ? currentStatus.label : null}
-          summary={isFactCheckValueBlank(factCheck.summary) ? factCheck.claim_description.context : factCheck.summary}
-          title={isFactCheckValueBlank(factCheck.title) ? factCheck.claim_description.description : factCheck.title}
+          summary={isFactCheckValueBlank(factCheck.summary) ? null : factCheck.summary}
+          title={isFactCheckValueBlank(factCheck.title) ? null : factCheck.title}
           url={factCheck.url}
           variant="fact-check"
           onClick={() => { setArticleToEdit(factCheck); }}

--- a/src/app/components/article/MediaArticlesDisplay.module.css
+++ b/src/app/components/article/MediaArticlesDisplay.module.css
@@ -7,6 +7,19 @@
   padding: 0 16px 16px;
   width: 100%;
 
+  .explainerCard {
+    opacity: 1;
+
+    &.explainerCardDimmed {
+      opacity: .15;
+      transition: opacity 225ms cubic-bezier(0, 0, .2, 1) 0ms;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+
   &::before {
     background-color: var(--color-white-100);
     content: '';
@@ -19,8 +32,4 @@
     right: 0;
     z-index: 2;
   }
-}
-
-.explainerCard:hover {
-  opacity: 1 !important;
 }

--- a/src/app/components/cds/media-cards/Card.module.css
+++ b/src/app/components/cds/media-cards/Card.module.css
@@ -82,6 +82,18 @@
       overflow: hidden;
     }
 
+    .cardSummaryClaimContent {
+      display: flex;
+      flex-direction: column;
+      margin: 0 0 8px;
+
+      &.cardSummaryClaimFactCheck {
+        border-bottom: solid 2px var(--color-gray-96);
+        margin: 0;
+        padding: 0 0 6px;
+      }
+    }
+
     .toggleCollapse {
       align-items: center;
       background-color: var(--color-blue-98);


### PR DESCRIPTION
## Description

- Lupa expressed a strong desire to bring the claim information into the media article cards for the list of articles on the media cluster item page. This PR brings that information in when available.
- Also moved the Rating information to the footer of the card and used the shared rating component to DRY things up a bit

References: CV2-5445

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual testing and smoke tests

## Things to pay attention to during code review

### AFTER - Claim and Fact Check, with long claim text truncated
<img width="579" alt="Screenshot 2024-10-08 at 10 28 46 AM" src="https://github.com/user-attachments/assets/e81b3cee-904a-4732-ab42-b26da0f190a9">

### AFTER - Claim only, no fact-check
<img width="646" alt="Screenshot 2024-10-08 at 10 22 51 AM" src="https://github.com/user-attachments/assets/b6d608f5-34fc-439a-8ca6-0147b25a1f8d">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [x] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
