### PR TITLE
allow all flash messages to be dismissed by user [CV2-5462]

### DIFF
--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -63,9 +63,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
                 content={msg}
                 floating
                 variant={variant}
-                onClose={persist ? () => {
-                  closeSnackbar(key);
-                } : null}
+                onClose={() => { closeSnackbar(key); }}
               />
             </div>
           ),
@@ -89,9 +87,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
                 floating
                 title={<>{createFriendlyErrorMessageTitle(msg)}</>}
                 variant={variant}
-                onClose={persist ? () => {
-                  closeSnackbar(key);
-                } : null}
+                onClose={() => { closeSnackbar(key); }}
               />
             </div>
           ),
@@ -114,9 +110,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
               content={message}
               floating
               variant={variant}
-              onClose={persist ? () => {
-                closeSnackbar(key);
-              } : null}
+              onClose={() => { closeSnackbar(key); }}
             />
           </div>
         ),


### PR DESCRIPTION
## Description

Suggestion by Jessie to allow users to dismiss any flash message. Before this PR only flash messages that persist on the screen were closable. No real reason to not allow the user to dismiss the flash message before the timeout removes it for the user. Some people are impatient! 

References: CV2-5462

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

sandbox verification

## Things to pay attention to during code review

### AFTER - the flash messages all now have the X in the upper right to dismiss
<img width="352" alt="Screenshot 2024-10-16 at 10 49 58 AM" src="https://github.com/user-attachments/assets/d2dca1cf-8213-43ae-8470-b28bde956836">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
