### PR TITLE
Display the item title on the `<SmallMediaCard />` component when rendered in the "Merge Media" > "Export" dialog.

### DIFF
--- a/src/app/components/cds/media-cards/SmallMediaCard.js
+++ b/src/app/components/cds/media-cards/SmallMediaCard.js
@@ -19,6 +19,7 @@ const SmallMediaCard = ({
   media,
   onClick,
   superAdminMask,
+  title,
 }) => {
   if (!media) {
     return (
@@ -58,7 +59,7 @@ const SmallMediaCard = ({
         <div className={styles.smallMediaCardContent}>
           <div className={styles.titleAndUrl}>
             <div className={cx('typography-subtitle2', 'small-media-card__title', styles.row, (media.url ? styles.oneLineDescription : styles.twoLinesDescription))}>
-              <ParsedText text={media.metadata?.title || media.quote || description} />
+              <ParsedText text={title || media.metadata?.title || media.quote || description} />
             </div>
             { media.url ?
               <div className={cx(styles.row, 'typography-body2')}>
@@ -88,17 +89,19 @@ SmallMediaCard.propTypes = {
     metadata: PropTypes.object,
   }).isRequired,
   superAdminMask: PropTypes.bool,
+  title: PropTypes.string,
   onClick: PropTypes.func,
 };
 
 SmallMediaCard.defaultProps = {
+  className: '',
   details: null,
   description: null,
   ignoreGeneralContentMask: true,
   maskContent: false,
   superAdminMask: false,
+  title: null,
   onClick: () => {},
-  className: '',
 };
 
 // eslint-disable-next-line import/no-unused-modules

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -426,6 +426,7 @@ const AutoCompleteMediaItem = (props, context) => {
                       ignoreGeneralContentMask={props.ignoreGeneralContentMask}
                       maskContent={projectMedia.show_warning_cover}
                       media={projectMedia.media}
+                      title={projectMedia.title}
                       onClick={e => handleClick(e, projectMedia.dbid)}
                     />
                   </Link>


### PR DESCRIPTION
## Description

I think that the `<SmallMediaCard />` component is consistent. It's a *media* card, not an *item* card, so the information displayed there is for the *media*.

But, under the context of the list of "Export" items under the "Merge Media" modal, it's harder to find a media when searching by the item title, since the card renders the media title, not the item title.

This PR fixes it by allowing the card to receive a custom `title` prop.

Reference: CV2-5868.

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. See reference ticket for details.

## Things to pay attention to during code review

Please let me know if you think that this solution is consistent. I wanted to make sure that the `<SmallMediaCard />` component is still a _media_ card.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 