### PR TITLE
CV2-5852 display article created by date, add time

### DIFF
--- a/localization/react-intl/src/app/components/article/ArticleForm.json
+++ b/localization/react-intl/src/app/components/article/ArticleForm.json
@@ -40,9 +40,14 @@
     "defaultMessage": "Create & Publish"
   },
   {
+    "id": "articleForm.createdByLabel",
+    "description": "Label to convey when the item was created",
+    "defaultMessage": "Created by:"
+  },
+  {
     "id": "articleForm.editedByLabel",
     "description": "Label to convey when the item was last edited",
-    "defaultMessage": "Edited by:"
+    "defaultMessage": "Last Edited:"
   },
   {
     "id": "articleForm.publishedAtDate",

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -159,10 +159,19 @@ const ArticleForm = ({
             { mode === 'edit' &&
               <div className={styles['article-form-info']}>
                 <div className={styles['article-form-info-labels']}>
+                  { article.created_at &&
+                    <div className="typography-subtitle2">
+                      <FormattedMessage
+                        defaultMessage="Created by:"
+                        description="Label to convey when the item was created"
+                        id="articleForm.createdByLabel"
+                      />
+                    </div>
+                  }
                   { article.updated_at &&
                     <div className="typography-subtitle2">
                       <FormattedMessage
-                        defaultMessage="Edited by:"
+                        defaultMessage="Last Edited:"
                         description="Label to convey when the item was last edited"
                         id="articleForm.editedByLabel"
                       />
@@ -188,9 +197,14 @@ const ArticleForm = ({
                   }
                 </div>
                 <div className={styles['article-form-info-content']}>
+                  { article.created_at &&
+                    <div className="typography-body2">
+                      {article.author.name}, <FormattedDate day="numeric" hour="numeric" minute="numeric" month="long" value={new Date(article.created_at * 1000)} year="numeric" />
+                    </div>
+                  }
                   { article.updated_at &&
                     <div className="typography-body2">
-                      {article.user.name}, <FormattedDate day="numeric" month="long" value={new Date(article.updated_at * 1000)} year="numeric" />
+                      {article.user.name}, <FormattedDate day="numeric" hour="numeric" minute="numeric" month="long" value={new Date(article.updated_at * 1000)} year="numeric" />
                     </div>
                   }
                   { publishedAt && articleType === 'fact-check' &&
@@ -678,7 +692,11 @@ export default createFragmentContainer(ArticleForm, graphql`
       tags
       rating
       report_status
+      author {
+        name
+      }
       updated_at
+      created_at
       user {
         name
       }
@@ -702,7 +720,11 @@ export default createFragmentContainer(ArticleForm, graphql`
       url
       language
       tags
+      author {
+        name
+      }
       updated_at
+      created_at
       user {
         name
       }


### PR DESCRIPTION
## Description

Added Created By value to Article Form.  Uses new `author` field found in both Explainers and Fact Checks.  Updated Edited By to Last Edited.  Add timestamps to both Created by and Last Edited: 

References: CV2-5852

## How to test?

Manually test via opening an explainer and a fact check's edit form.  

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
