### PR TITLE
Sort entries descending

### DIFF
--- a/src/app/components/dashboard/VerticalBarMediaReceivedByType.js
+++ b/src/app/components/dashboard/VerticalBarMediaReceivedByType.js
@@ -17,7 +17,7 @@ const VerticalBarMediaReceivedByType = ({ intl, statistics }) => (
           Object.entries(statistics.number_of_media_received_by_media_type).map(([name, value]) => ({
             name: getMediaTypeDisplayName(name, intl),
             value,
-          }))
+          })).sort((a, b) => b.value - a.value) // Sort in descending order
         }
         title={title}
       />


### PR DESCRIPTION
## Description

This commit sorts the bars in the Media Received widget for the tipline dashboard in descending order (high to low).

References: CV2-5662

## How to test?

Go to the Tipline Dashboard and verify if the Media Received is sorted in descending order (high to low).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
