### PR TITLE
fix/cv2-5791 tab wrapper wraps based on wrapContent prop

### DIFF
--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -320,7 +320,6 @@ const SandboxComponent = ({ admin }) => {
 
   const [categoryTab, setCategoryTab] = React.useState('all');
   const onChangeCategoryTab = (event) => {
-    console.log(event); // eslint-disable-line no-console
     setCategoryTab(event);
   };
 

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -36,11 +36,6 @@ import ParsedText from '../ParsedText';
 import ClusterCard from '../search/SearchResultsCards/ClusterCard';
 import CheckFeedDataPoints from '../../CheckFeedDataPoints';
 import { FlashMessageSetterContext } from '../FlashMessage';
-import {
-  getQueryStringValue,
-  pushQueryStringValue,
-  deleteQueryStringValue,
-} from '../../urlHelpers';
 import styles from './sandbox.module.css';
 
 const SandboxComponent = ({ admin }) => {
@@ -48,10 +43,6 @@ const SandboxComponent = ({ admin }) => {
   if (!isAdmin) {
     return null;
   }
-
-  let category = null;
-  category = getQueryStringValue('category');
-  const [selectedCategory, setSelectedTab] = React.useState(category);
 
   const [tags, setTags] = React.useState([
     'first',
@@ -327,6 +318,12 @@ const SandboxComponent = ({ admin }) => {
     setReorderTheme(event.target.value);
   };
 
+  const [categoryTab, setCategoryTab] = React.useState('all');
+  const onChangeCategoryTab = (event) => {
+    console.log(event); // eslint-disable-line no-console
+    setCategoryTab(event);
+  };
+
   const [sampleDataSet, setSampleDataSet] = React.useState('design');
   const [stackedBarChartEmptySection, setStackedBarChartEmptySection] = React.useState(true);
 
@@ -421,65 +418,72 @@ const SandboxComponent = ({ admin }) => {
     }
   };
 
-  const handleClick = (newCategory) => {
-    if (category !== newCategory) {
-      if (newCategory === 'all') {
-        setSelectedTab(null);
-        deleteQueryStringValue('category');
-      } else {
-        setSelectedTab(newCategory);
-        pushQueryStringValue('category', newCategory);
-      }
-    }
-  };
-
   return (
     <div className={styles.sandbox}>
       <h5>
         UI Sandbox&nbsp;<span aria-label="Beach" role="img">🏖️</span>
       </h5>
-      <ul className={styles.sandboxNav}>
-        <li>
-          <ButtonMain label="All" size="small" theme={!selectedCategory ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('all')} />
-        </li>
-        <li>
-          <ButtonMain label="Cards" size="small" theme={selectedCategory === 'cards' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('cards')} />
-        </li>
-        <li>
-          <ButtonMain label="Buttons" size="small" theme={selectedCategory === 'buttons' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('buttons')} />
-        </li>
-        <li>
-          <ButtonMain label="Inputs" size="small" theme={selectedCategory === 'inputs' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('inputs')} />
-        </li>
-        <li>
-          <ButtonMain label="Chips" size="small" theme={selectedCategory === 'chips' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('chips')} />
-        </li>
-        <li>
-          <ButtonMain label="Tags" size="small" theme={selectedCategory === 'tags' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('tags')} />
-        </li>
-        <li>
-          <ButtonMain label="Alerts &amp; Prompts" size="small" theme={selectedCategory === 'alerts' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('alerts')} />
-        </li>
-        <li>
-          <ButtonMain label="Text Display" size="small" theme={selectedCategory === 'text' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('text')} />
-        </li>
-        <li>
-          <ButtonMain label="Loading Animations" size="small" theme={selectedCategory === 'loaders' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('loaders')} />
-        </li>
-        <li>
-          <ButtonMain label="Slideout" size="small" theme={selectedCategory === 'slideout' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('slideout')} />
-        </li>
-        <li>
-          <ButtonMain label="Errors" size="small" theme={selectedCategory === 'errors' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('errors')} />
-        </li>
-        <li>
-          <ButtonMain label="Charts" size="small" theme={selectedCategory === 'charts' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('charts')} />
-        </li>
-        <li>
-          <ButtonMain label="Tabs" size="small" theme={selectedCategory === 'tabs' ? 'info' : 'lightText'} variant="contained" onClick={() => handleClick('tabs')} />
-        </li>
-      </ul>
-      { (!selectedCategory || selectedCategory === 'cards') &&
+      <TabWrapper
+        className={styles.sandboxNav}
+        tabs={[
+          {
+            label: 'All',
+            value: 'all',
+          },
+          {
+            label: 'Cards',
+            value: 'cards',
+          },
+          {
+            label: 'Buttons',
+            value: 'buttons',
+          },
+          {
+            label: 'Inputs',
+            value: 'inputs',
+          },
+          {
+            label: 'Chips',
+            value: 'chips',
+          },
+          {
+            label: 'Tags',
+            value: 'tags',
+          },
+          {
+            label: 'Alerts & Prompts',
+            value: 'alerts',
+          },
+          {
+            label: 'Text Display',
+            value: 'text',
+          },
+          {
+            label: 'Loading Animations',
+            value: 'loaders',
+          },
+          {
+            label: 'Slideout',
+            value: 'slideout',
+          },
+          {
+            label: 'Errors',
+            value: 'errors',
+          },
+          {
+            label: 'Charts',
+            value: 'charts',
+          },
+          {
+            label: 'Tabs',
+            value: 'tabs',
+          },
+        ]}
+        value={categoryTab}
+        wrapContent
+        onChange={onChangeCategoryTab}
+      />
+      { (categoryTab === 'all' || categoryTab === 'cards') &&
         <section>
           <h6>Item Cards</h6>
           <div className={styles.componentWrapper}>
@@ -708,7 +712,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'buttons') &&
+      { (categoryTab === 'all' || categoryTab === 'buttons') &&
         <section>
           <h6>Buttons</h6>
           <div className={styles.componentWrapper}>
@@ -971,7 +975,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'inputs') &&
+      { (categoryTab === 'all' || categoryTab === 'inputs') &&
         <section>
           <h6>Inputs</h6>
           <div className={styles.componentWrapper}>
@@ -1559,7 +1563,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'chips') &&
+      { (categoryTab === 'all' || categoryTab === 'chips') &&
         <section>
           <h6>Chips</h6>
           <div className={styles.componentWrapper}>
@@ -1596,7 +1600,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'tags') &&
+      { (categoryTab === 'all' || categoryTab === 'tags') &&
         <section>
           <h6>Tags</h6>
           <div className={styles.componentWrapper}>
@@ -1657,7 +1661,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'alerts') &&
+      { (categoryTab === 'all' || categoryTab === 'alerts') &&
         <section>
           <h6>Alerts &amp; Prompts</h6>
           <div className={styles.componentWrapper}>
@@ -1789,7 +1793,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'text') &&
+      { (categoryTab === 'all' || categoryTab === 'text') &&
         <section>
           <h6>Parsed Text</h6>
           <div className={styles.componentWrapper}>
@@ -1801,7 +1805,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'loaders') &&
+      { (categoryTab === 'all' || categoryTab === 'loaders') &&
         <section>
           <h6>Loading Animations</h6>
           <div className={styles.componentWrapper}>
@@ -1865,7 +1869,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'slideout') &&
+      { (categoryTab === 'all' || categoryTab === 'slideout') &&
         <section id="sandbox-slideout">
           <h6>Slideout</h6>
           <div className={styles.componentWrapper}>
@@ -1972,7 +1976,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'errors') &&
+      { (categoryTab === 'all' || categoryTab === 'errors') &&
         <section>
           <h6>Errors</h6>
           <div className={styles.componentWrapper}>
@@ -1986,7 +1990,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'charts') &&
+      { (categoryTab === 'all' || categoryTab === 'charts') &&
         <section>
           <h6>Charts</h6>
           <div className={styles.componentWrapper}>
@@ -2231,7 +2235,7 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (!selectedCategory || selectedCategory === 'tabs') &&
+      { (categoryTab === 'all' || categoryTab === 'tabs') &&
         <section>
           <h6>Tabs</h6>
           <div className={styles.componentWrapper}>

--- a/src/app/components/cds/menus-lists-dialogs/TabWrapper.js
+++ b/src/app/components/cds/menus-lists-dialogs/TabWrapper.js
@@ -13,11 +13,13 @@ const TabWrapper = ({
   tabs,
   value,
   variant,
+  wrapContent,
 }) => {
   const [activeTab, setActiveTab] = React.useState(getQueryStringValue('tab') || value || tabs.find(tab => tab.show !== false).value);
   const wrapperRef = React.useRef(null);
   const [isOverflowing, setIsOverflowing] = React.useState(false);
   const [fullTabWidth, setFullTabWidth] = React.useState(0);
+  const wrapperHeightMax = size === 'large' ? 130 : 95;
 
   useLayoutEffect(() => {
     if (wrapperRef.current) {
@@ -31,10 +33,15 @@ const TabWrapper = ({
     const checkOverflow = (tabWidth) => {
       if (wrapperRef.current) {
         const containerWidth = wrapperRef.current.clientWidth;
-        if (tabWidth > containerWidth && !isOverflowing) {
+        const containerHeight = wrapperRef.current.clientHeight;
+        if (tabWidth > containerWidth && !isOverflowing && !wrapContent) {
           setIsOverflowing(true);
         } else if (tabWidth <= containerWidth && isOverflowing) {
           setIsOverflowing(false);
+        }
+
+        if (containerHeight > wrapperHeightMax && wrapContent) {
+          setIsOverflowing(true);
         }
       }
     };
@@ -60,10 +67,15 @@ const TabWrapper = ({
     const handleResize = () => {
       if (wrapperRef.current) {
         const containerWidth = wrapperRef.current.clientWidth;
-        if (fullTabWidth > containerWidth) {
+        const containerHeight = wrapperRef.current.clientHeight;
+        if (fullTabWidth > containerWidth && !wrapContent) {
           setIsOverflowing(true);
         } else {
           setIsOverflowing(false);
+        }
+
+        if (containerHeight > wrapperHeightMax && !isOverflowing && wrapContent) {
+          setIsOverflowing(true);
         }
       }
     };
@@ -98,6 +110,7 @@ const TabWrapper = ({
           [styles.sizeDefault]: size === 'default',
           [styles.sizeLarge]: size === 'large' || isOverflowing,
           [styles.variantBanner]: variant === 'banner',
+          [styles.wrapContent]: wrapContent,
         },
       )}
       ref={wrapperRef}
@@ -139,6 +152,7 @@ TabWrapper.defaultProps = {
   size: 'default',
   value: null,
   variant: 'default',
+  wrapContent: false,
 };
 
 TabWrapper.propTypes = {
@@ -147,6 +161,7 @@ TabWrapper.propTypes = {
   tabs: PropTypes.array.isRequired,
   value: PropTypes.string,
   variant: PropTypes.oneOf(['default', 'banner']),
+  wrapContent: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/app/components/cds/menus-lists-dialogs/TabWrapper.module.css
+++ b/src/app/components/cds/menus-lists-dialogs/TabWrapper.module.css
@@ -3,10 +3,10 @@
   background: var(--color-beige-93);
   border-radius: var(--border-radius-default, 8px);
   display: flex;
-  gap: 16px;
+  gap: 3px;
   margin: 8px;
   min-width: 350px;
-  padding: 8px 10px;
+  padding: 8px;
 
   &.variantBanner {
     border-radius: var(--border-radius-zero, 0);

--- a/src/app/components/cds/menus-lists-dialogs/TabWrapper.module.css
+++ b/src/app/components/cds/menus-lists-dialogs/TabWrapper.module.css
@@ -8,13 +8,13 @@
   min-width: 350px;
   padding: 8px 10px;
 
-  &.sizeLarge {
-    height: 62px;
-  }
-
   &.variantBanner {
     border-radius: var(--border-radius-zero, 0);
     margin: 0;
+  }
+
+  &.wrapContent {
+    flex-wrap: wrap;
   }
 
   .select {

--- a/src/app/components/cds/sandbox.module.css
+++ b/src/app/components/cds/sandbox.module.css
@@ -4,13 +4,8 @@
   padding: 16px 32px;
 
   .sandboxNav {
-    display: flex;
-    flex-flow: row wrap;
-    gap: 16px;
-    list-style: none;
-    margin: 20px 0 40px;
-    min-width: 300px;
-    padding: 0;
+    background-color: var(--color-beige-86);
+    margin: 20px 0;
   }
 
   h6 {

--- a/src/app/components/media/MediaComponentRightPanel.js
+++ b/src/app/components/media/MediaComponentRightPanel.js
@@ -99,6 +99,7 @@ const MediaComponentRightPanel = ({
             },
           ]}
           value={showTab}
+          wrapContent
           onChange={setShowTab}
         />
       </div>

--- a/src/app/styles/css/mixins/variables.css
+++ b/src/app/styles/css/mixins/variables.css
@@ -154,7 +154,7 @@
 
   --z-index-max: 1000; /* Nothing will ever be higher, for example tooltips and toasts */
   --z-index-10: 10; /* Highest main UI elements, such as slideouts */
-  --z-index-9: 9; /* Highest main UI elements, such as slideouts */
+  --z-index-9: 9;
   --z-index-8: 8;
   --z-index-7: 7;
   --z-index-6: 6;


### PR DESCRIPTION

## Description

Tab Wrapper takes in a new prop, wrapContent (default false), that allows the container to wrap up to 2 rows before breaking to a Select dropdown component.  Removed the height value for large as it was cutting off the wrapped row.  

References: CV2-5791

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
