### PR TITLE
Epic/CV2-5510: why media is in cluster

### DIFF
--- a/localization/react-intl/src/app/components/media/MediaOrigin.json
+++ b/localization/react-intl/src/app/components/media/MediaOrigin.json
@@ -17,7 +17,7 @@
   {
     "id": "mediaOrigin.userAddedTooltip",
     "description": "Tooltip message for User Added",
-    "defaultMessage": "<strong>{user}</strong> uploaded this media using the Check interface"
+    "defaultMessage": "<strong>{user}</strong> uploaded this media using Check"
   },
   {
     "id": "mediaOrigin.userMerged",
@@ -27,7 +27,7 @@
   {
     "id": "mediaOrigin.userMergedTooltip",
     "description": "Tooltip message for User Merged",
-    "defaultMessage": "<strong>{user}</strong> added this media by merging from another cluster"
+    "defaultMessage": "<strong>{user}</strong> added this media by merging from another cluster of media"
   },
   {
     "id": "mediaOrigin.userMatched",

--- a/localization/react-intl/src/app/components/media/MediaOriginBanner.json
+++ b/localization/react-intl/src/app/components/media/MediaOriginBanner.json
@@ -6,22 +6,22 @@
   },
   {
     "id": "mediaOriginBanner.userAdded",
-    "description": "Message for User Matched",
-    "defaultMessage": "This media was added to the cluster by <strong>{user}</strong>"
+    "description": "Message for User Added",
+    "defaultMessage": "This media was added to the cluster of media by <strong>{user}</strong>"
   },
   {
     "id": "mediaOriginBanner.userMerged",
-    "description": "Message for User Matched",
-    "defaultMessage": "This media was added to the cluster by <strong>{user}</strong> when merged from <strong><u>{cluster}</u></strong>"
+    "description": "Message for User Merged",
+    "defaultMessage": "This media was merged into this cluster of media by <strong>{user}</strong>"
   },
   {
     "id": "mediaOriginBanner.userMatched",
     "description": "Message for User Matched",
-    "defaultMessage": "This media was added to the cluster by <strong>{user}</strong> when accepted from <strong><u>{cluster}</u></strong>"
+    "defaultMessage": "This media was added to the cluster of media by <strong>{confirmedBy}</strong> when accepted from <strong><u>{originTitle}</u></strong>"
   },
   {
     "id": "mediaOriginBanner.autoMatched",
     "description": "Message for Auto Matched",
-    "defaultMessage": "This media was automatically matched to the cluster"
+    "defaultMessage": "This media was automatically matched to the cluster of media"
   }
 ]

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -27,7 +27,6 @@ import TabWrapper from './menus-lists-dialogs/TabWrapper';
 import Reorder from '../layout/Reorder';
 import AddIcon from '../../icons/settings.svg';
 import CalendarIcon from '../../icons/calendar_month.svg';
-import MediaOrigin from '../media/MediaOrigin';
 import MediaOriginBanner from '../media/MediaOriginBanner';
 import ListIcon from '../../icons/list.svg';
 import FigmaColorLogo from '../../icons/figma_color.svg';
@@ -2390,31 +2389,6 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (categoryTab === 'all' || categoryTab === 'media-cluster-origin-buttons') && (
-        <section>
-          <div className={styles.componentWrapper}>
-            <div className={cx('typography-subtitle2', [styles.componentName])}>
-              Media Origin
-              <a
-                className={styles.figmaLink}
-                href="https://www.figma.com/design/aVRaTgms3H4jY8hOslFq5y/Media?node-id=901-1203&p=f&m=dev"
-                rel="noopener noreferrer"
-                target="_blank"
-                title="Figma Designs"
-              >
-                <FigmaColorLogo />
-              </a>
-
-              <MediaOrigin type={CheckMediaOrigin.TIPLINE_SUBMITTED} />
-              <MediaOrigin type={CheckMediaOrigin.USER_ADDED} />
-              <MediaOrigin type={CheckMediaOrigin.USER_MERGED} />
-              <MediaOrigin type={CheckMediaOrigin.USER_MATCHED} />
-              <MediaOrigin type={CheckMediaOrigin.AUTO_MATCHED} />
-              <MediaOrigin type={99} /> {/* invalid type */}
-            </div>
-          </div>
-        </section>
-      )}
       { (categoryTab === 'all' || categoryTab === 'media-cluster-origin-buttons') && (
         <section>
           <div className={styles.componentWrapper}>

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -27,7 +27,6 @@ import TabWrapper from './menus-lists-dialogs/TabWrapper';
 import Reorder from '../layout/Reorder';
 import AddIcon from '../../icons/settings.svg';
 import CalendarIcon from '../../icons/calendar_month.svg';
-import MediaOriginBanner from '../media/MediaOriginBanner';
 import ListIcon from '../../icons/list.svg';
 import FigmaColorLogo from '../../icons/figma_color.svg';
 import ArticleCard from '../search/SearchResultsCards/ArticleCard';
@@ -37,7 +36,6 @@ import ParsedText from '../ParsedText';
 import ClusterCard from '../search/SearchResultsCards/ClusterCard';
 import CheckFeedDataPoints from '../../CheckFeedDataPoints';
 import { FlashMessageSetterContext } from '../FlashMessage';
-import CheckMediaOrigin from '../../CheckMediaOrigin';
 import styles from './sandbox.module.css';
 
 const SandboxComponent = ({ admin }) => {
@@ -485,10 +483,6 @@ const SandboxComponent = ({ admin }) => {
           {
             label: 'Tabs',
             value: 'tabs',
-          },
-          {
-            label: 'Media Cluster Origin Buttons',
-            value: 'media-cluster-origin-buttons',
           },
         ]}
         value={categoryTab}
@@ -2389,30 +2383,6 @@ const SandboxComponent = ({ admin }) => {
           </div>
         </section>
       }
-      { (categoryTab === 'all' || categoryTab === 'media-cluster-origin-buttons') && (
-        <section>
-          <div className={styles.componentWrapper}>
-            <div className={cx('typography-subtitle2', [styles.componentName])}>
-              Media Origin Banner
-              <a
-                className={styles.figmaLink}
-                href="https://www.figma.com/design/aVRaTgms3H4jY8hOslFq5y/Media?node-id=901-1203&p=f&m=dev"
-                rel="noopener noreferrer"
-                target="_blank"
-                title="Figma Designs"
-              >
-                <FigmaColorLogo />
-              </a>
-
-              <MediaOriginBanner cluster="Foo bar" timestamp={1736876257} type={CheckMediaOrigin.TIPLINE_SUBMITTED} user="Smooch" />
-              <MediaOriginBanner cluster="Foo bar" timestamp={1736876257} type={CheckMediaOrigin.USER_ADDED} user="Bruce" />
-              <MediaOriginBanner cluster="Foo bar" timestamp={1736876257} type={CheckMediaOrigin.USER_MERGED} user="Kara" />
-              <MediaOriginBanner cluster="Bla" timestamp={1736876257} type={CheckMediaOrigin.USER_MATCHED} user="Clark" />
-              <MediaOriginBanner cluster="Foo bar" timestamp={1736876257} type={CheckMediaOrigin.AUTO_MATCHED} user="Alegre" />
-            </div>
-          </div>
-        </section>
-      )}
     </div>
   );
 };

--- a/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialogComponent.js
+++ b/src/app/components/cds/menus-lists-dialogs/MediaAndRequestsDialogComponent.js
@@ -16,6 +16,7 @@ const MediaAndRequestsDialogComponent = ({
   dialogTitle,
   feedId,
   mediaHeader,
+  mediaOriginBanner,
   mediaSlug,
   onClick,
   onClose,
@@ -54,7 +55,10 @@ const MediaAndRequestsDialogComponent = ({
         <div className={styles.columns}>
           { context === 'workspace' ?
             <>
-              <MediaCardLargeQueryRenderer projectMediaId={projectMediaId} />
+              <div>
+                {mediaOriginBanner}
+                <MediaCardLargeQueryRenderer projectMediaId={projectMediaId} />
+              </div>
               <div>
                 { projectMediaId && projectMediaImportedId && ( // Show the toggle if we have two values to switch between
                   <div className={styles.toggle}>
@@ -93,6 +97,7 @@ const MediaAndRequestsDialogComponent = ({
 MediaAndRequestsDialogComponent.defaultProps = {
   dialogTitle: '',
   mediaHeader: null,
+  mediaOriginBanner: null,
   projectMediaImportedId: null,
   feedId: null,
 };
@@ -101,6 +106,7 @@ MediaAndRequestsDialogComponent.propTypes = {
   dialogTitle: PropTypes.string,
   feedId: PropTypes.number,
   mediaHeader: PropTypes.element,
+  mediaOriginBanner: PropTypes.element,
   mediaSlug: PropTypes.element.isRequired,
   projectMediaId: PropTypes.number.isRequired,
   projectMediaImportedId: PropTypes.number,

--- a/src/app/components/media/MediaCardLargeFooter.js
+++ b/src/app/components/media/MediaCardLargeFooter.js
@@ -125,7 +125,7 @@ const MediaCardLargeFooter = ({
             ),
             (
               <MediaOrigin
-                type={projectMedia.media_cluster_origin}
+                origin={projectMedia.media_cluster_origin}
                 user={projectMedia.media_cluster_origin_user?.name}
               />
             ),

--- a/src/app/components/media/MediaCardLargeFooter.js
+++ b/src/app/components/media/MediaCardLargeFooter.js
@@ -5,6 +5,7 @@ import { FormattedMessage, FormattedDate } from 'react-intl';
 import MediaCardLargeFooterContent from './MediaCardLargeFooterContent';
 import MediaCardLargeActions from './MediaCardLargeActions';
 import MediaSlug from './MediaSlug';
+import MediaOrigin from './MediaOrigin';
 import ExternalLink from '../ExternalLink';
 import LastRequestDate from '../cds/media-cards/LastRequestDate';
 import MediaIdentifier from '../cds/media-cards/MediaIdentifier';
@@ -122,6 +123,12 @@ const MediaCardLargeFooter = ({
                 variant="text"
               />
             ),
+            (
+              <MediaOrigin
+                type={projectMedia.media_cluster_origin}
+                user={projectMedia.media_cluster_origin_user?.name}
+              />
+            ),
           ]}
         />
         : null
@@ -165,6 +172,10 @@ export default createFragmentContainer(MediaCardLargeFooter, graphql`
     }
     transcription: annotation(annotation_type: "transcription") {
       data
+    }
+    media_cluster_origin
+    media_cluster_origin_user {
+      name
     }
     ...MediaCardLargeActions_projectMedia
   }

--- a/src/app/components/media/MediaComponent.js
+++ b/src/app/components/media/MediaComponent.js
@@ -8,6 +8,7 @@ import cx from 'classnames/bind';
 import MediaCardLarge from './MediaCardLarge';
 import MediaSlug from './MediaSlug';
 import MediaComponentRightPanel from './MediaComponentRightPanel';
+import MediaOriginBanner from './MediaOriginBanner';
 import MediaSimilarityBar from './Similarity/MediaSimilarityBar';
 import MediaSimilaritiesComponent from './Similarity/MediaSimilaritiesComponent';
 import MediaFeedInformation from './MediaFeedInformation';
@@ -189,6 +190,14 @@ class MediaComponent extends Component {
                     dialogTitle={projectMedia.title || projectMedia.quote || projectMedia.description}
                     feedId={projectMedia.imported_from_feed_id}
                     mediaHeader={<MediaFeedInformation projectMedia={projectMedia} />}
+                    mediaOriginBanner={
+                      <MediaOriginBanner
+                        mediaClusterRelationship={projectMedia.media_cluster_relationship}
+                        origin={projectMedia.media_cluster_origin}
+                        originTimestamp={projectMedia.media_cluster_origin_timestamp}
+                        user={projectMedia.media_cluster_origin_user.name}
+                      />
+                    }
                     mediaSlug={
                       <MediaSlug
                         className={styles['media-slug-title']}
@@ -340,6 +349,19 @@ export default createFragmentContainer(withPusher(MediaComponent), graphql`
       dbid
       team {
         slug
+      }
+    }
+    media_cluster_origin
+    media_cluster_origin_user {
+      name
+    }
+    media_cluster_origin_timestamp
+    media_cluster_relationship {
+      target {
+        title
+      }
+      confirmed_by {
+        name
       }
     }
     is_confirmed_similar_to_another_item

--- a/src/app/components/media/MediaOrigin.js
+++ b/src/app/components/media/MediaOrigin.js
@@ -10,8 +10,8 @@ import Tipline from '../../icons/question_answer.svg';
 import Tooltip from '../cds/alerts-and-prompts/Tooltip';
 import CheckMediaOrigin from '../../CheckMediaOrigin';
 
-const getIconAndMessage = (type, user) => {
-  switch (type) {
+const getIconAndMessage = (origin, user) => {
+  switch (origin) {
   case CheckMediaOrigin.TIPLINE_SUBMITTED:
     return {
       icon: <Tipline />,
@@ -42,7 +42,7 @@ const getIconAndMessage = (type, user) => {
       ),
       tooltipMessage: (
         <FormattedHTMLMessage
-          defaultMessage="<strong>{user}</strong> uploaded this media using the Check interface"
+          defaultMessage="<strong>{user}</strong> uploaded this media using Check"
           description="Tooltip message for User Added"
           id="mediaOrigin.userAddedTooltip"
           values={{ user }}
@@ -61,7 +61,7 @@ const getIconAndMessage = (type, user) => {
       ),
       tooltipMessage: (
         <FormattedHTMLMessage
-          defaultMessage="<strong>{user}</strong> added this media by merging from another cluster"
+          defaultMessage="<strong>{user}</strong> added this media by merging from another cluster of media"
           description="Tooltip message for User Merged"
           id="mediaOrigin.userMergedTooltip"
           values={{ user }}
@@ -114,8 +114,8 @@ const getIconAndMessage = (type, user) => {
   }
 };
 
-const MediaOrigin = ({ type, user }) => {
-  const { icon, message, tooltipMessage } = getIconAndMessage(type, user);
+const MediaOrigin = ({ origin, user }) => {
+  const { icon, message, tooltipMessage } = getIconAndMessage(origin, user);
 
   return (
     <Tooltip
@@ -135,13 +135,9 @@ const MediaOrigin = ({ type, user }) => {
   );
 };
 
-MediaOrigin.defaultProps = {
-  user: 'Unknown User',
-};
-
 MediaOrigin.propTypes = {
-  type: PropTypes.number.isRequired,
-  user: PropTypes.string,
+  origin: PropTypes.number.isRequired,
+  user: PropTypes.string.isRequired,
 };
 
 export default MediaOrigin;

--- a/src/app/components/media/MediaOrigin.test.js
+++ b/src/app/components/media/MediaOrigin.test.js
@@ -10,29 +10,29 @@ import CheckMediaOrigin from '../../CheckMediaOrigin';
 
 describe('<MediaOrigin />', () => {
   it('should render a button with the correct icon and message for each type', () => {
-    const tiplineSubmitted = mountWithIntl(<MediaOrigin type={CheckMediaOrigin.TIPLINE_SUBMITTED} />);
+    const tiplineSubmitted = mountWithIntl(<MediaOrigin origin={CheckMediaOrigin.TIPLINE_SUBMITTED} user="Smooch" />);
     expect(tiplineSubmitted.find(Tipline).length).toEqual(1);
     expect(tiplineSubmitted.html()).toMatch('Tipline Submitted');
 
-    const userAdded = mountWithIntl(<MediaOrigin type={CheckMediaOrigin.USER_ADDED} user="John Doe" />);
+    const userAdded = mountWithIntl(<MediaOrigin origin={CheckMediaOrigin.USER_ADDED} user="John Doe" />);
     expect(userAdded.find(PersonAdd).length).toEqual(1);
     expect(userAdded.html()).toMatch('User Added');
 
-    const userMerged = mountWithIntl(<MediaOrigin type={CheckMediaOrigin.USER_MERGED} user="John Doe" />);
+    const userMerged = mountWithIntl(<MediaOrigin origin={CheckMediaOrigin.USER_MERGED} user="John Doe" />);
     expect(userMerged.find(Person).length).toEqual(1);
     expect(userMerged.html()).toMatch('User Merged');
 
-    const userMatched = mountWithIntl(<MediaOrigin type={CheckMediaOrigin.USER_MATCHED} user="John Doe" />);
+    const userMatched = mountWithIntl(<MediaOrigin origin={CheckMediaOrigin.USER_MATCHED} user="John Doe" />);
     expect(userMatched.find(PersonCheck).length).toEqual(1);
     expect(userMatched.html()).toMatch('User Matched');
 
-    const autoMatched = mountWithIntl(<MediaOrigin type={CheckMediaOrigin.AUTO_MATCHED} />);
+    const autoMatched = mountWithIntl(<MediaOrigin origin={CheckMediaOrigin.AUTO_MATCHED} user="Alegre" />);
     expect(autoMatched.find(Bolt).length).toEqual(1);
     expect(autoMatched.html()).toMatch('Auto Matched');
   });
 
   it('should return null for invalid type', () => {
-    const wrapper = mountWithIntl(<MediaOrigin type={99} />);
+    const wrapper = mountWithIntl(<MediaOrigin origin={99} user="user" />);
     expect(wrapper.find('FormattedMessage').length).toEqual(0);
   });
 });

--- a/src/app/components/media/MediaOriginBanner.js
+++ b/src/app/components/media/MediaOriginBanner.js
@@ -11,21 +11,23 @@ import CheckMediaOrigin from '../../CheckMediaOrigin';
 import { parseStringUnixTimestamp } from '../../helpers';
 import TimeBefore from '../TimeBefore';
 
-const getIconAndMessage = (type, user, cluster, timestamp) => {
-  // The default messages are temporary, and will be updated in the ticket CV2-5785
-  const formattedTimestamp = <TimeBefore date={parseStringUnixTimestamp(timestamp)} />;
-  switch (type) {
+const getIconAndMessage = (origin, mediaClusterRelationship, user, originTimestamp) => {
+  const formattedTimestamp = <TimeBefore date={parseStringUnixTimestamp(originTimestamp)} />;
+  const confirmedBy = mediaClusterRelationship?.confirmed_by?.name;
+  const originTitle = mediaClusterRelationship?.target?.title;
+
+  switch (origin) {
   case CheckMediaOrigin.TIPLINE_SUBMITTED:
     return {
       icon: <Tipline />,
       message: (
         <>
           <FormattedHTMLMessage
-            defaultMessage="This media was submitted via <strong>Tipline</strong> "
+            defaultMessage="This media was submitted via <strong>Tipline</strong>"
             description="Message for Tipline Submitted"
             id="mediaOriginBanner.tiplineSubmitted"
-            values={{ timestamp }}
           />
+          {', '}
           {formattedTimestamp}
         </>
       ),
@@ -36,11 +38,12 @@ const getIconAndMessage = (type, user, cluster, timestamp) => {
       message: (
         <>
           <FormattedHTMLMessage
-            defaultMessage="This media was added to the cluster by <strong>{user}</strong> "
-            description="Message for User Matched"
+            defaultMessage="This media was added to the cluster of media by <strong>{user}</strong>"
+            description="Message for User Added"
             id="mediaOriginBanner.userAdded"
             values={{ user }}
           />
+          {', '}
           {formattedTimestamp}
         </>
       ),
@@ -51,11 +54,12 @@ const getIconAndMessage = (type, user, cluster, timestamp) => {
       message: (
         <>
           <FormattedHTMLMessage
-            defaultMessage="This media was added to the cluster by <strong>{user}</strong> when merged from <strong><u>{cluster}</u></strong> "
-            description="Message for User Matched"
+            defaultMessage="This media was merged into this cluster of media by <strong>{user}</strong>"
+            description="Message for User Merged"
             id="mediaOriginBanner.userMerged"
-            values={{ user, cluster }}
+            values={{ user }}
           />
+          {', '}
           {formattedTimestamp}
         </>
       ),
@@ -66,11 +70,12 @@ const getIconAndMessage = (type, user, cluster, timestamp) => {
       message: (
         <>
           <FormattedHTMLMessage
-            defaultMessage="This media was added to the cluster by <strong>{user}</strong> when accepted from <strong><u>{cluster}</u></strong> "
+            defaultMessage="This media was added to the cluster of media by <strong>{confirmedBy}</strong> when accepted from <strong><u>{originTitle}</u></strong>"
             description="Message for User Matched"
             id="mediaOriginBanner.userMatched"
-            values={{ user, cluster }}
+            values={{ confirmedBy, originTitle }}
           />
+          {', '}
           {formattedTimestamp}
         </>
       ),
@@ -81,10 +86,11 @@ const getIconAndMessage = (type, user, cluster, timestamp) => {
       message: (
         <>
           <FormattedHTMLMessage
-            defaultMessage="This media was automatically matched to the cluster "
+            defaultMessage="This media was automatically matched to the cluster of media"
             description="Message for Auto Matched"
             id="mediaOriginBanner.autoMatched"
           />
+          {', '}
           {formattedTimestamp}
         </>
       ),
@@ -99,24 +105,39 @@ const getIconAndMessage = (type, user, cluster, timestamp) => {
 };
 
 const MediaOriginBanner = ({
-  cluster, timestamp, type, user,
+  mediaClusterRelationship, origin, originTimestamp, user,
 }) => {
-  const { icon, message } = getIconAndMessage(type, user, cluster, timestamp);
-
+  const { icon, message } = getIconAndMessage(origin, mediaClusterRelationship, user, originTimestamp);
   return (
-    <Alert
-      content={<span style={{ color: 'black' }}>{message}</span>}
-      customIcon={icon}
-      icon
-      variant="info"
-    />
+    <div style={{ marginBottom: '8px' }}>
+      <Alert
+        content={<span style={{ color: 'black' }}>{message}</span>}
+        customIcon={icon}
+        icon
+        variant="info"
+      />
+    </div>
   );
 };
 
+MediaOriginBanner.defaultProps = {
+  mediaClusterRelationship: {},
+};
+
 MediaOriginBanner.propTypes = {
-  cluster: PropTypes.string.isRequired,
-  timestamp: PropTypes.number.isRequired,
-  type: PropTypes.number.isRequired,
+  mediaClusterRelationship: PropTypes.shape({
+    confirmedBy: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    target: PropTypes.shape({
+      title: PropTypes.string,
+    }),
+  }),
+  origin: PropTypes.number.isRequired,
+  originTimestamp: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
   user: PropTypes.string.isRequired,
 };
 

--- a/src/app/components/media/MediaOriginBanner.test.js
+++ b/src/app/components/media/MediaOriginBanner.test.js
@@ -9,33 +9,33 @@ import Tipline from '../../icons/question_answer.svg';
 import CheckMediaOrigin from '../../CheckMediaOrigin';
 
 describe('<MediaBanner />', () => {
-  const timestamp = 1736876257;
-  const cluster = 'Cluster A';
+  const originTimestamp = 1736876257;
+  const mediaClusterRelationship = { confirmed_by: { name: 'Cluster A' }, target: { title: 'Cluster B' } };
   const user = 'Bruce';
   it('should render a banner with the correct icon and message for each type', () => {
-    const tiplineSubmitted = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={CheckMediaOrigin.TIPLINE_SUBMITTED} user={user} />);
+    const tiplineSubmitted = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={CheckMediaOrigin.TIPLINE_SUBMITTED} originTimestamp={originTimestamp} user={user} />);
     expect(tiplineSubmitted.find(Tipline).length).toEqual(1);
     expect(tiplineSubmitted.html()).toContain('This media was submitted via <strong>Tipline</strong>');
 
-    const userAdded = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={CheckMediaOrigin.USER_ADDED} user={user} />);
+    const userAdded = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={CheckMediaOrigin.USER_ADDED} originTimestamp={originTimestamp} user={user} />);
     expect(userAdded.find(PersonAdd).length).toEqual(1);
-    expect(userAdded.html()).toContain('This media was added to the cluster by');
+    expect(userAdded.html()).toContain('This media was added to the cluster of media by');
 
-    const userMerged = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={CheckMediaOrigin.USER_MERGED} user={user} />);
+    const userMerged = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={CheckMediaOrigin.USER_MERGED} originTimestamp={originTimestamp} user={user} />);
     expect(userMerged.find(Person).length).toEqual(1);
-    expect(userMerged.html()).toContain('This media was added to the cluster by');
+    expect(userMerged.html()).toContain('his media was merged into this cluster of media by');
 
-    const userMatched = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={CheckMediaOrigin.USER_MATCHED} user={user} />);
+    const userMatched = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={CheckMediaOrigin.USER_MATCHED} originTimestamp={originTimestamp} user={user} />);
     expect(userMatched.find(PersonCheck).length).toEqual(1);
-    expect(userMatched.html()).toContain('This media was added to the cluster by');
+    expect(userMatched.html()).toContain('This media was added to the cluster of media by');
 
-    const autoMatched = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={CheckMediaOrigin.AUTO_MATCHED} user={user} />);
+    const autoMatched = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={CheckMediaOrigin.AUTO_MATCHED} originTimestamp={originTimestamp} user={user} />);
     expect(autoMatched.find(Bolt).length).toEqual(1);
-    expect(autoMatched.html()).toContain('This media was automatically matched to the cluster');
+    expect(autoMatched.html()).toContain('This media was automatically matched to the cluster of media');
   });
 
   it('should return null for invalid type', () => {
-    const wrapper = mountWithIntl(<MediaBanner cluster={cluster} timestamp={timestamp} type={99} user={user} />);
+    const wrapper = mountWithIntl(<MediaBanner mediaClusterRelationship={mediaClusterRelationship} origin={99} originTimestamp={originTimestamp} user={user} />);
     expect(wrapper.find('FormattedMessage').length).toEqual(0);
   });
 });

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -24,6 +24,7 @@ import { getErrorMessage } from '../../../helpers';
 import MediaIdentifier from '../../cds/media-cards/MediaIdentifier';
 import LastRequestDate from '../../cds/media-cards/LastRequestDate';
 import RequestsCount from '../../cds/media-cards/RequestsCount';
+import MediaOrigin from '../MediaOrigin';
 import styles from '../media.module.css';
 import similarityStyles from './MediaSimilarities.module.css';
 
@@ -269,6 +270,8 @@ const MediaRelationship = ({
   mainProjectMediaConfirmedSimilarCount,
   mainProjectMediaDemand,
   mainProjectMediaId,
+  media_cluster_origin,
+  media_cluster_origin_user,
   relationship,
   relationshipSourceId,
   relationshipTargetId,
@@ -299,6 +302,11 @@ const MediaRelationship = ({
       slug={relationship?.target?.media_slug || relationship?.target?.title}
       theme="lightText"
       variant="text"
+    />
+  ), (
+    <MediaOrigin
+      type={media_cluster_origin}
+      user={media_cluster_origin_user?.name}
     />
   )];
 

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -25,6 +25,7 @@ import MediaIdentifier from '../../cds/media-cards/MediaIdentifier';
 import LastRequestDate from '../../cds/media-cards/LastRequestDate';
 import RequestsCount from '../../cds/media-cards/RequestsCount';
 import MediaOrigin from '../MediaOrigin';
+import MediaOriginBanner from '../MediaOriginBanner';
 import styles from '../media.module.css';
 import similarityStyles from './MediaSimilarities.module.css';
 
@@ -270,12 +271,14 @@ const MediaRelationship = ({
   mainProjectMediaConfirmedSimilarCount,
   mainProjectMediaDemand,
   mainProjectMediaId,
-  media_cluster_origin,
-  media_cluster_origin_user,
+  mediaClusterRelationship,
+  origin,
+  originTimestamp,
   relationship,
   relationshipSourceId,
   relationshipTargetId,
   setFlashMessage,
+  user,
 }) => {
   const [isSelected, setIsSelected] = React.useState(false);
 
@@ -305,8 +308,8 @@ const MediaRelationship = ({
     />
   ), (
     <MediaOrigin
-      type={media_cluster_origin}
-      user={media_cluster_origin_user?.name}
+      origin={origin}
+      user={user}
     />
   )];
 
@@ -319,6 +322,14 @@ const MediaRelationship = ({
           dialogTitle={relationship?.target?.media.metadata?.title || relationship?.target?.media.quote || relationship?.target?.description}
           feedId={relationship?.target?.imported_from_feed_id}
           mediaHeader={<MediaFeedInformation projectMedia={relationship?.target} />}
+          mediaOriginBanner={
+            <MediaOriginBanner
+              mediaClusterRelationship={mediaClusterRelationship}
+              origin={origin}
+              originTimestamp={originTimestamp}
+              user={user}
+            />
+          }
           mediaSlug={
             <MediaSlug
               className={styles['media-slug-title']}

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -27,6 +27,8 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => (
         mainProjectMediaConfirmedSimilarCount={projectMedia.confirmedSimilarCount}
         mainProjectMediaDemand={projectMedia.demand}
         mainProjectMediaId={projectMedia.id}
+        media_cluster_origin={relationship.node.target?.media_cluster_origin}
+        media_cluster_origin_user={relationship.node.target?.media_cluster_origin_user.name}
         relationship={relationship.node}
         relationshipSourceId={relationship.node.source_id}
         relationshipTargetId={relationship.node.target_id}
@@ -72,6 +74,10 @@ export default createFragmentContainer(MediaSimilaritiesComponent, graphql`
           target_id
           target {
             id
+            media_cluster_origin
+            media_cluster_origin_user{
+              name
+            }
             dbid
             title
             description

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.js
@@ -27,11 +27,13 @@ const MediaSimilaritiesComponent = ({ projectMedia }) => (
         mainProjectMediaConfirmedSimilarCount={projectMedia.confirmedSimilarCount}
         mainProjectMediaDemand={projectMedia.demand}
         mainProjectMediaId={projectMedia.id}
-        media_cluster_origin={relationship.node.target?.media_cluster_origin}
-        media_cluster_origin_user={relationship.node.target?.media_cluster_origin_user.name}
+        mediaClusterRelationship={relationship.node.target?.media_cluster_relationship}
+        origin={relationship.node.target?.media_cluster_origin}
+        originTimestamp={relationship.node.target?.media_cluster_origin_timestamp}
         relationship={relationship.node}
         relationshipSourceId={relationship.node.source_id}
         relationshipTargetId={relationship.node.target_id}
+        user={relationship.node.target?.media_cluster_origin_user?.name}
       />
     ))}
   </div>
@@ -75,8 +77,17 @@ export default createFragmentContainer(MediaSimilaritiesComponent, graphql`
           target {
             id
             media_cluster_origin
-            media_cluster_origin_user{
+            media_cluster_origin_user {
               name
+            }
+            media_cluster_origin_timestamp
+            media_cluster_relationship {
+              target{
+                title
+              }
+              confirmed_by {
+                name
+              }
             }
             dbid
             title

--- a/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
+++ b/src/app/components/media/Similarity/MediaSimilaritiesComponent.test.js
@@ -18,6 +18,12 @@ describe('<MediaSimilaritiesComponent />', () => {
               dbid: 1,
               source_id: 1,
               target_id: 1,
+              target: {
+                media_cluster_origin: 1,
+                media_cluster_origin_user: {
+                  name: 'test User',
+                },
+              },
             },
           },
           {
@@ -26,6 +32,10 @@ describe('<MediaSimilaritiesComponent />', () => {
               dbid: 2,
               source_id: 1,
               target_id: 1,
+              media_cluster_origin: 1,
+              media_cluster_origin_user: {
+                name: 'test User',
+              },
             },
           },
         ],


### PR DESCRIPTION
## Description

- [X] Add the MediaOrigin to the required sections of the MediaPage.
- [X] Add the MediaOriginBanner to the required sections of the MediaPage.
- [X] Update GraphQL query to fetch the newly added media_cluster_origin fields.
- [X] Update unit tests
- [X] Create follow-up ticket for the refactoring:

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

- manually and running the unit tests

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [x] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
