### PR TITLE
Fix Error when searching for removed imported fact-check 

### DIFF
--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -388,9 +388,9 @@ const AutoCompleteMediaItem = (props, context) => {
                     statusColor={currentStatus ? currentStatus.style?.color : null}
                     statusLabel={currentStatus ? currentStatus.label : null}
                     summary={isFactCheckValueBlank(projectMedia.fact_check.summary) ? projectMedia.fact_check.claim_description?.description : projectMedia.fact_check.summary}
-                    tags={projectMedia.fact_check?.tags}
+                    tags={projectMedia.fact_check.tags}
                     title={isFactCheckValueBlank(projectMedia.fact_check.title) ? projectMedia.fact_check.claim_description?.context : projectMedia.fact_check.title}
-                    url={projectMedia.fact_check?.url}
+                    url={projectMedia.fact_check.url}
                     variant="fact-check"
                     onChangeTags={() => {}}
                   />

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -333,6 +333,15 @@ const AutoCompleteMediaItem = (props, context) => {
         <div className={styles['media-item-autocomplete-results']}>
           { searchResult.items.map((projectMedia) => {
             let currentStatus = null;
+
+            /* If the selected item type is fact-check and the projectMedia lacks a fact-check, return null.
+            This may be due to a missing ElasticSearch update or a race condition during the update process,
+            where fact-check data is temporarily unavailable. This avoids showing stale or invalid data.
+            */
+            if (props.selectedItemType === 'fact-check' && !projectMedia.fact_check) {
+              return null;
+            }
+
             if (projectMedia.fact_check?.rating) {
               currentStatus = getStatus(searchResult.team.verification_statuses, projectMedia.fact_check.rating);
             }
@@ -369,18 +378,18 @@ const AutoCompleteMediaItem = (props, context) => {
                 { props.selectedItemType === 'fact-check' ?
                   <ArticleCard
                     className={selectedDbid === projectMedia.dbid ? styles['media-item-autocomplete-selected-item'] : null}
-                    date={projectMedia.fact_check?.updated_at}
+                    date={projectMedia.fact_check.updated_at}
                     handleClick={e => handleClick(e, projectMedia.dbid)}
-                    isPublished={projectMedia.fact_check?.report_status === 'published'}
+                    isPublished={projectMedia.fact_check.report_status === 'published'}
                     key={projectMedia.id}
-                    languageCode={projectMedia.fact_check?.language !== 'und' ? projectMedia.fact_check?.language : null}
-                    publishedAt={projectMedia.fact_check?.claim_description?.updated_at}
+                    languageCode={projectMedia.fact_check.language !== 'und' ? projectMedia.fact_check.language : null}
+                    publishedAt={projectMedia.fact_check.claim_description?.updated_at}
                     readOnly
                     statusColor={currentStatus ? currentStatus.style?.color : null}
                     statusLabel={currentStatus ? currentStatus.label : null}
-                    summary={isFactCheckValueBlank(projectMedia.fact_check?.summary) ? projectMedia.fact_check?.claim_description?.description : projectMedia.fact_check?.summary}
+                    summary={isFactCheckValueBlank(projectMedia.fact_check.summary) ? projectMedia.fact_check.claim_description?.description : projectMedia.fact_check.summary}
                     tags={projectMedia.fact_check?.tags}
-                    title={isFactCheckValueBlank(projectMedia.fact_check?.title) ? projectMedia.fact_check?.claim_description?.context : projectMedia.fact_check?.title}
+                    title={isFactCheckValueBlank(projectMedia.fact_check.title) ? projectMedia.fact_check.claim_description?.context : projectMedia.fact_check.title}
                     url={projectMedia.fact_check?.url}
                     variant="fact-check"
                     onChangeTags={() => {}}

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -368,19 +368,19 @@ const AutoCompleteMediaItem = (props, context) => {
                 { props.selectedItemType === 'fact-check' ?
                   <ArticleCard
                     className={selectedDbid === projectMedia.dbid ? styles['media-item-autocomplete-selected-item'] : null}
-                    date={projectMedia.fact_check.updated_at}
+                    date={projectMedia.fact_check?.updated_at}
                     handleClick={e => handleClick(e, projectMedia.dbid)}
-                    isPublished={projectMedia.fact_check.report_status === 'published'}
+                    isPublished={projectMedia.fact_check?.report_status === 'published'}
                     key={projectMedia.id}
-                    languageCode={projectMedia.fact_check.language !== 'und' ? projectMedia.fact_check.language : null}
-                    publishedAt={projectMedia.fact_check.claim_description?.updated_at}
+                    languageCode={projectMedia.fact_check?.language !== 'und' ? projectMedia.fact_check?.language : null}
+                    publishedAt={projectMedia.fact_check?.claim_description?.updated_at}
                     readOnly
                     statusColor={currentStatus ? currentStatus.style?.color : null}
                     statusLabel={currentStatus ? currentStatus.label : null}
-                    summary={isFactCheckValueBlank(projectMedia.fact_check.summary) ? projectMedia.fact_check.claim_description?.description : projectMedia.fact_check.summary}
-                    tags={projectMedia.fact_check.tags}
-                    title={isFactCheckValueBlank(projectMedia.fact_check.title) ? projectMedia.fact_check.claim_description?.context : projectMedia.fact_check.title}
-                    url={projectMedia.fact_check.url}
+                    summary={isFactCheckValueBlank(projectMedia.fact_check?.summary) ? projectMedia.fact_check?.claim_description?.description : projectMedia.fact_check?.summary}
+                    tags={projectMedia.fact_check?.tags}
+                    title={isFactCheckValueBlank(projectMedia.fact_check?.title) ? projectMedia.fact_check?.claim_description?.context : projectMedia.fact_check?.title}
+                    url={projectMedia.fact_check?.url}
                     variant="fact-check"
                     onChangeTags={() => {}}
                   />


### PR DESCRIPTION
## Description

Add safe navigation to avoid the crash with the error:

`AutoCompleteMediaItem.js:258 TypeError: Cannot read properties of null (reading 'updated_at')
    at AutoCompleteMediaItem.js:371:51
    at Array.map (<anonymous>)
    at bq (AutoCompleteMediaItem.js:333:32)
    at to (react-dom.production.min.js:157:137)
    at Yo (react-dom.production.min.js:180:154)
    at Hs (react-dom.production.min.js:269:343)
    at Mu (react-dom.production.min.js:250:347)
    at wu (react-dom.production.min.js:250:278)
    at _u (react-dom.production.min.js:250:138)
    at fu (react-dom.production.min.js:243:163)
    at react-dom.production.min.js:123:115
    at t.unstable_runWithPriority (scheduler.production.min.js:18:343)
    at Ha (react-dom.production.min.js:122:325)
    at Ua (react-dom.production.min.js:123:61)
    at Wa (react-dom.production.min.js:122:428)
    at su (react-dom.production.min.js:237:203)
    at xo (react-dom.production.min.js:170:408)`

that was happening when searching for removed imported fact-check, probably due to a race condition. 

Reference: CV2-5600

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
