### PR TITLE
Make TabWrapper replace history state rather than push

### DIFF
--- a/src/app/components/cds/menus-lists-dialogs/TabWrapper.js
+++ b/src/app/components/cds/menus-lists-dialogs/TabWrapper.js
@@ -3,7 +3,7 @@ import cx from 'classnames/bind';
 import PropTypes from 'prop-types';
 import Tab from './Tab';
 import Select from '../inputs/Select';
-import { getQueryStringValue, pushQueryStringValue } from '../../../urlHelpers';
+import { getQueryStringValue, replaceQueryStringValue } from '../../../urlHelpers';
 import styles from './TabWrapper.module.css';
 
 const TabWrapper = ({
@@ -90,13 +90,13 @@ const TabWrapper = ({
     if (getQueryStringValue('tab')) {
       onChange(getQueryStringValue('tab'));
     } else {
-      pushQueryStringValue('tab', activeTab);
+      replaceQueryStringValue('tab', activeTab);
     }
   }, []);
 
   const handleClick = (newValue) => {
     setActiveTab(newValue);
-    pushQueryStringValue('tab', newValue);
+    replaceQueryStringValue('tab', newValue);
     onChange(newValue);
   };
 

--- a/src/app/urlHelpers.js
+++ b/src/app/urlHelpers.js
@@ -20,6 +20,12 @@ function pushQueryStringValue(key, value) {
   window.history.pushState({}, '', url);
 }
 
+function replaceQueryStringValue(key, value) {
+  const url = new URL(window.location);
+  url.searchParams.set(key, value);
+  window.history.replaceState({}, '', url);
+}
+
 function deleteQueryStringValue(key) {
   const url = new URL(window.location);
   url.searchParams.delete(key);
@@ -141,6 +147,7 @@ export {
   getPathnameAndSearch,
   getQueryStringValue,
   pushQueryStringValue,
+  replaceQueryStringValue,
   deleteQueryStringValue,
   pageSize,
 }; // eslint-disable-line import/prefer-default-export


### PR DESCRIPTION
## Description

This commit makes TabWrapper replace history state rather than push.

Previously when TabWrapper mounted it would push a new state in the navigation history, making navigating back from an item not work. Clicking once in the "navigate back" arrow would keep the user in the same page (minus the ?tab= query). Another side effect was stacking as many navigation states as view on different tabs, making it harder to navigate back.

References: CV2-5819

## How to test?

- From any list navigate to a media item and click the back arrow to navigate back to the list
- From the dashboard, navigate to a top requested media cluster and navigate back to the dashboard
- Expected: No more than a single click on the back arrow should be necessary to navigate back to the previous page

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
