### PR TITLE
Hide fields related to old templates from the UI

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotSettings.js
+++ b/src/app/components/team/SmoochBot/SmoochBotSettings.js
@@ -9,6 +9,16 @@ import styles from '../Settings.module.css';
 const SmoochBotSettings = (props) => {
   const fields = props.schema;
 
+  const fieldsNotInUse = [
+    'smooch_template_name_for_fact_check_report_image_only',
+    'smooch_template_name_for_fact_check_report_text_only',
+    'smooch_template_name_for_fact_check_report_updated_image_only',
+    'smooch_template_name_for_fact_check_report_updated_text_only',
+    'smooch_template_name_for_more_information_needed_text_only',
+    'smooch_template_name_for_newsletter',
+    'smooch_template_name_for_newsletter_with_button',
+  ];
+
   return (
     <React.Fragment>
       <div className={styles['setting-content-container-title']}>
@@ -88,15 +98,18 @@ const SmoochBotSettings = (props) => {
               ))}
             </div>
             <div className={inputStyles['form-fieldset']}>
-              {Object.keys(fields).filter(f => /^smooch_template_name_for_/.test(f)).map(field => (
-                <SmoochBotSetting
-                  currentUser={props.currentUser}
-                  field={field}
-                  schema={fields[field]}
-                  value={props.settings[field] || ' '}
-                  onChange={props.onChange}
-                />
-              ))}
+              {Object.keys(fields)
+                .filter(f => /^smooch_template_name_for_/.test(f))
+                .filter(f => !fieldsNotInUse.includes(f))
+                .map(field => (
+                  <SmoochBotSetting
+                    currentUser={props.currentUser}
+                    field={field}
+                    schema={fields[field]}
+                    value={props.settings[field] || ' '}
+                    onChange={props.onChange}
+                  />
+                ))}
             </div>
           </div>
 


### PR DESCRIPTION
## Description

Hide fields related to old templates from the UI

References: CV2-2614

## Type of change

- [x] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Tested manually that fields specified in `fieldsNotInUse` are not rendered on the tipline template settings.

![image](https://github.com/user-attachments/assets/7b2c1766-aa32-4a68-a75b-f14359f36c37)

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
