### PR TITLE
Clean up to media card actions

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaCardLargeActions.json
+++ b/localization/react-intl/src/app/components/media/MediaCardLargeActions.json
@@ -2,16 +2,16 @@
   {
     "id": "mediaMetadata.openLink",
     "description": "Menu option for navigating to the original media url",
-    "defaultMessage": "Open link"
+    "defaultMessage": "Open Link"
   },
   {
     "id": "mediaMetadata.ImageSearch",
     "description": "Menu option for performing reverse image searches on google or other engines",
-    "defaultMessage": "Reverse image search"
+    "defaultMessage": "Reverse Image Search"
   },
   {
     "id": "mediaCardLarge.more",
     "description": "Button to open an expanded view of the media",
-    "defaultMessage": "More"
+    "defaultMessage": "More…"
   }
 ]

--- a/localization/react-intl/src/app/components/media/OcrButton.json
+++ b/localization/react-intl/src/app/components/media/OcrButton.json
@@ -17,6 +17,6 @@
   {
     "id": "ocrButton.label",
     "description": "Button label - when this button is clicked, text is extracted from image",
-    "defaultMessage": "Extract text from this media"
+    "defaultMessage": "Extract Text from Media"
   }
 ]

--- a/localization/react-intl/src/app/components/media/RefreshButton.json
+++ b/localization/react-intl/src/app/components/media/RefreshButton.json
@@ -5,6 +5,11 @@
     "defaultMessage": "Media refreshed successfully"
   },
   {
+    "id": "refreshButton.labelWait",
+    "description": "Button label to indicate that media is being refreshed",
+    "defaultMessage": "Refreshing, please wait…"
+  },
+  {
     "id": "refreshButton.label",
     "description": "Button label to initiate the refresh of media is content",
     "defaultMessage": "Refresh Media"

--- a/localization/react-intl/src/app/components/media/TranscriptionButton.json
+++ b/localization/react-intl/src/app/components/media/TranscriptionButton.json
@@ -12,11 +12,11 @@
   {
     "id": "transcriptionButton.inProgress",
     "description": "Message displayed when transcription operation hasn't started yet",
-    "defaultMessage": "Requesting transcription…"
+    "defaultMessage": "Requesting Transcription…"
   },
   {
     "id": "transcriptionButton.label",
     "description": "Button label - when this button is clicked, transcription operation starts",
-    "defaultMessage": "Transcribe this Media"
+    "defaultMessage": "Transcribe Media"
   }
 ]

