### PR TITLE
remove unnecessary code causing content warning broken state

### DIFF
--- a/src/app/components/media/MediaCardLarge.module.css
+++ b/src/app/components/media/MediaCardLarge.module.css
@@ -9,6 +9,7 @@
   > .video-media-card,
   > .webpage-media-card {
     flex: 1 1;
+    min-height: calc(226px * (16/9));
     min-width: calc(200px * (16/9));
   }
 

--- a/src/app/components/media/MediaCardLarge.module.css
+++ b/src/app/components/media/MediaCardLarge.module.css
@@ -12,10 +12,6 @@
     min-width: calc(200px * (16/9));
   }
 
-  .aspect-ratio-media-card {
-    padding: 0 0 16px;
-  }
-
   .pender-card-wrapper {
     .pender-card {
       min-height: 200px;


### PR DESCRIPTION
## Description

@amoedoamorim I noticed a bug on QA from my last PR:
https://github.com/meedan/check-web/pull/2214

It was causing the content warning to be clipped, in cases like when the media is no longer available, or being block by the browser (like mine was doing) see the screenshots below. This is just a quick css fix for that case

<img width="599" alt="Screenshot 2024-11-27 at 2 09 58 PM" src="https://github.com/user-attachments/assets/844fa4c8-66bf-4aad-a473-3f52343279e5">
### In this case:
<img width="584" alt="Screenshot 2024-11-27 at 2 09 51 PM" src="https://github.com/user-attachments/assets/04adf704-46b6-4e94-8a63-3a4a0b54a305">


