### PR TITLE
Hard-refresh when switching workspaces.

### DIFF
--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -65,6 +65,12 @@ const UserWorkspacesComponent = ({
   };
 
   const onSuccess = (team) => {
+    /* While debugging an error related to creating tipline resources, I realized it occurred only
+       when navigating to the tipline settings page directly from the Workspaces list (i.e., switching
+       from one workspace to another). The resource isn't created because the workspace ID being used
+       is still the previous one. As a result, the session isn't fully cleared or switched to the new
+       workspace. The simplest fix is to force a hard refresh to ensure a completely new session under
+       the new workspace. */
     window.location.assign(`/${team.slug}/all-items`);
   };
 

--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -65,7 +65,7 @@ const UserWorkspacesComponent = ({
   };
 
   const onSuccess = (team) => {
-    window.location.assign(`/${team.slug}/all-items`)
+    window.location.assign(`/${team.slug}/all-items`);
   };
 
   const setCurrentTeam = (team) => {

--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { FormattedMessage } from 'react-intl';
 import { commitMutation, createPaginationContainer, graphql } from 'react-relay/compat';
-import { browserHistory } from 'react-router';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -66,8 +65,7 @@ const UserWorkspacesComponent = ({
   };
 
   const onSuccess = (team) => {
-    const path = `/${team.slug}/all-items`;
-    browserHistory.push(path);
+    window.location.assign(`/${team.slug}/all-items`)
   };
 
   const setCurrentTeam = (team) => {


### PR DESCRIPTION
## Description

While debugging an error related to creating tipline resources, I realized it occurred only when navigating to the tipline settings page directly from the Workspaces list (i.e., switching from one workspace to another). The resource isn't created because the workspace ID being used is still the previous one. As a result, the session isn't fully cleared or switched to the new workspace. The simplest fix is to force a hard refresh to ensure a completely new session under the new workspace.

Fixes: [CV2-6003](https://meedan.atlassian.net/browse/CV2-6003).

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Manually. Just make sure you can still switch between workspaces.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I've made sure my branch is runnable and given good testing steps in the PR description
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 

[CV2-6003]: https://meedan.atlassian.net/browse/CV2-6003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