### PR TITLE
Fix/cv2 5735 apply admin filter to all thumbnails

### DIFF
--- a/src/app/components/cds/media-cards/ItemThumbnail.js
+++ b/src/app/components/cds/media-cards/ItemThumbnail.js
@@ -16,7 +16,7 @@ const ItemThumbnail = ({
   type,
   url,
 }) => {
-  const [generalContentMask, setGeneralContentMask] = React.useState(window.storage.getValue('contentMask') || maskContent);
+  const [generalContentMask, setGeneralContentMask] = React.useState(window.localStorage.getItem('contentMask') || maskContent);
   const isHidden = maskContent || (!ignoreGeneralContentMask && generalContentMask === 'true');
 
   useEffect(() => {

--- a/src/app/components/cds/media-cards/SmallMediaCard.js
+++ b/src/app/components/cds/media-cards/SmallMediaCard.js
@@ -14,6 +14,7 @@ const SmallMediaCard = ({
   className, // { type, url, domain, quote, picture, metadata }
   description,
   details,
+  ignoreGeneralContentMask,
   maskContent,
   media,
   onClick,
@@ -53,7 +54,7 @@ const SmallMediaCard = ({
       }
     >
       <div className={styles.smallMediaCard} onClick={onClick} onKeyDown={onClick}>
-        <ItemThumbnail maskContent={maskContent || superAdminMask} picture={media?.picture} size="small" type={media?.type} url={media?.url} />
+        <ItemThumbnail ignoreGeneralContentMask={ignoreGeneralContentMask} maskContent={maskContent || superAdminMask} picture={media?.picture} size="small" type={media?.type} url={media?.url} />
         <div className={styles.smallMediaCardContent}>
           <div className={styles.titleAndUrl}>
             <div className={cx('typography-subtitle2', styles.row, (media.url ? styles.oneLineDescription : styles.twoLinesDescription))}>
@@ -76,6 +77,7 @@ SmallMediaCard.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
   details: PropTypes.array,
+  ignoreGeneralContentMask: PropTypes.bool,
   maskContent: PropTypes.bool,
   media: PropTypes.shape({
     type: PropTypes.string.isRequired,
@@ -92,6 +94,7 @@ SmallMediaCard.propTypes = {
 SmallMediaCard.defaultProps = {
   details: null,
   description: null,
+  ignoreGeneralContentMask: true,
   maskContent: false,
   superAdminMask: false,
   onClick: () => {},

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -423,6 +423,7 @@ const AutoCompleteMediaItem = (props, context) => {
                           />
                         ),
                       ]}
+                      ignoreGeneralContentMask={props.ignoreGeneralContentMask}
                       maskContent={projectMedia.show_warning_cover}
                       media={projectMedia.media}
                       onClick={e => handleClick(e, projectMedia.dbid)}
@@ -452,6 +453,7 @@ AutoCompleteMediaItem.defaultProps = {
   customFilter: null,
   dbid: null,
   disablePublished: false,
+  ignoreGeneralContentMask: true,
   multiple: false,
   showFilters: false,
   typesToShow: ['claims', 'links', 'images', 'videos', 'audios'],
@@ -461,6 +463,7 @@ AutoCompleteMediaItem.propTypes = {
   customFilter: PropTypes.func,
   dbid: PropTypes.number, // filter results: do _not_ select this number
   disablePublished: PropTypes.bool,
+  ignoreGeneralContentMask: PropTypes.bool,
   multiple: PropTypes.bool,
   showFilters: PropTypes.bool,
   typesToShow: PropTypes.arrayOf(PropTypes.string),

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -247,6 +247,7 @@ class CreateRelatedMediaDialog extends React.Component {
                 customFilter={this.props.customFilter}
                 dbid={media ? media.dbid : null}
                 disablePublished={Boolean(this.props.disablePublished)}
+                ignoreGeneralContentMask={false}
                 key={action}
                 media={media}
                 multiple={action === 'addSimilarToThis'}

--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -268,7 +268,7 @@ class MediaActionsBarComponent extends Component {
 
     return (
       <div className={cx('media-actions-bar', styles['media-actions-wrapper'])}>
-        <ItemThumbnail maskContent={media.show_warning_cover} picture={media.media?.picture} type={media.media?.type} url={media.media?.url} />
+        <ItemThumbnail ignoreGeneralContentMask={false} maskContent={media.show_warning_cover} picture={media.media?.picture} type={media.media?.type} url={media.media?.url} />
         <div className={styles['media-actions-title']}>
           <ItemTitle projectMediaId={this.props.media?.dbid} />
           <div className={styles['media-actions-context']}>

--- a/src/app/components/media/SuperAdminControls.js
+++ b/src/app/components/media/SuperAdminControls.js
@@ -13,13 +13,6 @@ const SuperAdminControls = ({
   const [superAdminmaskContent, setSuperAdminMaskContent] = React.useState(maskSession);
   const [superAdminMaskContentSession, setSuperAdminMaskContentSession] = React.useState(maskSession);
 
-  useEffect(() => {
-    const mask = window.storage.getValue('contentMask');
-    if (mask !== null) {
-      setSuperAdminMaskContent(mask);
-    }
-  }, []);
-
   const updateStoredValue = (value) => {
     window.storage.set('contentMask', value);
     window.dispatchEvent(new StorageEvent('storage', {
@@ -27,6 +20,12 @@ const SuperAdminControls = ({
       newValue: value,
     }));
   };
+
+  useEffect(() => {
+    // this will be later updated to pull a stored value in local storage
+    // but at the moment, just reset the local storage value to the default mask value
+    updateStoredValue(true);
+  }, []);
 
   const handleSuperAdminClickPage = () => {
     const newValue = !superAdminmaskContent;

--- a/src/app/components/media/SuperAdminControls.js
+++ b/src/app/components/media/SuperAdminControls.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
@@ -13,10 +13,26 @@ const SuperAdminControls = ({
   const [superAdminmaskContent, setSuperAdminMaskContent] = React.useState(maskSession);
   const [superAdminMaskContentSession, setSuperAdminMaskContentSession] = React.useState(maskSession);
 
+  useEffect(() => {
+    const mask = window.storage.getValue('contentMask');
+    if (mask !== null) {
+      setSuperAdminMaskContent(mask);
+    }
+  }, []);
+
+  const updateStoredValue = (value) => {
+    window.storage.set('contentMask', value);
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'contentMask',
+      newValue: value,
+    }));
+  };
+
   const handleSuperAdminClickPage = () => {
     const newValue = !superAdminmaskContent;
     setSuperAdminMaskContent(newValue);
     handleSuperAdminMask(newValue);
+    updateStoredValue(newValue);
   };
 
   const handleSuperAdminClickSession = () => {
@@ -26,6 +42,7 @@ const SuperAdminControls = ({
     // Call methods for apply admin screen on this page to apply session action to current page
     setSuperAdminMaskContent(newValue);
     handleSuperAdminMask(newValue);
+    updateStoredValue(newValue);
   };
 
   return (


### PR DESCRIPTION
## Description

The admin content filter now puts a value to local storage.  This lets items not in the component tree pull from the same value.  Added a check in the ItemThumbnail component that looks for this flag and uses that to also determine if content should be hidden.  Also added a prop to ItemThumbnail that by default ignores this new localstorage value, to avoid impacts to other pages in the application.  For the item main icon and the search results in the Merge items, that value is set to false, allowing the thumbnail to be hidden by the admin flag.  

References: CV2-5735

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
