### PR TITLE
Add time to request status tickers

### DIFF
--- a/src/app/components/TimeBefore.js
+++ b/src/app/components/TimeBefore.js
@@ -8,10 +8,16 @@ function hoursDiff(date2, date1) {
   return Math.abs(Math.round(diff));
 }
 
-const TimeBefore = ({ date, intl }) => {
+const TimeBefore = ({ date, includeTime, intl }) => {
   if (new Date(date).toString() === 'Invalid Date') {
     return '-';
   }
+
+  const dateOptions = includeTime
+    ? {
+      month: 'short', year: 'numeric', day: '2-digit', hour: 'numeric', minute: 'numeric',
+    }
+    : { month: 'short', year: 'numeric', day: '2-digit' };
   return (
     <FormattedDate
       day="numeric"
@@ -24,7 +30,7 @@ const TimeBefore = ({ date, intl }) => {
       {title => (
         <time dateTime={date.toISOString()} title={title}>
           { hoursDiff(new Date(), date) >= 24 ?
-            date.toLocaleDateString(intl.locale, { month: 'short', year: 'numeric', day: '2-digit' }) :
+            date.toLocaleDateString(intl.locale, dateOptions) :
             <FormattedRelative value={date} /> }
         </time>
       )}
@@ -32,8 +38,13 @@ const TimeBefore = ({ date, intl }) => {
   );
 };
 
+TimeBefore.defaultProps = {
+  includeTime: false,
+};
+
 TimeBefore.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
+  includeTime: PropTypes.bool,
   intl: intlShape.isRequired,
 };
 

--- a/src/app/components/TimeBefore.test.js
+++ b/src/app/components/TimeBefore.test.js
@@ -24,4 +24,18 @@ describe('<TimeBefore />', () => {
     expect(content.length).toEqual(1);
     expect(content.text()).toMatch('2017');
   });
+
+  it('should display date and time when includeTime is true', () => {
+    const wrapper = mountWithIntlProvider(<TimeBefore date={new Date('2023-10-01T10:30:00Z')} includeTime />);
+    const content = wrapper.find('time');
+    expect(content.text()).toMatch('2023');
+    expect(content.text()).toMatch('10:30 AM');
+  });
+
+  it('should display only date when includeTime is not passed', () => {
+    const wrapper = mountWithIntlProvider(<TimeBefore date={new Date('2023-10-01T10:30:00Z')} />);
+    const content = wrapper.find('time');
+    expect(content.text()).toMatch('2023');
+    expect(content.text()).not.toMatch('10:30 AM');
+  });
 });

--- a/src/app/components/annotations/TiplineRequest.js
+++ b/src/app/components/annotations/TiplineRequest.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';
@@ -164,7 +163,7 @@ const TiplineRequest = ({
       ) : (
         intl.formatMessage(messages.smoochNoMessage)
       )}
-      time={<TimeBefore date={updatedAt} />}
+      time={<TimeBefore date={updatedAt} includeTime />}
     />
   );
 };
@@ -174,6 +173,12 @@ TiplineRequest.defaultProps = {
 };
 
 TiplineRequest.propTypes = {
+  annotated: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    media: PropTypes.shape({
+      file_path: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
   annotation: PropTypes.shape({
     smooch_data: PropTypes.object.isRequired,
     created_at: PropTypes.string.isRequired,
@@ -182,12 +187,6 @@ TiplineRequest.propTypes = {
     smooch_report_update_received_at: PropTypes.number,
     associated_graphql_id: PropTypes.string.isRequired,
     dbid: PropTypes.number.isRequired,
-  }).isRequired,
-  annotated: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    media: PropTypes.shape({
-      file_path: PropTypes.string.isRequired,
-    }).isRequired,
   }).isRequired,
   hideButtons: PropTypes.bool,
   intl: intlShape.isRequired,


### PR DESCRIPTION
## Description

We need to display the time along with the date in the request status tickers. However, since the TimeBefore component is reused in multiple places across the codebase, adding the includeTime prop allows us to extend its functionality without affecting other areas where we only want to show the date. This change ensures flexibility by including the time where necessary while maintaining the existing behavior in components that don't require it.


-  [X] display the time along with the date in request status tickers.
-  [X] add a new includeTime prop to control whether or not the time is shown.
-  [X] Add unit tests
-  [X] remove /* eslint-disable react/sort-prop-types */ from the component

Reference: CV2-4050

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- add unit tests and also testing locally checking that the time is being displayed in the request status tickers

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
