### PR TITLE
update integration test: remove the checking for tag counts

### DIFF
--- a/test/spec/tag_spec.rb
+++ b/test/spec/tag_spec.rb
@@ -54,8 +54,6 @@ shared_examples 'tag' do
     wait_for_selector('#confirm-dialog__confirm-action-button').click
     wait_for_selector('.team-tags__row')
     expect(@driver.page_source.include?('tag added automatically')).to be(true)
-    # check that it does not have a item using this tag
-    expect(wait_for_selector('td > a').text == '0').to be(true)
     # create a media
     create_media('new media')
     sleep 30 # wait for the items to be indexed in the Elasticsearch


### PR DESCRIPTION
## Description

Updated integration test to reflect the removal of tag count information from the Team Tag Settings page.

References: CV2-5631

## How to test?

running integration tests

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
