### PR TITLE
Put the Uptime script in the right position.

### DIFF
--- a/src/web/views/index.js
+++ b/src/web/views/index.js
@@ -20,6 +20,7 @@ module.exports = ({ config }) => {
       <!DOCTYPE html>
       <html>
         <head>
+          ${uptimeMonitoring(config)}
           <meta name="robots" content="noindex">
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -37,7 +38,6 @@ module.exports = ({ config }) => {
         </head>
         <body>
           <div id="root"></div>
-          ${uptimeMonitoring(config)}
           ${simpleAnalytics(config)}
         </body>
         <script src="/js/index.bundle${BUNDLE_PREFIX}.js" defer="defer"></script>


### PR DESCRIPTION
## Description

According to the documentation, the Uptime script must be placed in the <head> section, before any other script.

Reference: https://support.uptime.com/hc/en-us/articles/360006595219-Why-am-I-Not-Seeing-My-RUM-Data

Reference: CV2-6017.

## How to test?

When inspecting the HTML source in the browser, you should see the Uptime script in the `<head>` section, not the body (if you have it enabled in the config).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
