### PR TITLE
Sort results by score in the media auto-complete modal.

### DIFF
--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -105,6 +105,7 @@ const AutoCompleteMediaItem = (props, context) => {
     eslimit: 50,
     archived: [CheckArchivedFlags.NONE, CheckArchivedFlags.UNCONFIRMED],
     show_similar: Boolean(props.customFilter),
+    sort: 'score',
   };
   if (keywordFields) {
     query.keyword_fields = keywordFields;


### PR DESCRIPTION
## Description

We want to be sure that the best results come first. The default (so, when the `sort` key is not provided) is to show most recent first.

Reference: CV2-5672.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Before:

![CV2-5672-before](https://github.com/user-attachments/assets/195ddc28-effc-487b-a438-d7270f2a02ad)

After:

![CV2-5672-after](https://github.com/user-attachments/assets/10e51f3c-2f91-4eb8-b2b2-a9872061fd0e)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 