### PR TITLE
CV2-6161 link team to bot preview history

### DIFF
--- a/src/app/components/bot/BotPreview.js
+++ b/src/app/components/bot/BotPreview.js
@@ -223,13 +223,14 @@ const submitMatchingSettings = ({
 
 const BotPreview = ({ me, team }) => {
   let smoochIntegrations = { '-': { displayName: 'No tiplines enabled' } };
+  const storageKey = `${teamSlug}BotPreviewMessageHistory`; // ensure that message history is tied to a specific workspace
 
   if (team.smooch_bot?.smooch_enabled_integrations && Object.keys(team.smooch_bot.smooch_enabled_integrations)[0]) {
     smoochIntegrations = team.smooch_bot.smooch_enabled_integrations;
   }
   const firstPlatform = Object.keys(smoochIntegrations)[0];
 
-  const savedHistory = safelyParseJSON(window.storage.getValue('botPreviewMessageHistory'), []);
+  const savedHistory = safelyParseJSON(window.storage.getValue(storageKey), []);
 
   // FIXME: When the Feature Flag is removed, we probably should just use:
   // const userRole = UserUtil.myRole(window.Check.store.getState().app.context.currentUser, TeamSlug)
@@ -348,7 +349,7 @@ const BotPreview = ({ me, team }) => {
     }
 
     setMessageHistory(newHistory);
-    window.storage.set('botPreviewMessageHistory', JSON.stringify(newHistory));
+    window.storage.set(storageKey, JSON.stringify(newHistory));
   };
 
   const sendQuery = (text) => {
@@ -394,13 +395,13 @@ const BotPreview = ({ me, team }) => {
     ];
 
     setMessageHistory(newHistory);
-    window.storage.set('botPreviewMessageHistory', JSON.stringify(newHistory));
+    window.storage.set(storageKey, JSON.stringify(newHistory));
   };
 
   const resetHistory = () => {
     setDialogOpen(false);
     setMessageHistory([]);
-    window.storage.set('botPreviewMessageHistory', JSON.stringify([]));
+    window.storage.set(storageKey, JSON.stringify([]));
   };
 
   if (!me.is_admin) return null;


### PR DESCRIPTION
## Description

To keep chat history tied to specific workspaces, I added the team slug as a prefix to the botPreviewMessageHistory key.  Now multiple chat histories can be saved based on what workspace the user is in.  

References: CV2-6161

## How to test?

Since this changes the storage key for the chat history, it will be like starting a new chat.  Send a message or two in the chat, check localstorage to confirm there's a <team-slug>BotPreviewMessageHistory key, then switch to a different workspace and do the same thing.  Verify the two chats are different.  

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
