### PR TITLE
CV2-5781 remove save from Shared Feed

### DIFF
--- a/src/app/components/feed/FeedFilters.js
+++ b/src/app/components/feed/FeedFilters.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { commitMutation, graphql } from 'react-relay/compat';
@@ -311,7 +310,7 @@ const FeedFilters = ({
             />
           </div>
           : null }
-        { disableSave ?
+        { !disableSave ?
           <ButtonMain
             buttonProps={{
               id: 'save-list__button',
@@ -335,23 +334,23 @@ const FeedFilters = ({
 };
 
 FeedFilters.defaultProps = {
-  filterOptions: [],
   currentFilters: {},
   disableSave: false,
   extra: null,
+  filterOptions: [],
 };
 
 FeedFilters.propTypes = {
-  filterOptions: PropTypes.arrayOf(PropTypes.string.isRequired),
   currentFilters: PropTypes.object,
+  disableSave: PropTypes.bool,
+  extra: PropTypes.node,
   feedTeam: PropTypes.shape({
     id: PropTypes.string.isRequired,
     requests_filters: PropTypes.object,
   }).isRequired,
-  onSubmit: PropTypes.func.isRequired,
-  disableSave: PropTypes.bool,
-  extra: PropTypes.node,
+  filterOptions: PropTypes.arrayOf(PropTypes.string.isRequired),
   intl: intlShape.isRequired,
+  onSubmit: PropTypes.func.isRequired,
 };
 
 export default withSetFlashMessage(injectIntl(FeedFilters));


### PR DESCRIPTION
## Description

Shared feeds that displayed Media Clusters had an unusable Save button.  There was already a disableSave value being passed, the logic was just backwards, where if disableSave was true, the button would show.

References: CV2-5781

## How to test?

Set up a Shared Feed for Media Clusters and Requests, verify there's no Save button besides the filters

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
