### PR TITLE
Fixing a couple of regressions (missing GraphQL fields).

### DIFF
--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -283,7 +283,7 @@ const MediaRelationship = ({
 
   const details = [(
     <LastRequestDate
-      lastRequestDate={+relationship?.target?.last_seen * 1000}
+      lastRequestDate={(+relationship?.target?.last_seen * 1000) || +relationship?.target?.created_at * 1000}
       theme="lightText"
       variant="text"
     />
@@ -381,9 +381,11 @@ export default createFragmentContainer(withSetFlashMessage(injectIntl(MediaRelat
       description
       type
       last_seen
+      created_at
       show_warning_cover
       quote
       imported_from_feed_id
+      requests_count
       media {
         ...SmallMediaCard_media
       }


### PR DESCRIPTION
## Description

Both regressions affect the media card on the item page:

* Request the `relationship.target.created_at` field, so we can fallback to it when `last_seen` is `null`.
* Request the `relationship.target.requests_count` field, which is currently causing a "NaN Requests" error.

Fixes: CV2-6126.

## How to test?

Open any media cluster page that has more than one media.

Previously:

![Captura de tela de 2025-02-06 00-14-09](https://github.com/user-attachments/assets/9808fcb9-c111-4519-ac77-289cbea910bb)

Now:

![Captura de tela de 2025-02-06 00-50-17](https://github.com/user-attachments/assets/039fd21a-aaed-4552-8d22-7fdb14338b49)

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).