--- a/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialog.module.css
+++ b/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialog.module.css
@@ -6,13 +6,13 @@
     position: relative;
 
     &::after {
-      background-color: var(--color-blue-81);
+      background-color: var(--color-gray-88);
       bottom: 0;
       content: '';
       left: 50%;
       position: absolute;
       top: 0;
-      width: 2px;
+      width: 1px;
     }
 
     > div {

--- a/src/app/components/media/MediaCardLarge.js
+++ b/src/app/components/media/MediaCardLarge.js
@@ -129,7 +129,7 @@ const MediaCardLarge = ({
           >
             { data.title ?
               <div className={cx('media-card-large__title', styles['media-card-large-title'])}>
-                { pinned ?
+                { pinned && !inModal ?
                   <PushPinIcon /> : null }
                 {data.title}
               </div> : null }

--- a/src/app/components/media/MediaCardLarge.module.css
+++ b/src/app/components/media/MediaCardLarge.module.css
@@ -77,6 +77,7 @@
     padding: 16px;
 
     blockquote {
+      @mixin typography-body1;
       -webkit-box-orient: vertical;
       display: -webkit-box; /* stylelint-disable-line */
       hyphens: auto;
@@ -117,6 +118,7 @@
       gap: 8px;
 
       blockquote {
+        @mixin typography-body2;
         -webkit-box-orient: vertical;
         display: -webkit-box; /* stylelint-disable-line */
         hyphens: auto;
@@ -131,21 +133,13 @@
       .media-card-large-footer-actions {
         align-items: center;
         display: flex;
+        flex-flow: row wrap;
         gap: 4px;
-
-        > div {
-          display: flex;
-          gap: 4px;
-        }
 
         &.media-card-large-footer-modal-actions {
           border-bottom: 1px solid var(--color-blue-81);
           padding-bottom: 16px;
         }
-      }
-
-      &.media-card-large-footer-modal {
-        padding: 16px 0;
       }
     }
   }

--- a/src/app/components/media/MediaCardLargeActions.js
+++ b/src/app/components/media/MediaCardLargeActions.js
@@ -3,24 +3,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
-import {
-  Menu,
-  MenuItem,
-} from '@material-ui/core';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
 import cx from 'classnames/bind';
 import RefreshButton from './RefreshButton';
 import OcrButton from './OcrButton';
 import TranscriptionButton from './TranscriptionButton';
 import MediaLanguageSwitcher from './MediaLanguageSwitcher';
-import ExternalLink from '../ExternalLink';
-import MoreVertIcon from '../../icons/more_vert.svg';
 import SearchIcon from '../../icons/search.svg';
 import OpenInNewIcon from '../../icons/open_in_new.svg';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import styles from './MediaCardLarge.module.css';
-import mediaStyles from './media.module.css';
 
 const ExtraMediaActions = ({
   projectMedia,
@@ -31,82 +22,60 @@ const ExtraMediaActions = ({
   const isPicture = !!projectMedia.picture && !isYoutubeVideo;
   const isVideo = isYoutubeVideo || isUploadedVideo;
   const allowsReverseSearch = isPicture || isVideo;
-  const [anchorEl, setAnchorEl] = React.useState(null);
-
-  const handleMenuAndClose = (callback) => {
-    if (callback) callback();
-    setAnchorEl(null);
-  };
 
   if (projectMedia.media.type === 'Claim') return null;
 
   return (
-    <div className="media-expanded-actions">
-      <ButtonMain
-        buttonProps={{
-          id: 'media-expanded-actions__menu',
-        }}
-        iconCenter={<MoreVertIcon />}
-        size="small"
-        theme="text"
-        variant="contained"
-        onClick={e => setAnchorEl(e.currentTarget)}
-      />
-      <Menu
-        anchorEl={anchorEl}
-        className={mediaStyles.mediaMenuList}
-        open={Boolean(anchorEl)}
-        onClose={() => setAnchorEl(null)}
-      >
-        { (projectMedia.media && projectMedia.media.url) ?
-          <MenuItem className={mediaStyles.mediaMenuItem} onClick={() => setAnchorEl(null)}>
-            <ListItemIcon className={mediaStyles.mediaMenuIcon}>
-              <OpenInNewIcon />
-            </ListItemIcon>
-            <ExternalLink
-              style={{ color: 'unset', textDecoration: 'none' }}
-              url={projectMedia.media.url}
-            >
-              <FormattedMessage
-                defaultMessage="Open link"
-                description="Menu option for navigating to the original media url"
-                id="mediaMetadata.openLink"
-              />
-            </ExternalLink>
-          </MenuItem> : null }
-        <TranscriptionButton
-          projectMediaId={projectMedia.id}
-          projectMediaType={projectMedia.media.type}
-          transcription={projectMedia.transcription}
-          onClick={() => setAnchorEl(null)}
-        />
-        { allowsReverseSearch ?
-          <MenuItem
-            className={mediaStyles.mediaMenuItem}
-            id="media-expanded-actions__reverse-image-search"
-            onClick={() => handleMenuAndClose(reverseImageSearchGoogle)}
-          >
-            <ListItemIcon className={mediaStyles.mediaMenuIcon}>
-              <SearchIcon />
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                <FormattedMessage
-                  defaultMessage="Reverse image search"
-                  description="Menu option for performing reverse image searches on google or other engines"
-                  id="mediaMetadata.ImageSearch"
-                />
-              }
+    <>
+      { (projectMedia.media && projectMedia.media.url) ?
+        <ButtonMain
+          buttonProps={{
+            id: 'media-expanded-actions__reverse-image-search',
+          }}
+          iconLeft={<OpenInNewIcon />}
+          label={
+            <FormattedMessage
+              defaultMessage="Open Link"
+              description="Menu option for navigating to the original media url"
+              id="mediaMetadata.openLink"
             />
-          </MenuItem> : null }
-        <OcrButton
-          hasExtractedText={Boolean(projectMedia.extracted_text)}
-          projectMediaId={projectMedia.id}
-          projectMediaType={projectMedia.media.type}
-          onClick={() => setAnchorEl(null)}
-        />
-      </Menu>
-    </div>
+          }
+          size="small"
+          theme="text"
+          variant="contained"
+          onClick={() => window.open(projectMedia.media.url)}
+        /> : null
+      }
+      <TranscriptionButton
+        projectMediaId={projectMedia.id}
+        projectMediaType={projectMedia.media.type}
+        transcription={projectMedia.transcription}
+      />
+      { allowsReverseSearch ?
+        <ButtonMain
+          buttonProps={{
+            id: 'media-expanded-actions__reverse-image-search',
+          }}
+          iconLeft={<SearchIcon />}
+          label={
+            <FormattedMessage
+              defaultMessage="Reverse Image Search"
+              description="Menu option for performing reverse image searches on google or other engines"
+              id="mediaMetadata.ImageSearch"
+            />
+          }
+          size="small"
+          theme="text"
+          variant="contained"
+          onClick={() => reverseImageSearchGoogle()}
+        /> : null
+      }
+      <OcrButton
+        hasExtractedText={Boolean(projectMedia.extracted_text)}
+        projectMediaId={projectMedia.id}
+        projectMediaType={projectMedia.media.type}
+      />
+    </>
   );
 };
 
@@ -128,41 +97,46 @@ class MediaExpandedActions extends React.Component {
     if (media.type === 'Blank') return null;
 
     return (
-      <div
-        className={cx(
-          styles['media-card-large-footer-actions'],
-          {
-            [styles['media-card-large-footer-modal-actions']]: bottomSeparator,
-          })
+      <>
+        { inModal ?
+          <MediaLanguageSwitcher projectMedia={projectMedia} />
+          : null
         }
-      >
-        { !inModal ?
-          <ButtonMain
-            iconRight={<OpenInNewIcon />}
-            label={
-              <FormattedMessage
-                defaultMessage="More"
-                description="Button to open an expanded view of the media"
-                id="mediaCardLarge.more"
+        <div
+          className={cx(
+            styles['media-card-large-footer-actions'],
+            {
+              [styles['media-card-large-footer-modal-actions']]: bottomSeparator,
+            })
+          }
+        >
+          { media.type !== 'Claim' ?
+            <>
+              { media.type === 'Link' ? <RefreshButton projectMediaId={projectMedia.id} /> : null }
+              <ExtraMediaActions
+                projectMedia={projectMedia}
+                reverseImageSearchGoogle={this.reverseImageSearchGoogle.bind(this)}
               />
-            }
-            size="small"
-            theme="text"
-            variant="contained"
-            onClick={onClickMore}
-          />
-          : <MediaLanguageSwitcher projectMedia={projectMedia} />
-        }
-        { media.type !== 'Claim' ?
-          <>
-            { media.type === 'Link' ?
-              <RefreshButton projectMediaId={projectMedia.id} /> : null }
-            <ExtraMediaActions
-              projectMedia={projectMedia}
-              reverseImageSearchGoogle={this.reverseImageSearchGoogle.bind(this)}
+            </> : null
+          }
+          { !inModal ?
+            <ButtonMain
+              label={
+                <FormattedMessage
+                  defaultMessage="More…"
+                  description="Button to open an expanded view of the media"
+                  id="mediaCardLarge.more"
+                />
+              }
+              size="small"
+              theme="text"
+              variant="contained"
+              onClick={onClickMore}
             />
-          </> : null }
-      </div>
+            : null
+          }
+        </div>
+      </>
     );
   }
 }

--- a/src/app/components/media/MediaCardLargeFooter.js
+++ b/src/app/components/media/MediaCardLargeFooter.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql, createFragmentContainer } from 'react-relay/compat';
 import { FormattedMessage, FormattedDate } from 'react-intl';
-import cx from 'classnames/bind';
 import MediaCardLargeFooterContent from './MediaCardLargeFooterContent';
 import MediaCardLargeActions from './MediaCardLargeActions';
 import MediaSlug from './MediaSlug';
@@ -68,14 +67,7 @@ const MediaCardLargeFooter = ({
   );
 
   return (
-    <div
-      className={cx(
-        styles['media-card-large-footer'],
-        {
-          [styles['media-card-large-footer-modal']]: inModal,
-        })
-      }
-    >
+    <div className={styles['media-card-large-footer']}>
       { /* 1st MediaLargeFooterContent, exclusive for Link, always displays URL above MediaCardLargeActions */}
       { projectMedia.type === 'Link' ?
         <MediaCardLargeFooterContent

--- a/src/app/components/media/OcrButton.js
+++ b/src/app/components/media/OcrButton.js
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { graphql, commitMutation } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
-import MenuItem from '@material-ui/core/MenuItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import DescriptionIcon from '../../icons/description.svg';
 import { withSetFlashMessage } from '../FlashMessage';
-import styles from './media.module.css';
 
 const OcrButton = ({
   hasExtractedText,
@@ -80,34 +77,30 @@ const OcrButton = ({
   }
 
   return (
-    <MenuItem
-      className={styles.mediaMenuItem}
-      disabled={pending}
-      id="ocr-button__extract-text"
-      onClick={handleClick}
-    >
-      { pending ?
-        <FormattedMessage
-          defaultMessage="Text extraction in progress…"
-          description="Message displayed while text is being extracted from an image"
-          id="ocrButton.inProgress"
-        /> :
-        <>
-          <ListItemIcon className={styles.mediaMenuIcon}>
-            <DescriptionIcon />
-          </ListItemIcon>
-          <ListItemText
-            primary={
-              <FormattedMessage
-                defaultMessage="Extract text from this media"
-                description="Button label - when this button is clicked, text is extracted from image"
-                id="ocrButton.label"
-              />
-            }
+    <ButtonMain
+      buttonProps={{
+        id: 'ocr-button__extract-text',
+      }}
+      iconLeft={<DescriptionIcon />}
+      label={
+        pending ?
+          <FormattedMessage
+            defaultMessage="Text extraction in progress…"
+            description="Message displayed while text is being extracted from an image"
+            id="ocrButton.inProgress"
           />
-        </>
+          :
+          <FormattedMessage
+            defaultMessage="Extract Text from Media"
+            description="Button label - when this button is clicked, text is extracted from image"
+            id="ocrButton.label"
+          />
       }
-    </MenuItem>
+      size="small"
+      theme="text"
+      variant="contained"
+      onClick={handleClick}
+    />
   );
 };
 

--- a/src/app/components/media/RefreshButton.js
+++ b/src/app/components/media/RefreshButton.js
@@ -69,11 +69,18 @@ const RefreshButton = ({ projectMediaId, setFlashMessage }) => {
       disabled={waitRequest}
       iconLeft={<RefreshIcon />}
       label={
-        <FormattedMessage
-          defaultMessage="Refresh Media"
-          description="Button label to initiate the refresh of media is content"
-          id="refreshButton.label"
-        />
+        waitRequest ?
+          <FormattedMessage
+            defaultMessage="Refreshing, please wait…"
+            description="Button label to indicate that media is being refreshed"
+            id="refreshButton.labelWait"
+          />
+          :
+          <FormattedMessage
+            defaultMessage="Refresh Media"
+            description="Button label to initiate the refresh of media is content"
+            id="refreshButton.label"
+          />
       }
       size="small"
       theme="text"

--- a/src/app/components/media/TranscriptionButton.js
+++ b/src/app/components/media/TranscriptionButton.js
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { graphql, commitMutation } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import MenuItem from '@material-ui/core/MenuItem';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import TranscribeIcon from '../../icons/transcribe.svg';
 import { withSetFlashMessage } from '../FlashMessage';
-import styles from './media.module.css';
 
 const TranscriptionButton = ({
   onClick,
@@ -80,34 +77,31 @@ const TranscriptionButton = ({
   }
 
   return (
-    <MenuItem
-      className={styles.mediaMenuItem}
+    <ButtonMain
+      buttonProps={{
+        id: 'transcription-button__request-transcription',
+      }}
       disabled={pending || (transcription && transcription.data && transcription.data.last_response.job_status)}
-      id="transcription-button__request-transcription"
-      onClick={handleClick}
-    >
-      { pending ?
-        <FormattedMessage
-          defaultMessage="Requesting transcription…"
-          description="Message displayed when transcription operation hasn't started yet"
-          id="transcriptionButton.inProgress"
-        /> :
-        <>
-          <ListItemIcon className={styles.mediaMenuIcon}>
-            <TranscribeIcon />
-          </ListItemIcon>
-          <ListItemText
-            primary={
-              <FormattedMessage
-                defaultMessage="Transcribe this Media"
-                description="Button label - when this button is clicked, transcription operation starts"
-                id="transcriptionButton.label"
-              />
-            }
+      iconLeft={<TranscribeIcon />}
+      label={
+        pending ?
+          <FormattedMessage
+            defaultMessage="Requesting Transcription…"
+            description="Message displayed when transcription operation hasn't started yet"
+            id="transcriptionButton.inProgress"
           />
-        </>
+          :
+          <FormattedMessage
+            defaultMessage="Transcribe Media"
+            description="Button label - when this button is clicked, transcription operation starts"
+            id="transcriptionButton.label"
+          />
       }
-    </MenuItem>
+      size="small"
+      theme="text"
+      variant="contained"
+      onClick={handleClick}
+    />
   );
 };
 

--- a/test/spec/search_spec.rb
+++ b/test/spec/search_spec.rb
@@ -39,7 +39,6 @@ shared_examples 'search' do
     wait_for_selector('.image-media-card')
     expect((@driver.current_url.to_s =~ /google/).nil?).to be(true)
     current_window = @driver.window_handles.last
-    wait_for_selector('#media-expanded-actions__menu').click
     wait_for_selector('#media-expanded-actions__reverse-image-search').click
     @driver.switch_to.window(@driver.window_handles.last)
     expect((@driver.current_url.to_s =~ /google/).nil?).to be(false)


### PR DESCRIPTION
## Description

Simplify media card actions:
- don't hide media actions in a menu, we don't have a lot of them and more valuable to see right away
- improve dialog layout for language picker to separate from other actions
- Add refreshing media waiting text to match other patterns
- Only show push pin icon in the list, not in the dialog
- allow actions to wrap when necessary

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

manual and ran smoke tests

## Things to pay attention to during code review

### AFTER - Dialog
<img width="970" alt="Screenshot 2024-12-06 at 12 18 23 PM" src="https://github.com/user-attachments/assets/ce0407e9-f01d-4e92-9ee3-2d2214400d7b">

### AFTER - Large media card footer actions
<img width="1014" alt="Screenshot 2024-12-06 at 12 24 26 PM" src="https://github.com/user-attachments/assets/3dff9997-cf21-40cc-8702-47d247aca2d3">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
