### PR TITLE
Add missing prop to display fact check publication status in shared feed feed list

### DIFF
--- a/src/app/components/search/SearchResultsCards/index.js
+++ b/src/app/components/search/SearchResultsCards/index.js
@@ -15,6 +15,7 @@ const SearchResultsCards = ({ projectMedias, team }) => (
         <div className="fact-check-card-wrapper" key={values.fact_check_title}>
           <ArticleCard
             date={values.updated_at_timestamp}
+            isPublished={projectMedia.report_status === 'published'}
             statusColor={status.style?.color}
             statusLabel={status.label || values.status}
             summary={values.fact_check_summary}


### PR DESCRIPTION
## Description

Added the missing prop `isPublished` to indicate if the fact check is published on the shared feed list.

Reference: CV2-5279

## How to test?
Tested manually on the shared feed list. 

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
