### PR TITLE
Changing the Uptime RUM script from inline to external

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,11 @@ function copy_build_web_config_js() {
   return gulp.src('./config.js').pipe(gulp.dest('./build/web/js'));
 }
 
-gulp.task('copy:build:web', gulp.series(copy_build_web_assets, copy_build_web_config_js));
+function copy_build_web_uptime_js() {
+  return gulp.src('./uptime.js').pipe(gulp.dest('./build/web/js'));
+}
+
+gulp.task('copy:build:web', gulp.series(copy_build_web_assets, copy_build_web_config_js, copy_build_web_uptime_js));
 
 gulp.task('transifex:translations', () => gulp.src('./localization/translations/**/*.json').pipe(mergeTransifex(buildConfig)).pipe(gulp.dest('./localization/translations/')));
 

--- a/src/web/views/index.js
+++ b/src/web/views/index.js
@@ -20,6 +20,7 @@ module.exports = ({ config }) => {
       <!DOCTYPE html>
       <html>
         <head>
+          ${uptimeMonitoring(config)}
           <meta name="robots" content="noindex">
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -37,7 +38,6 @@ module.exports = ({ config }) => {
         </head>
         <body>
           <div id="root"></div>
-          ${uptimeMonitoring(config)}
           ${simpleAnalytics(config)}
         </body>
         <script src="/js/index.bundle${BUNDLE_PREFIX}.js" defer="defer"></script>

--- a/src/web/views/index.js
+++ b/src/web/views/index.js
@@ -10,7 +10,7 @@ const simpleAnalytics = config => config.useAnalytics ?
     </noscript>` : '';
 
 const uptimeMonitoring = config => config.uptimeId ?
-  `<script>(function(w,d,s){w._uptime_rum2={};w._uptime_rum2.errors=[];w._uptime_rum2.uuid='${config.uptimeId}';w._uptime_rum2.url='https://rumcollector.uptime.com';s=document.createElement('script');s.async=1;s.src='https://rum.uptime.com/static/rum/compiled/v2/rum.js';d.getElementsByTagName('head')[0].appendChild(s);w.addEventListener('error',function(e){w._uptime_rum2.errors.push({t:new Date(),err:e})});})(window,document);</script>`
+  `<script async src="/js/uptime.js?uptimeId=${config.uptimeId}"></script>`
   : '';
 
 module.exports = ({ config }) => {

--- a/uptime.js
+++ b/uptime.js
@@ -1,0 +1,30 @@
+(function() {
+  function getQueryParam(name) {
+    const urlParams = new URLSearchParams(document.currentScript.src.replace(/^.*\?/, '?'));
+    return urlParams.get(name);
+  }
+
+  const uptimeId = getQueryParam('uptimeId');
+  if (!uptimeId) {
+    console.error('Uptime RUM: Missing uptimeId!');
+    return;
+  }
+
+  console.log(`Running Uptime RUM with ID ${uptimeId}`);
+
+  (function(w, d, s) {
+    w._uptime_rum2 = {};
+    w._uptime_rum2.errors = [];
+    w._uptime_rum2.uuid = uptimeId; // Set dynamically from URL param
+    w._uptime_rum2.url = 'https://rumcollector.uptime.com';
+    
+    s = d.createElement('script');
+    s.async = 1;
+    s.src = 'https://rum.uptime.com/static/rum/compiled/v2/rum.js';
+    d.getElementsByTagName('head')[0].appendChild(s);
+
+    w.addEventListener('error', function(e) {
+      w._uptime_rum2.errors.push({ t: new Date(), err: e });
+    });
+  })(window, document);
+})();


### PR DESCRIPTION
## Description

In order to comply with the Content Security Policy, make the Uptime RUM script an external script, instead of inline.

References: CV2-6017.

## How to test?

The Uptime script should execute.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
