### PR TITLE
CV2-5958 Add custom slider component

### DIFF
--- a/src/app/components/bot/BotPreview.module.css
+++ b/src/app/components/bot/BotPreview.module.css
@@ -187,48 +187,6 @@
 
       .settings-slider-wrapper {
         margin: 8px 24px;
-
-        :global(.MuiSlider-rail) {
-          border-radius: var(--border-radius-medium);
-          color: var(--color-gray-96);
-          height: 10px;
-        }
-
-        :global(.MuiSlider-track) {
-          display: none;
-        }
-
-        :global(.MuiSlider-mark) {
-          color: var(--color-gray-88);
-          height: 18px;
-          margin-top: -4px;
-          width: 3px;
-
-          &:hover {
-            border: 12px solid var(--color-blue-32);
-            border-radius: var(--border-radius-max);
-            margin-left: -10px;
-            margin-top: -7px;
-            opacity: .2;
-          }
-        }
-
-        :global(.MuiSlider-thumb) {
-          height: 22px;
-          margin-left: -10px;
-          margin-top: -7px;
-          width: 22px;
-        }
-
-        :global(.MuiSlider-markLabel) {
-          color: var(--color-gray-15);
-          font-weight: 600;
-          top: 36px;
-        }
-
-        :global(.MuiSlider-marked) {
-          margin-bottom: 26px;
-        }
       }
 
       .settings-slider-help-text {

--- a/src/app/components/bot/MatchingSettings.js
+++ b/src/app/components/bot/MatchingSettings.js
@@ -1,21 +1,10 @@
 import React from 'react';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import Slider from '@material-ui/core/Slider';
+import SliderComponent from '../cds/inputs/SliderComponent';
 import TextField from '../cds/inputs/TextField';
-import Tooltip from '../cds/alerts-and-prompts/Tooltip';
 import LibraryAddCheckIcon from '../../icons/library_add_check.svg';
 import styles from './BotPreview.module.css';
 import settingsStyles from '../team/Settings.module.css';
-
-const valueLabelComponet = (props) => {
-  const { children, open, value } = props;
-
-  return (
-    <Tooltip arrow open={open} placement="top" title={value}>
-      {children}
-    </Tooltip>
-  );
-};
 
 const messages = defineMessages({
   lenientMessage: {
@@ -94,9 +83,9 @@ const MatchingSettings = ({
           />
         </div>
         <div className={styles['settings-slider-wrapper']}>
-          <Slider
-            ValueLabelComponent={valueLabelComponet}
+          <SliderComponent
             disabled={!isAdmin}
+            marked
             marks={marks}
             max={0.9}
             min={0.75}

--- a/src/app/components/bot/MatchingSettings.js
+++ b/src/app/components/bot/MatchingSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import SliderComponent from '../cds/inputs/SliderComponent';
+import Slider from '../cds/inputs/Slider';
 import TextField from '../cds/inputs/TextField';
 import LibraryAddCheckIcon from '../../icons/library_add_check.svg';
 import styles from './BotPreview.module.css';
@@ -83,7 +83,7 @@ const MatchingSettings = ({
           />
         </div>
         <div className={styles['settings-slider-wrapper']}>
-          <SliderComponent
+          <Slider
             disabled={!isAdmin}
             marked
             marks={marks}

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -16,6 +16,7 @@ import ListSort from './inputs/ListSort';
 import TextArea from './inputs/TextArea';
 import DatePicker from './inputs/DatePicker';
 import LanguagePickerSelect from './inputs/LanguagePickerSelect';
+import SliderComponent from './inputs/SliderComponent';
 import Time from './inputs/Time';
 import { ToggleButton, ToggleButtonGroup } from './inputs/ToggleButtonGroup';
 import Select from './inputs/Select';
@@ -217,6 +218,9 @@ const SandboxComponent = ({ admin }) => {
   const [checkboxLabel, setCheckboxLabel] = React.useState(Boolean(true));
   const [checkboxDisabled, setCheckboxDisabled] = React.useState(Boolean(false));
   const [checkboxChecked, setCheckboxChecked] = React.useState(Boolean(false));
+
+  const [sliderMarked, setSliderMarked] = React.useState(Boolean(true));
+  const [sliderDisabled, setSliderDisabled] = React.useState(Boolean(true));
 
   const [selectLabel, setSelectLabel] = React.useState(Boolean(true));
   const [selectIconLeft, setSelectIconLeft] = React.useState(Boolean(true));
@@ -1603,6 +1607,60 @@ const SandboxComponent = ({ admin }) => {
                 disabled={checkboxDisabled}
                 label={checkboxLabel ? 'I am a Checkbox label' : null}
                 onChange={() => setCheckboxChecked(!checkboxChecked)}
+              />
+            </div>
+          </div>
+          <div className={styles.componentWrapper}>
+            <div className={styles.componentControls}>
+              <div className={cx('typography-subtitle2', [styles.componentName])}>
+                Slider
+              </div>
+              <ul>
+                <li>
+                  <SwitchComponent
+                    checked={sliderMarked}
+                    label="Marked"
+                    labelPlacement="top"
+                    onChange={() => setSliderMarked(!sliderMarked)}
+                  />
+                </li>
+                <li>
+                  <SwitchComponent
+                    checked={sliderDisabled}
+                    label="Disabled"
+                    labelPlacement="top"
+                    onChange={() => setSliderDisabled(!sliderDisabled)}
+                  />
+                </li>
+              </ul>
+            </div>
+            <div className={styles.componentBlockVariants}>
+              <SliderComponent
+                disabled={sliderDisabled}
+                marked={sliderMarked}
+                marks={sliderMarked ? [
+                  {
+                    value: '0.75',
+                    label: 'Lowest',
+                  },
+                  {
+                    value: '0.80',
+                    label: '',
+                  },
+                  {
+                    value: '0.85',
+                    label: '',
+                  },
+                  {
+                    value: '0.90',
+                    label: 'Highest',
+                  },
+                ] : null}
+                max={0.9}
+                min={0.75}
+                step={null}
+                track={!sliderMarked}
+                valueLabelDisplay="auto"
               />
             </div>
           </div>

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -16,7 +16,7 @@ import ListSort from './inputs/ListSort';
 import TextArea from './inputs/TextArea';
 import DatePicker from './inputs/DatePicker';
 import LanguagePickerSelect from './inputs/LanguagePickerSelect';
-import SliderComponent from './inputs/SliderComponent';
+import Slider from './inputs/Slider';
 import Time from './inputs/Time';
 import { ToggleButton, ToggleButtonGroup } from './inputs/ToggleButtonGroup';
 import Select from './inputs/Select';
@@ -1635,7 +1635,7 @@ const SandboxComponent = ({ admin }) => {
               </ul>
             </div>
             <div className={styles.componentBlockVariants}>
-              <SliderComponent
+              <Slider
                 disabled={sliderDisabled}
                 marked={sliderMarked}
                 marks={sliderMarked ? [

--- a/src/app/components/cds/inputs/Slider.js
+++ b/src/app/components/cds/inputs/Slider.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import cx from 'classnames/bind';
-import Slider from '@material-ui/core/Slider';
+import { Slider as MuiSlider } from '@material-ui/core';
 import Tooltip from '../alerts-and-prompts/Tooltip';
 import styles from './Slider.module.css';
 
 const valueLabelComponet = (props) => {
-  const { children, open, value } = props;
+  const {
+    children,
+    open,
+    value,
+    valueLabelDisplay,
+  } = props;
+
+  if (valueLabelDisplay === 'off') {
+    return children;
+  }
 
   return (
     <Tooltip arrow open={open} placement="top" title={value}>
@@ -14,8 +23,8 @@ const valueLabelComponet = (props) => {
   );
 };
 
-const SliderComponent = props => (
-  <Slider
+const Slider = props => (
+  <MuiSlider
     ValueLabelComponent={valueLabelComponet}
     className={cx(
       styles.sliderComponent,
@@ -28,4 +37,4 @@ const SliderComponent = props => (
   />
 );
 
-export default SliderComponent;
+export default Slider;

--- a/src/app/components/cds/inputs/Slider.module.css
+++ b/src/app/components/cds/inputs/Slider.module.css
@@ -5,7 +5,7 @@
       color: var(--color-gray-96);
       height: 10px;
     }
-    
+
     :global(.MuiSlider-track) {
       display: none;
     }

--- a/src/app/components/cds/inputs/Slider.module.css
+++ b/src/app/components/cds/inputs/Slider.module.css
@@ -1,0 +1,45 @@
+.sliderComponent {
+  &.marked {
+    :global(.MuiSlider-rail) {
+      border-radius: var(--border-radius-medium);
+      color: var(--color-gray-96);
+      height: 10px;
+    }
+    
+    :global(.MuiSlider-track) {
+      display: none;
+    }
+
+    :global(.MuiSlider-mark) {
+      color: var(--color-gray-88);
+      height: 18px;
+      margin-top: -4px;
+      width: 3px;
+
+      &:hover {
+        border: 12px solid var(--color-blue-32);
+        border-radius: var(--border-radius-max);
+        margin-left: -10px;
+        margin-top: -7px;
+        opacity: .2;
+      }
+    }
+
+    :global(.MuiSlider-thumb) {
+      height: 22px;
+      margin-left: -10px;
+      margin-top: -7px;
+      width: 22px;
+    }
+
+    :global(.MuiSlider-markLabel) {
+      color: var(--color-gray-15);
+      font-weight: 600;
+      top: 36px;
+    }
+
+    :global(.MuiSlider-marked) {
+      margin-bottom: 26px;
+    }
+  }
+}

--- a/src/app/components/cds/inputs/Slider.test.js
+++ b/src/app/components/cds/inputs/Slider.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Slider from './Slider';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+
+describe('<Slider />', () => {
+  const props = {
+    value: 10,
+    onChange: () => {},
+  };
+
+  it('renders without crashing', () => {
+    mountWithIntl(<Slider {...props} />);
+  });
+
+  const markedProps = {
+    marked: 'true',
+    marks: true,
+    max: 5,
+    min: 1,
+    step: 1,
+    value: 2,
+    onChange: () => {},
+  };
+
+  it('renders marked slider', () => {
+    const slider = mountWithIntl(<Slider {...markedProps} />);
+    const marks = slider.find('.MuiSlider-mark');
+    expect(marks).toHaveLength(5);
+  });
+});

--- a/src/app/components/cds/inputs/SliderComponent.js
+++ b/src/app/components/cds/inputs/SliderComponent.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import cx from 'classnames/bind';
+import Slider from '@material-ui/core/Slider';
+import Tooltip from '../alerts-and-prompts/Tooltip';
+import styles from './Slider.module.css';
+
+const valueLabelComponet = (props) => {
+  const { children, open, value } = props;
+
+  return (
+    <Tooltip arrow open={open} placement="top" title={value}>
+      {children}
+    </Tooltip>
+  );
+};
+
+const SliderComponent = props => (
+  <Slider
+    ValueLabelComponent={valueLabelComponet}
+    className={cx(
+      styles.sliderComponent,
+      {
+        [props.className]: true,
+        [styles.marked]: props.marked,
+      },
+    )}
+    {...props}
+  />
+);
+
+export default SliderComponent;

--- a/src/app/components/cds/media-cards/MediaTimeline.js
+++ b/src/app/components/cds/media-cards/MediaTimeline.js
@@ -1,6 +1,6 @@
 import React from 'react';
 // import PropTypes from 'prop-types';
-import { Slider } from '@material-ui/core';
+import Slider from '../inputs/Slider';
 import styles from './MediaControls.module.css';
 
 const MediaTimeline = ({

--- a/src/app/components/cds/media-cards/MediaVolume.js
+++ b/src/app/components/cds/media-cards/MediaVolume.js
@@ -1,6 +1,6 @@
 import React from 'react';
 // import PropTypes from 'prop-types';
-import Slider from '@material-ui/core/Slider';
+import Slider from '../inputs/Slider';
 import ButtonMain from '../buttons-checkboxes-chips/ButtonMain';
 import VolumeUpIcon from '../../../icons/volume_up.svg';
 import VolumeOffIcon from '../../../icons/volume_off.svg';

--- a/src/app/components/team/Similarity/ThresholdControl.js
+++ b/src/app/components/team/Similarity/ThresholdControl.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Slider from '@material-ui/core/Slider';
+import Slider from '../../cds/inputs/Slider';
 import TextField from '../../cds/inputs/TextField';
 import styles from './ThresholdControl.module.css';
 import settingsStyles from '../Settings.module.css';


### PR DESCRIPTION
## Description

Added a slider component that uses our custom tooltip.  Adds a marked prop which lets us move out the slider specific styling from the BotPreview css.  Added to Sandbox.

References: CV2-5958

## How to test?

Manually, no functional change

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
