### PR TITLE
6093 – Remove X (née Twitter) and Instagram from messaging platforms list in tipline settings

### DIFF
--- a/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
+++ b/localization/react-intl/src/app/components/team/SmoochBot/SmoochBotIntegrations.json
@@ -30,11 +30,6 @@
     "defaultMessage": "Use this code or download the image to display the QR code on online or offline promotion. Scanning the QR code opens WhatsApp and starts a tipline conversation."
   },
   {
-    "id": "smoochBotIntegrations.twitterDisabled",
-    "description": "Disclaimer displayed on X tipline settings page.",
-    "defaultMessage": "The integration with X is currently not available, following changes to the X API on April 21, 2023."
-  },
-  {
     "id": "smoochBotIntegrations.page",
     "description": "Label for the connected Facebook page for this bot",
     "defaultMessage": "Connected page: {link}"
@@ -73,10 +68,5 @@
     "id": "smoochBotIntegrations.lineChannelSecret",
     "description": "Output of the LINE channel secret paired with the token",
     "defaultMessage": "LINE channel secret"
-  },
-  {
-    "id": "smoochBotIntegrations.instagram",
-    "description": "Label for the connected Instagram profile for this bot",
-    "defaultMessage": "Connected profile: {link}"
   }
 ]

--- a/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
@@ -13,10 +13,8 @@ import FileCopyOutlinedIcon from '../../../icons/content_copy.svg';
 import FacebookIcon from '../../../icons/facebook.svg';
 import LineIcon from '../../../icons/line.svg';
 import TelegramIcon from '../../../icons/telegram.svg';
-import TwitterIcon from '../../../icons/twitter.svg';
 import ViberIcon from '../../../icons/viber.svg';
 import WhatsAppIcon from '../../../icons/whatsapp.svg';
-import InstagramIcon from '../../../icons/instagram.svg';
 import socialStyles from '../../../styles/css/socials.module.css';
 import smoochBotStyles from './SmoochBot.module.css';
 
@@ -195,24 +193,6 @@ const SmoochBotIntegrations = ({ enabledIntegrations, installationId, settings }
           url="https://airtable.com/shrAhYXEFGe7F9QHr"
         />
         <SmoochBotIntegrationButton
-          deprecationNotice={
-            <FormattedMessage
-              defaultMessage="The integration with X is currently not available, following changes to the X API on April 21, 2023."
-              description="Disclaimer displayed on X tipline settings page."
-              id="smoochBotIntegrations.twitterDisabled"
-            />
-          }
-          disabled={false}
-          helpUrl="https://help.checkmedia.org/en/articles/8772777-setup-your-tipline-bot"
-          icon={<TwitterIcon className={socialStyles['x-black']} />}
-          installationId={installationId}
-          label="X (Twitter)"
-          online={false}
-          readOnly={false}
-          type="twitter"
-          url={null}
-        />
-        <SmoochBotIntegrationButton
           disabled={!isEnabled}
           helpUrl="https://help.checkmedia.org/en/articles/8772777-setup-your-tipline-bot#h_6adda6c137"
           icon={<FacebookIcon className={socialStyles['facebook-blue']} />}
@@ -333,32 +313,6 @@ const SmoochBotIntegrations = ({ enabledIntegrations, installationId, settings }
           ]}
           readOnly={!isSmoochSet}
           type="line"
-        />
-        <SmoochBotIntegrationButton
-          disabled={!isEnabled}
-          helpUrl="https://help.checkmedia.org/en/articles/8772777-setup-your-tipline-bot#h_b872d32c4d"
-          icon={<InstagramIcon className={socialStyles['instagram-pink']} />}
-          info={
-            isOnline('instagram') ?
-              <FormattedMessage
-                defaultMessage="Connected profile: {link}"
-                description="Label for the connected Instagram profile for this bot"
-                id="smoochBotIntegrations.instagram"
-                values={{
-                  link: (
-                    <a href={`https://instagram.com/${enabledIntegrations.instagram.businessUsername}`} rel="noopener noreferrer" target="_blank">
-                      {enabledIntegrations.instagram.businessName}
-                    </a>
-                  ),
-                }}
-              /> : null
-          }
-          installationId={installationId}
-          label="Instagram"
-          online={isOnline('instagram')}
-          readOnly={!isSmoochSet}
-          type="instagram"
-          url={settings.smooch_facebook_authorization_url.replace('authorize/facebook', 'authorize/instagram')}
         />
       </div>
     </React.Fragment>


### PR DESCRIPTION
## Description

Removed Twitter and Instagram buttons from `settings/tipline/platforms` since it's no longer possible to connect to tiplines.

References: CV2-6093

## How to test?

I tested manually by checking the buttons were no longer present:

<img width="826" alt="Screenshot 2025-02-12 at 14 10 56" src="https://github.com/user-attachments/assets/3d517382-6b2c-4874-8a20-a092caed156a" />


## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
