### PR TITLE
CV2-5915: remove notes from search settings

### DIFF
--- a/localization/react-intl/src/app/components/search/SearchKeywordConfig/SearchKeywordConfigComponent.json
+++ b/localization/react-intl/src/app/components/search/SearchKeywordConfig/SearchKeywordConfigComponent.json
@@ -60,11 +60,6 @@
     "defaultMessage": "URL"
   },
   {
-    "id": "searchKeywordConfig.allNotes",
-    "description": "Label for checkbox to toggle searching for keyword across notes (aka comments)",
-    "defaultMessage": "Notes"
-  },
-  {
     "id": "searchKeywordConfig.request",
     "description": "Label for checkbox to toggle searching for keyword across Requests data",
     "defaultMessage": "Request"

--- a/src/app/components/search/SearchKeywordConfig/SearchKeywordConfigComponent.js
+++ b/src/app/components/search/SearchKeywordConfig/SearchKeywordConfigComponent.js
@@ -146,18 +146,6 @@ const SearchKeywordConfigComponent = ({
       parent: 'media',
     },
   ];
-  const noteOption = [
-    {
-      value: 'comments',
-      label: (
-        <FormattedMessage
-          defaultMessage="Notes"
-          description="Label for checkbox to toggle searching for keyword across notes (aka comments)"
-          id="searchKeywordConfig.allNotes"
-        />
-      ),
-    },
-  ];
   const userRequestOptions = [
     {
       value: 'user_and_request',
@@ -198,8 +186,6 @@ const SearchKeywordConfigComponent = ({
     ...claimFactCheckOptions,
     ...hrOption,
     ...mediaOptions,
-    ...hrOption,
-    ...noteOption,
     ...hrOption,
     ...userRequestOptions,
   ];


### PR DESCRIPTION
## Description

Remove the Notes option from the search settings, as the comments have been deprecated.

References: CV2-5915

## Type of change

- [ ] Performance improvement and/or refactoring (non-breaking change that keeps existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security mitigation or enhancement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Automated test (add or update automated tests)

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I've made sure my branch is runnable and given good testing steps in the PR description
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I implemented any new components, they are self-contained, their `propTypes` are declared and they use React Hooks and, if data-fetching is required, they use Relay Modern with fragment containers
- [ ] If my components involve user interaction - specifically button, text fields, or other inputs - I have added a [BEM-like class name](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1327628289/Naming+conventions+for+interactive+elements) to the element that is interacted with
- [ ] To the best of my knowledge, any new styles are applied according to the design system
- [ ] If I added a new external dependency, I included a rationale for doing so and an estimate of the change in bundle size (e.g., checked in https://bundlephobia.com/)
- [ ] If I touched a file that included an eslint-disable-file header, I updated the code such that the disabler can be removed 
