### PR TITLE
Added orientation and theme prop to TogglebuttonGroup

### DIFF
--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -197,6 +197,7 @@ const SandboxComponent = ({ admin }) => {
   const [toggleButtonGroupLabel, setToggleButtonGroupLabel] = React.useState(Boolean(true));
   const [toggleButtonGroupHelp, setToggleButtonGroupHelp] = React.useState(Boolean(true));
   const [toggleButtonGroupDisabled, setToggleButtonGroupDisabled] = React.useState(Boolean(false));
+  const [toggleButtonGroupisVertical, setToggleButtonGroupisVertical] = React.useState(Boolean(false));
 
   const [timeLabel, setTimeLabel] = React.useState(Boolean(false));
   const [timeHelp, setTimeHelp] = React.useState(Boolean(false));
@@ -266,6 +267,11 @@ const SandboxComponent = ({ admin }) => {
   const [toggleButtonGroupVariant, setToggleButtonGroupVariant] = React.useState('contained');
   const onChangeToggleButtonGroupVariant = (event) => {
     setToggleButtonGroupVariant(event.target.value);
+  };
+
+  const [toggleButtonGroupTheme, setToggleButtonGroupTheme] = React.useState('default');
+  const onChangeToggleButtonGroupTheme = (event) => {
+    setToggleButtonGroupTheme(event.target.value);
   };
 
   const [toggleButtonGroupValue, setToggleButtonGroupValue] = React.useState('1');
@@ -925,6 +931,16 @@ const SandboxComponent = ({ admin }) => {
                   </Select>
                 </li>
                 <li>
+                  <Select
+                    label="Theme"
+                    value={toggleButtonGroupTheme}
+                    onChange={onChangeToggleButtonGroupTheme}
+                  >
+                    <option value="default">default</option>
+                    <option value="setting">setting</option>
+                  </Select>
+                </li>
+                <li>
                   <SwitchComponent
                     checked={toggleButtonGroupLabel}
                     label="Label"
@@ -948,6 +964,14 @@ const SandboxComponent = ({ admin }) => {
                     onChange={() => setToggleButtonGroupDisabled(!toggleButtonGroupDisabled)}
                   />
                 </li>
+                <li>
+                  <SwitchComponent
+                    checked={toggleButtonGroupisVertical}
+                    label="Vertical"
+                    labelPlacement="top"
+                    onChange={() => setToggleButtonGroupisVertical(!toggleButtonGroupisVertical)}
+                  />
+                </li>
               </ul>
             </div>
             <div className={styles.componentBlockVariants} style={{ backgroundColor: 'var(--color-beige-93' }}>
@@ -955,7 +979,9 @@ const SandboxComponent = ({ admin }) => {
                 exclusive
                 helpContent={toggleButtonGroupHelp ? 'I can be of help to ToggleButtonGroup' : null}
                 label={toggleButtonGroupLabel ? 'I am a toggleButtonGroup label' : null}
+                orientation={toggleButtonGroupisVertical ? 'vertical' : 'horizontal'}
                 size={toggleButtonGroupSize}
+                theme={toggleButtonGroupTheme}
                 value={toggleButtonGroupValue}
                 variant={toggleButtonGroupVariant}
                 onChange={(e, newValue) => changeToggleButtonGroupExample(newValue)}

--- a/src/app/components/cds/inputs/ToggleButtonGroup.js
+++ b/src/app/components/cds/inputs/ToggleButtonGroup.js
@@ -19,7 +19,9 @@ const ToggleButtonGroup = ({
   className,
   helpContent,
   label,
+  orientation,
   size,
+  theme,
   variant,
   ...toggleButtonGroupProps
 }) => (
@@ -40,6 +42,7 @@ const ToggleButtonGroup = ({
       <div
         className={cx(
           styles['toggle-button-group'],
+          styles[`theme-${theme}`],
           {
             [className]: true,
             [styles.sizeDefault]: size === 'default',
@@ -47,6 +50,7 @@ const ToggleButtonGroup = ({
             [styles.sizeLarge]: size === 'large',
             [styles.contained]: variant === 'contained',
             [styles.outlined]: variant === 'outlined',
+            [styles.vertical]: orientation === 'vertical',
           })
         }
       >
@@ -73,6 +77,7 @@ ToggleButtonGroup.defaultProps = {
   size: 'default',
   helpContent: null,
   label: '',
+  theme: 'default',
   variant: 'outlined',
 };
 
@@ -81,6 +86,7 @@ ToggleButtonGroup.propTypes = {
   size: PropTypes.oneOf(['default', 'small', 'large']),
   helpContent: PropTypes.node,
   label: PropTypes.node,
+  theme: PropTypes.oneOf(['default', 'setting']),
   variant: PropTypes.oneOf(['contained', 'outlined']),
 };
 

--- a/src/app/components/cds/inputs/ToggleButtonGroup.module.css
+++ b/src/app/components/cds/inputs/ToggleButtonGroup.module.css
@@ -124,6 +124,11 @@
       min-height: 42px;
     }
 
+    button:not(:first-child) {
+      border-left: 0;
+      border-top: 2px solid var(--color-gray-88);
+    }
+
     :global(.MuiToggleButtonGroup-grouped:not(:first-child)) {
       border-top-right-radius: 0;
     }

--- a/src/app/components/cds/inputs/ToggleButtonGroup.module.css
+++ b/src/app/components/cds/inputs/ToggleButtonGroup.module.css
@@ -112,6 +112,51 @@
     }
   }
 
+  &.vertical {
+    height: auto;
+
+    :global(.MuiToggleButtonGroup-root) {
+      display: flex;
+      flex-direction: column;
+    }
+
+    :global(.MuiButtonBase-root) {
+      min-height: 42px;
+    }
+
+    :global(.MuiToggleButtonGroup-grouped:not(:first-child)) {
+      border-top-right-radius: 0;
+    }
+
+    :global(.MuiToggleButtonGroup-grouped:not(:last-child)) {
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  &.theme-setting {
+    &.contained,
+    &.outlined {
+      :global(.MuiButtonBase-root.Mui-selected) {
+        background-color: var(--color-purple-61);
+        border-color: var(--color-purple-61);
+        color: var(--color-white-100);
+
+        &:hover {
+          background-color: var(--color-purple-61);
+          border-color: var(--color-purple-61);
+        }
+      }
+    }
+
+    :global(.MuiButtonBase-root) {
+      &:hover {
+        background-color: var(--color-purple-96);
+        color: var(--color-purple-61);
+        transition: color 100ms linear, background-color 100ms linear, border-color 100ms linear;
+      }
+    }
+  }
+
   :global(.MuiButtonBase-root.Mui-disabled) {
     background-color: var(--color-gray-96);
     color: var(--color-gray-59);

--- a/src/app/components/cds/inputs/ToggleButtonGroup.module.css
+++ b/src/app/components/cds/inputs/ToggleButtonGroup.module.css
@@ -141,7 +141,7 @@
   &.theme-setting {
     &.contained,
     &.outlined {
-      :global(.MuiButtonBase-root.Mui-selected) {
+      :global(.MuiButtonBase-root.Mui-selected):not(:global(.Mui-disabled)) {
         background-color: var(--color-purple-61);
         border-color: var(--color-purple-61);
         color: var(--color-white-100);


### PR DESCRIPTION
## Description

Added two new props to the ToggleButtonGroup component: theme and orientation.  The new theme is called 'setting' to avoid overlapping with other theme names.  The orientation defaults to horizontal but can be toggled to vertical.  I think our version of the MaterialUI toggle button group predates the orientation prop (it's still in the /lab/ library, so likely still in development), so I had to add a custom settings for it.  

All new props can be tested in the Sandbox

References: CV2-5734

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually in the Sandbox

## Things to pay attention to during code review

Given the defaults, nothing should change for any other ToggleButtonGroup, but good to check.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
