### PR TITLE
Avoid crash in ratings chart when rating was removed from workspace settings

### DIFF
--- a/localization/react-intl/src/app/components/dashboard/VerticalBarFactChecksByRating.json
+++ b/localization/react-intl/src/app/components/dashboard/VerticalBarFactChecksByRating.json
@@ -3,5 +3,10 @@
     "id": "verticalBarFactChecksByRating.title",
     "description": "Title for the number of fact-checks by rating widget",
     "defaultMessage": "Claim & Fact-Checks"
+  },
+  {
+    "id": "verticalBarFactChecksByRating.removed",
+    "description": "Label for the fact-checks ratings chart for a rating that was removed",
+    "defaultMessage": "(removed)"
   }
 ]

--- a/localization/react-intl/src/app/components/dashboard/VerticalBarFactChecksByRating.json
+++ b/localization/react-intl/src/app/components/dashboard/VerticalBarFactChecksByRating.json
@@ -3,10 +3,5 @@
     "id": "verticalBarFactChecksByRating.title",
     "description": "Title for the number of fact-checks by rating widget",
     "defaultMessage": "Claim & Fact-Checks"
-  },
-  {
-    "id": "verticalBarFactChecksByRating.removed",
-    "description": "Label for the fact-checks ratings chart for a rating that was removed",
-    "defaultMessage": "(removed)"
   }
 ]

--- a/src/app/components/dashboard/VerticalBarFactChecksByRating.js
+++ b/src/app/components/dashboard/VerticalBarFactChecksByRating.js
@@ -16,7 +16,7 @@ const VerticalBarFactChecksByRating = ({ language, statistics, team }) => (
       <VerticalBarChartWidget
         data={
           Object.entries(statistics.number_of_fact_checks_by_rating).map(([name, value]) => ({
-            name: getStatus(team.verification_statuses, name, language).label,
+            name: getStatus(team.verification_statuses, name, language).label || name,
             value,
             color: getStatusStyle(getStatus(team.verification_statuses, name), 'color'),
           }))

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -42,7 +42,7 @@ function getStatus(statusesParam, id, language, defaultLanguage) {
       status = JSON.parse(JSON.stringify(st));
     }
   });
-  if (language) {
+  if (language && status.locales) {
     const defaultLabel = status.locales[defaultLanguage || 'en'] ?
       status.locales[defaultLanguage || 'en'].label : '';
     status.label = status.locales[language] ?


### PR DESCRIPTION
## Description

In the fact-check chart "by rating", fallback to the rating ID when the rating was removed from the workspace settings. This avoids a crash in the app.

Reference: CV2-4111.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

I was able to reproduce locally this same situation that was reported on QA.

## Things to pay attention to during code review

Do sure if falling back to the ID is the best solution. Alternatives:

- Use a hard-coded fallback label like "(removed)" or "(other)"
- Don't show in the chart

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
