### PR TITLE
More inline styles removed

### DIFF
--- a/src/app/components/ExternalLink.js
+++ b/src/app/components/ExternalLink.js
@@ -7,7 +7,6 @@ const ExternalLink = ({
   className,
   maxUrlLength,
   readable,
-  style,
   title,
   url,
 }) => {
@@ -20,7 +19,7 @@ const ExternalLink = ({
   displayUrl = maxUrlLength ? truncateLength(displayUrl, maxUrlLength) : displayUrl;
 
   return (
-    <a className={className} href={url} rel="noopener noreferrer" style={{ color: 'var(--color-blue-32)', ...style }} target="_blank">
+    <a className={className} href={url} rel="noopener noreferrer" target="_blank">
       {children || displayUrl}
     </a>
   );
@@ -30,7 +29,6 @@ ExternalLink.propTypes = {
   children: PropTypes.node,
   maxUrlLength: PropTypes.number,
   readable: PropTypes.bool,
-  style: PropTypes.object,
   title: PropTypes.string,
   url: PropTypes.string.isRequired,
 };
@@ -39,7 +37,6 @@ ExternalLink.defaultProps = {
   children: null,
   maxUrlLength: null,
   readable: false,
-  style: {},
   title: null,
 };
 

--- a/src/app/components/annotations/Annotation.js
+++ b/src/app/components/annotations/Annotation.js
@@ -38,7 +38,6 @@ class Annotation extends Component {
           <a
             href={`http://www.openstreetmap.org/?mlat=${coordinates[0]}&mlon=${coordinates[1]}&zoom=12#map=12/${coordinates[0]}/${coordinates[1]}`}
             rel="noreferrer noopener"
-            style={{ textDecoration: 'underline' }}
             target="_blank"
           >
             <ParsedText block text={name} />

--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -157,7 +157,7 @@ const MediaArticlesComponent = ({
         ) : (
           <>
             <div className={cx('typography-body1', styles.articlesSidebarNoArticle)}>
-              <DescriptionIcon style={{ fontSize: 'var(--font-size-h4)' }} />
+              <DescriptionIcon />
               <div>
                 <FormattedMessage
                   defaultMessage="No articles are being delivered to Tipline users who send requests that match this Media."

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 // DESIGNS: https://www.figma.com/file/7ZlvdotCAzeIQcbIKxOB65/Components?type=design&node-id=4-45716&mode=design&t=G3fBIdgR6AWtOlNu-4
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -120,19 +119,19 @@ Alert.defaultProps = {
 };
 
 Alert.propTypes = {
-  className: PropTypes.string,
-  title: PropTypes.node,
-  content: PropTypes.node,
-  floating: PropTypes.bool,
   banner: PropTypes.bool,
+  buttonLabel: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  className: PropTypes.string,
   contained: PropTypes.bool,
+  content: PropTypes.node,
   customIcon: PropTypes.node,
   extraActions: PropTypes.node,
+  floating: PropTypes.bool,
   icon: PropTypes.bool,
-  buttonLabel: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  title: PropTypes.node,
+  variant: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
   onButtonClick: PropTypes.func,
   onClose: PropTypes.func,
-  variant: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
 };
 
 export default Alert;

--- a/src/app/components/cds/inputs/LanguagePickerSelect.js
+++ b/src/app/components/cds/inputs/LanguagePickerSelect.js
@@ -6,6 +6,7 @@ import TextField from '../../cds/inputs/TextField';
 import LanguageRegistry, { languageLabel } from '../../../LanguageRegistry';
 import LanguageIcon from '../../../icons/language.svg';
 import ChevronDownIcon from '../../../icons/chevron_down.svg';
+import inputStyles from '../../../styles/css/inputs.module.css';
 
 const messages = defineMessages({
   optionLabel: {
@@ -69,7 +70,7 @@ const LanguagePickerSelect = ({
   };
 
   return (
-    <div id="language-change" style={{ minWidth: '230px' }}>
+    <div className={inputStyles['language-picker-wrapper']} id="language-change">
       <Autocomplete
         disableClearable
         disabled={isDisabled}

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -83,7 +83,7 @@ const FeedTopBar = ({
     }
 
     return (
-      <div style={{ position: 'relative' }}>
+      <div className={styles.feedTopBarItemWrapper}>
         <Tooltip
           arrow
           placement="top"

--- a/src/app/components/feed/FeedTopBar.module.css
+++ b/src/app/components/feed/FeedTopBar.module.css
@@ -10,6 +10,10 @@
     gap: 12px;
     padding: 6px;
 
+    .feedTopBarItemWrapper {
+      position: relative;
+    }
+
     .feedTopBarItem {
       align-items: center;
       border: 2px solid var(--color-blue-54);

--- a/src/app/components/media/MediaOriginBanner.js
+++ b/src/app/components/media/MediaOriginBanner.js
@@ -11,6 +11,7 @@ import Alert from '../cds/alerts-and-prompts/Alert';
 import CheckMediaOrigin from '../../CheckMediaOrigin';
 import { parseStringUnixTimestamp } from '../../helpers';
 import TimeBefore from '../TimeBefore';
+import dialogStyles from '../../styles/css/dialog.module.css';
 
 const getIconAndMessage = (origin, mediaClusterRelationship, user, originTimestamp) => {
   const formattedTimestamp = <TimeBefore date={parseStringUnixTimestamp(originTimestamp)} />;
@@ -114,14 +115,13 @@ const MediaOriginBanner = ({ projectMedia }) => {
   } = projectMedia;
   const { icon, message } = getIconAndMessage(origin, mediaClusterRelationship, user?.name, originTimestamp);
   return (
-    <div style={{ marginBottom: '8px' }}>
-      <Alert
-        content={message}
-        customIcon={icon}
-        icon
-        variant="info"
-      />
-    </div>
+    <Alert
+      className={dialogStyles['dialog-alert']}
+      content={message}
+      customIcon={icon}
+      icon
+      variant="info"
+    />
   );
 };
 

--- a/src/app/components/media/SensitiveContentMenuButton.js
+++ b/src/app/components/media/SensitiveContentMenuButton.js
@@ -9,6 +9,7 @@ import {
   Radio,
   RadioGroup,
 } from '@material-ui/core';
+import Alert from '../cds/alerts-and-prompts/Alert';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import LimitedTextArea from '../layout/inputs/LimitedTextArea';
 import SwitchComponent from '../cds/inputs/SwitchComponent';
@@ -214,7 +215,7 @@ const SensitiveContentMenu = ({
       onClose={onDismiss}
     >
       <div className={dialogStyles['dialog-content']}>
-        <div className={inputStyles['form-fieldset']} style={{ color: !enableSwitch && (formError === 'no_switch_enabled') ? 'red' : null }}>
+        <div className={inputStyles['form-fieldset']}>
           <SwitchComponent
             checked={enableSwitch}
             className={inputStyles['form-fieldset-field']}
@@ -235,14 +236,20 @@ const SensitiveContentMenu = ({
               value={contentType}
               onChange={e => handleSetContentType(e.target.value)}
             >
-              <div className={inputStyles['form-fieldset-title']} style={{ color: formError === 'no_warning_type' ? 'red' : null }}>
-                <FormattedMessage
-                  defaultMessage="Select a category"
-                  description="Header for sensitive content types"
-                  id="sensitiveContentMenuButton.selectCategory"
-                  tagName="strong"
-                />
-              </div>
+              { formError === 'no_warning_type' &&
+              <Alert
+                className={dialogStyles['dialog-alert']}
+                icon
+                title={
+                  <FormattedMessage
+                    defaultMessage="Select a category"
+                    description="Header for sensitive content types"
+                    id="sensitiveContentMenuButton.selectCategory"
+                  />
+                }
+                variant="error"
+              />
+              }
               <FormControlLabel
                 control={<Radio />}
                 label={<FormattedMessage

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -127,7 +127,6 @@ class AnnotationFilterDate extends React.Component {
             </>
           )}
           cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
-          className="fresh"
           maxDate={this.endDateStringOrNull || undefined}
           okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
           value={this.startDateStringOrNull}

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -127,9 +127,9 @@ class AnnotationFilterDate extends React.Component {
             </>
           )}
           cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
+          className="fresh"
           maxDate={this.endDateStringOrNull || undefined}
           okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
-          style={{ margin: '0 16px' }}
           value={this.startDateStringOrNull}
           onChange={this.handleChangeStartDate}
         />

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -166,7 +166,6 @@ function DateRangeSelectorStartEnd(props) {
           </>
         )}
         cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
-        className="fresh"
         maxDate={getEndDateStringOrNull() || undefined}
         okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
         value={getStartDateStringOrNull()}

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -166,9 +166,9 @@ function DateRangeSelectorStartEnd(props) {
           </>
         )}
         cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
+        className="fresh"
         maxDate={getEndDateStringOrNull() || undefined}
         okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
-        style={{ margin: '0 16px' }}
         value={getStartDateStringOrNull()}
         onChange={handleChangeStartDate}
       />

--- a/src/app/components/search/SearchKeyword.js
+++ b/src/app/components/search/SearchKeyword.js
@@ -271,9 +271,9 @@ class SearchKeyword extends React.Component {
                 <>
                   <input
                     accept="image/*,video/*,audio/*"
+                    className={searchStyles['search-form-config-hidden']}
                     id="media-upload"
                     ref={(el) => { this.fileInput = el; }}
-                    style={{ display: 'none' }}
                     type="file"
                     onChange={this.handleUpload}
                   />

--- a/src/app/components/search/search.module.css
+++ b/src/app/components/search/search.module.css
@@ -19,6 +19,10 @@
     gap: 8px;
     height: 48px;
     padding: 8px;
+
+    .search-form-config-hidden {
+      display: none;
+    }
   }
 }
 

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -270,7 +270,7 @@ class EditTaskDialog extends React.Component {
           />
         ),
         value: 'multiple_choice',
-        icon: <CheckBoxIcon style={{ transform: 'scale(1,1)' }} />,
+        icon: <CheckBoxIcon />,
         description: (
           <FormattedMessage
             defaultMessage="Allows you to select one or more predefined options"

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -198,7 +198,7 @@ class EditTaskDialog extends React.Component {
           />
         ),
         value: 'number',
-        icon: <NumberIcon style={{ fontSize: '24px' }} />,
+        icon: <NumberIcon />,
         description: (
           <FormattedMessage
             defaultMessage="Allows you to enter a number"

--- a/src/app/components/team/Rules/RuleOperatorWrapper.js
+++ b/src/app/components/team/Rules/RuleOperatorWrapper.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -74,7 +73,7 @@ const RuleOperatorWrapper = (props) => {
               >
                 <span>
                   <ButtonMain
-                    iconCenter={<ClearIcon style={{ color: props.deleteIconColor }} />}
+                    iconCenter={<ClearIcon />}
                     size="default"
                     theme="lightText"
                     variant="text"
@@ -93,7 +92,6 @@ RuleOperatorWrapper.defaultProps = {
   allowRemove: false,
   operator: 'and',
   operators: ['and', 'or'],
-  deleteIconColor: 'var(--color-gray-37)',
   onSetOperator: null,
 };
 
@@ -101,10 +99,9 @@ RuleOperatorWrapper.propTypes = {
   allowRemove: PropTypes.bool,
   operator: PropTypes.string,
   operators: PropTypes.arrayOf(PropTypes.string),
-  deleteIconColor: PropTypes.string,
-  onSetOperator: PropTypes.func,
   onAdd: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
+  onSetOperator: PropTypes.func,
 };
 
 export default RuleOperatorWrapper;

--- a/src/app/styles/css/inputs.module.css
+++ b/src/app/styles/css/inputs.module.css
@@ -174,6 +174,10 @@
   margin: 0 8px;
 }
 
+.language-picker-wrapper {
+  min-width: 230px;
+}
+
 :global(.MuiFormHelperText-root).mui-helper-error {
   color: var(--color-pink-53);
 }


### PR DESCRIPTION
## Description

This is the last batch of "easily achievable" removed inline styles. the remainder `40 matches across 23 files` take a bit more logic work, but with this PR along with the already merged one its down from over 100 instances.

Also sorted some prop types because alphabetization is FUN!

## How to test?

not much to test, the only visual change is to use an <Alert... component in the content warning dialog to indicate when the user has not selected a category. See screenshot below for what it looks like after:

<img width="330" alt="Screenshot 2025-02-12 at 3 16 13 PM" src="https://github.com/user-attachments/assets/4b535bf3-0069-4223-a6c9-2cb1cd7b45e0" />

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
