### PR TITLE
The Minimum Value for the Relative Date Filter Should Be 1 Day Instead of Zero

### DIFF
--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -250,6 +250,7 @@ function DateRangeSelectorRelative(props) {
         { placeholder => (
           <TextField
             className={styles['filter-input-number']}
+            min={1}
             placeholder={placeholder}
             type="number"
             value={relativeQuantity}
@@ -305,7 +306,7 @@ const DateRangeFilter = ({
     years: 'y',
   };
   const [relativeRange, setRelativeRange] = React.useState((value && value[getValueType()]?.period_type) || relativeRanges.days);
-  const [relativeQuantity, setRelativeQuantity] = React.useState((value && value[getValueType()]?.period) || '0');
+  const [relativeQuantity, setRelativeQuantity] = React.useState((value && value[getValueType()]?.period) || '1');
 
   const getDateStringOrNull = field => (value && value[getValueType()][field]) || null;
 


### PR DESCRIPTION
## Description

The current zero value in the relative date filter does not return the expected results. A simple fix is to set the minimum and default value to 1.

Fixes: CV2-5851.

## How to test?

Manually: Ensure that for the articles' relative date filter, the default and minimum number of days is one, not zero.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
