### PR TITLE
Fix: Prevent rendering null content when origin is missing

### DIFF
--- a/src/app/components/media/MediaOrigin.js
+++ b/src/app/components/media/MediaOrigin.js
@@ -117,6 +117,14 @@ const getIconAndMessage = (origin, user) => {
 
 const MediaOrigin = ({ projectMedia }) => {
   const { media_cluster_origin: origin, media_cluster_origin_user: user } = projectMedia;
+
+  // We check for `origin == null` (instead of `!origin`) because TIPLINE_SUBMITTED is 0,
+  // which would evaluate as falsy in a `!origin` check. Using `== null` ensures we only
+  // fallback when `origin` is `null` , not when it's `0`.
+  if (origin == null) {
+    return null;
+  }
+
   const { icon, message, tooltipMessage } = getIconAndMessage(origin, user?.name);
 
   return (

--- a/src/app/components/media/MediaOriginBanner.js
+++ b/src/app/components/media/MediaOriginBanner.js
@@ -112,6 +112,14 @@ const MediaOriginBanner = ({ projectMedia }) => {
     media_cluster_origin_user: user,
     media_cluster_relationship: mediaClusterRelationship,
   } = projectMedia;
+
+  // We check for `origin == null` (instead of `!origin`) because TIPLINE_SUBMITTED is 0,
+  // which would evaluate as falsy in a `!origin` check. Using `== null` ensures we only
+  // fallback when `origin` is `null` , not when it's `0`.
+  if (origin == null) {
+    return null;
+  }
+
   const { icon, message } = getIconAndMessage(origin, mediaClusterRelationship, user?.name, originTimestamp);
   return (
     <div style={{ marginBottom: '8px' }}>

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -301,7 +301,7 @@ const MediaRelationship = ({
       variant="text"
     />
   ), (
-    relationship?.target ? (
+    relationship?.target.media_cluster_origin_user?.name ? (
       <MediaOrigin
         projectMedia={relationship?.target}
       />
@@ -388,6 +388,9 @@ export default createFragmentContainer(withSetFlashMessage(injectIntl(MediaRelat
       quote
       imported_from_feed_id
       requests_count
+      media_cluster_origin_user {
+        name
+      }
       media {
         ...SmallMediaCard_media
       }

--- a/src/app/components/media/Similarity/MediaRelationship.js
+++ b/src/app/components/media/Similarity/MediaRelationship.js
@@ -301,9 +301,11 @@ const MediaRelationship = ({
       variant="text"
     />
   ), (
-    <MediaOrigin
-      projectMedia={relationship?.target}
-    />
+    relationship?.target ? (
+      <MediaOrigin
+        projectMedia={relationship?.target}
+      />
+    ) : null
   )];
 
   const maskContent = relationship?.target?.show_warning_cover;


### PR DESCRIPTION
## Description

This prevents the alert and bullets from rendering with null content 
Reference: CV2-6130

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
