### PR TITLE
Consolidate list styles in settings area

### DIFF
--- a/localization/react-intl/src/app/components/team/Languages/LanguageListItem.json
+++ b/localization/react-intl/src/app/components/team/Languages/LanguageListItem.json
@@ -6,7 +6,7 @@
   {
     "id": "languageListItem.default",
     "description": "Label to indicate that this language is the default",
-    "defaultMessage": "<strong>{language}</strong> (default)"
+    "defaultMessage": "default"
   },
   {
     "id": "statusListItem.makeDefault",

--- a/localization/react-intl/src/app/components/team/Languages/LanguageListItem.json
+++ b/localization/react-intl/src/app/components/team/Languages/LanguageListItem.json
@@ -6,7 +6,7 @@
   {
     "id": "languageListItem.default",
     "description": "Label to indicate that this language is the default",
-    "defaultMessage": "default"
+    "defaultMessage": "default tipline language"
   },
   {
     "id": "statusListItem.makeDefault",

--- a/localization/react-intl/src/app/components/team/Languages/LanguagesComponent.json
+++ b/localization/react-intl/src/app/components/team/Languages/LanguagesComponent.json
@@ -7,7 +7,7 @@
   {
     "id": "languagesComponent.title",
     "description": "Title of Language settings page",
-    "defaultMessage": "Language"
+    "defaultMessage": "Supported Languages [{languageCount}]"
   },
   {
     "id": "languagesComponent.languageDetection",
@@ -38,10 +38,5 @@
     "id": "languagesComponent.alertTitleDisabled",
     "description": "Title for extra information about the language detection toggle switch when it is disabled",
     "defaultMessage": "Language detection is disabled"
-  },
-  {
-    "id": "languagesComponent.languages",
-    "description": "Title of the active languages list section in language settings page",
-    "defaultMessage": "Supported Languages [{languageCount}]"
   }
 ]

--- a/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
+++ b/localization/react-intl/src/app/components/team/Statuses/StatusListItem.json
@@ -7,7 +7,7 @@
   {
     "id": "statusListItem.default",
     "description": "The label of the user created status, with an additional note in parenthesis if the label is the default",
-    "defaultMessage": "{statusLabel}"
+    "defaultMessage": "(default)"
   },
   {
     "id": "statusListItem.makeDefault",

--- a/localization/react-intl/src/app/components/team/TeamTags/TeamTagsComponent.json
+++ b/localization/react-intl/src/app/components/team/TeamTags/TeamTagsComponent.json
@@ -35,13 +35,8 @@
     "defaultMessage": "No Workspace Tags"
   },
   {
-    "id": "teamTagsComponent.tableHeaderName",
-    "description": "Column header in tags table.",
-    "defaultMessage": "Name"
-  },
-  {
-    "id": "teamTagsComponent.tableHeaderUpdatedAt",
-    "description": "Column header in tags table.",
-    "defaultMessage": "Updated"
+    "id": "teamTagsComponent.lastUpdated",
+    "description": "The date the last time this tag was updated",
+    "defaultMessage": "Last Updated: {count}"
   }
 ]

--- a/src/app/components/search/AnnotationFilterDate.js
+++ b/src/app/components/search/AnnotationFilterDate.js
@@ -127,6 +127,7 @@ class AnnotationFilterDate extends React.Component {
             </>
           )}
           cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
+          className="fresh"
           maxDate={this.endDateStringOrNull || undefined}
           okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
           value={this.startDateStringOrNull}

--- a/src/app/components/search/DateRangeFilter.js
+++ b/src/app/components/search/DateRangeFilter.js
@@ -166,6 +166,7 @@ function DateRangeSelectorStartEnd(props) {
           </>
         )}
         cancelLabel={<FormattedMessage defaultMessage="Cancel" description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation" id="global.cancel" />}
+        className="fresh"
         maxDate={getEndDateStringOrNull() || undefined}
         okLabel={<FormattedMessage defaultMessage="OK" description="Generic label for a button or link for a user to press when they wish to confirm an action" id="global.ok" />}
         value={getStartDateStringOrNull()}

--- a/src/app/components/team/Languages/LanguageListItem.js
+++ b/src/app/components/team/Languages/LanguageListItem.js
@@ -198,7 +198,7 @@ const LanguageListItem = ({
             <>
               <br />
               <FormattedMessage
-                defaultMessage="default"
+                defaultMessage="default tipline language"
                 description="Label to indicate that this language is the default"
                 id="languageListItem.default"
                 tagName="small"

--- a/src/app/components/team/Languages/LanguageListItem.js
+++ b/src/app/components/team/Languages/LanguageListItem.js
@@ -1,7 +1,6 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { FormattedHTMLMessage, FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { commitMutation, createFragmentContainer, graphql } from 'react-relay/compat';
 import { Store } from 'react-relay/classic';
 import Menu from '@material-ui/core/Menu';
@@ -194,14 +193,17 @@ const LanguageListItem = ({
         }
       >
         <div>
-          { isDefault ? (
-            <FormattedHTMLMessage
-              defaultMessage="<strong>{language}</strong> (default)"
-              description="Label to indicate that this language is the default"
-              id="languageListItem.default"
-              values={{ language: languageLabelFull(code) }}
-            />
-          ) : <strong>{ languageLabelFull(code) }</strong>
+          <strong>{ languageLabelFull(code) }</strong>
+          { isDefault &&
+            <>
+              <br />
+              <FormattedMessage
+                defaultMessage="default"
+                description="Label to indicate that this language is the default"
+                id="languageListItem.default"
+                tagName="small"
+              />
+            </>
           }
         </div>
         <div className={settingsStyles['setting-content-list-actions']}>
@@ -354,6 +356,8 @@ const LanguageListItem = ({
 };
 
 LanguageListItem.propTypes = {
+  code: PropTypes.string.isRequired,
+  setLanguages: PropTypes.func.isRequired,
   team: PropTypes.shape({
     id: PropTypes.string.isRequired,
     get_language: PropTypes.string.isRequired,
@@ -366,8 +370,6 @@ LanguageListItem.propTypes = {
       )).isRequired,
     }).isRequired,
   }).isRequired,
-  code: PropTypes.string.isRequired,
-  setLanguages: PropTypes.func.isRequired,
 };
 
 export default createFragmentContainer(injectIntl(LanguageListItem), graphql`

--- a/src/app/components/team/Languages/LanguagesComponent.js
+++ b/src/app/components/team/Languages/LanguagesComponent.js
@@ -85,9 +85,10 @@ const LanguagesComponent = ({ team }) => {
         }
         title={
           <FormattedMessage
-            defaultMessage="Language"
+            defaultMessage="Supported Languages [{languageCount}]"
             description="Title of Language settings page"
             id="languagesComponent.title"
+            values={{ languageCount: languages.length }}
           />
         }
       />
@@ -150,14 +151,6 @@ const LanguagesComponent = ({ team }) => {
           />
         </div>
         <div className={settingsStyles['setting-content-container']}>
-          <div className={settingsStyles['setting-content-container-title']}>
-            <FormattedMessage
-              defaultMessage="Supported Languages [{languageCount}]"
-              description="Title of the active languages list section in language settings page"
-              id="languagesComponent.languages"
-              values={{ languageCount: languages.length }}
-            />
-          </div>
           <ul className={settingsStyles['setting-content-list']}>
             {languages.map(l => (
               <LanguageListItem

--- a/src/app/components/team/Settings.module.css
+++ b/src/app/components/team/Settings.module.css
@@ -101,6 +101,7 @@
         background-color: var(--color-white-100);
         border-radius: var(--border-radius-default);
         padding: 16px;
+        position: relative;
 
         .setting-content-container-title {
           align-items: center;
@@ -319,15 +320,6 @@
 
             &.team-avatar {
               flex: 0 0 auto;
-            }
-
-            p {
-              color: var(--color-gray-37);
-              margin: 3px 0 0 26px;
-
-              &.member-count {
-                margin: 3px 0 0;
-              }
             }
 
             &.setting-content-list-actions {

--- a/src/app/components/team/Statuses/StatusListItem.js
+++ b/src/app/components/team/Statuses/StatusListItem.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -57,29 +56,18 @@ const StatusListItem = ({
   return (
     <li>
       <div>
-        {isDefault ? (
-          <FormattedMessage
-            defaultMessage="{statusLabel}"
-            description="The label of the user created status, with an additional note in parenthesis if the label is the default"
-            id="statusListItem.default"
-            values={{
-              statusLabel: (
-                <StatusLabel color={status.style.color}>
-                  {statusLabel}
-                  <small>
-                    (default)
-                  </small>
-                </StatusLabel>
-              ),
-            }}
-          />
-        ) : (
-          <StatusLabel color={status.style.color}>
-            {statusLabel}
-          </StatusLabel>
-        )
-        }
-        <p>{statusDescription}</p>
+        <StatusLabel color={status.style.color}>
+          {statusLabel}
+          {isDefault &&
+            <FormattedMessage
+              defaultMessage="(default)"
+              description="The label of the user created status, with an additional note in parenthesis if the label is the default"
+              id="statusListItem.default"
+              tagName="small"
+            />
+          }
+        </StatusLabel>
+        <small>{statusDescription}</small>
         <StatusMessage message={statusMessage} />
       </div>
       <div className={settingsStyles['setting-content-list-actions']}>
@@ -107,14 +95,14 @@ const StatusListItem = ({
 StatusListItem.propTypes = {
   defaultLanguage: PropTypes.string.isRequired,
   isDefault: PropTypes.bool,
-  onDelete: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired,
-  onMakeDefault: PropTypes.func.isRequired,
   preventDelete: PropTypes.bool,
   status: PropTypes.shape({
     id: PropTypes.string.isRequired,
     locales: PropTypes.object.isRequired,
   }).isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onMakeDefault: PropTypes.func.isRequired,
 };
 
 StatusListItem.defaultProps = {

--- a/src/app/components/team/Statuses/TranslateStatuses.js
+++ b/src/app/components/team/Statuses/TranslateStatuses.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -217,12 +216,12 @@ const TranslateStatuses = ({
 };
 
 TranslateStatuses.propTypes = {
+  currentLanguage: PropTypes.string.isRequired,
+  defaultLanguage: PropTypes.string.isRequired,
   statuses: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
   }).isRequired).isRequired,
-  defaultLanguage: PropTypes.string.isRequired,
-  currentLanguage: PropTypes.string.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };
 

--- a/src/app/components/team/TeamTags/TeamTagsComponent.js
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.js
@@ -1,13 +1,7 @@
-/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames/bind';
 import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 import SaveTag from './SaveTag';
 import TeamTagsActions from './TeamTagsActions';
 import BlankState from '../../layout/BlankState';
@@ -168,53 +162,44 @@ const TeamTagsComponent = ({
           </BlankState>
           :
           <div className={settingsStyles['setting-content-container']}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell className={styles['table-col-head-name']}>
-                    <FormattedMessage
-                      defaultMessage="Name"
-                      description="Column header in tags table."
-                      id="teamTagsComponent.tableHeaderName"
-                    />
-                  </TableCell>
-                  <TableCell className={styles['table-col-head-updated']}>
-                    <FormattedMessage
-                      defaultMessage="Updated"
-                      description="Column header in tags table."
-                      id="teamTagsComponent.tableHeaderUpdatedAt"
-                    />
-                  </TableCell>
-                  <TableCell className={styles['table-col-head-action']} padding="checkbox" />
-                </TableRow>
-              </TableHead>
-              { isPaginationLoading && <Loader size="medium" theme="grey" variant="inline" /> }
-              <TableBody className={isPaginationLoading && styles['tags-hide']}>
-                { tags.slice(cursor, cursor + pageSize).map(tag => (
-                  <TableRow className="team-tags__row" key={tag.id}>
-                    <TableCell>
-                      {tag.text}
-                    </TableCell>
-                    <TableCell>
-                      <TimeBefore date={tag.updated_at} />
-                    </TableCell>
-                    <TableCell>
-                      <Can permission="create TagText" permissions={permissions}>
-                        <TeamTagsActions
-                          pageSize={pageSize}
-                          relay={relay}
-                          rules={rules}
-                          rulesSchema={rulesSchema}
-                          tag={tag}
-                          teamDbid={teamDbid}
-                          teamId={teamId}
-                        />
-                      </Can>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            { isPaginationLoading &&
+              <div className={styles['tags-loader']}>
+                <Loader size="small" theme="grey" variant="inline" />
+              </div>
+            }
+            <ul className={settingsStyles['setting-content-list']}>
+              { tags.slice(cursor, cursor + pageSize).map(tag => (
+                <li className="team-tags__row" key={tag.id}>
+                  <div>
+                    <strong>{tag.text}</strong>
+                    <br />
+                    <Tooltip
+                      arrow
+                      title={
+                        <FormattedMessage defaultMessage="Last Updated: {count}" description="The date the last time this tag was updated" id="teamTagsComponent.lastUpdated" values={{ count: tag.updated_at }} />
+                      }
+                    >
+                      <small>
+                        <TimeBefore date={tag.updated_at} />
+                      </small>
+                    </Tooltip>
+                  </div>
+                  <Can permission="create TagText" permissions={permissions}>
+                    <div className={settingsStyles['setting-content-list-actions']}>
+                      <TeamTagsActions
+                        pageSize={pageSize}
+                        relay={relay}
+                        rules={rules}
+                        rulesSchema={rulesSchema}
+                        tag={tag}
+                        teamDbid={teamDbid}
+                        teamId={teamId}
+                      />
+                    </div>
+                  </Can>
+                </li>
+              ))}
+            </ul>
           </div>
         }
       </div>
@@ -238,17 +223,17 @@ TeamTagsComponent.defaultProps = {
 };
 
 TeamTagsComponent.propTypes = {
-  teamId: PropTypes.string.isRequired,
-  teamDbid: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
   permissions: PropTypes.string.isRequired,
-  rulesSchema: PropTypes.object.isRequired,
   rules: PropTypes.arrayOf(PropTypes.object),
+  rulesSchema: PropTypes.object.isRequired,
   tags: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
     updated_at: PropTypes.object.isRequired, // Date object
   }).isRequired).isRequired,
-  pageSize: PropTypes.number.isRequired,
+  teamDbid: PropTypes.number.isRequired,
+  teamId: PropTypes.string.isRequired,
 };
 
 export default TeamTagsComponent;

--- a/src/app/components/team/TeamTags/TeamTagsComponent.module.css
+++ b/src/app/components/team/TeamTags/TeamTagsComponent.module.css
@@ -2,27 +2,17 @@
   align-items: center;
   display: flex;
   flex-direction: row;
+  position: relative;
   text-align: center;
   user-select: none;
   width: 100%;
 }
 
-.tags-hide {
-  visibility: hidden;
-}
-
-.table-col-head-name {
-  width: 50%;
-}
-
-.table-col-head-updated {
-  width: 25%;
-}
-
-.table-col-head-items {
-  width: 15%;
-}
-
-.table-col-head-action {
-  width: 10%;
+.tags-loader {
+  background-color: var(--overlayWhite);
+  height: 100%;
+  left: 0;
+  position: absolute;
+  right: 0;
+  z-index: var(--z-index-1);
 }

--- a/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
+++ b/src/app/components/user/UserWorkspaces/PaginatedUserWorkspaces.js
@@ -162,14 +162,14 @@ const UserWorkspacesComponent = ({
                   </div>
                   <div>
                     <strong>{team.name}</strong>
-                    <p className={styles['member-count']}>
-                      <FormattedMessage
-                        defaultMessage="{membersCount, plural, one {# member} other {# members}}"
-                        description="Count of members of a workspace"
-                        id="switchTeams.member"
-                        values={{ membersCount: team.members_count }}
-                      />
-                    </p>
+                    <br />
+                    <FormattedMessage
+                      defaultMessage="{membersCount, plural, one {# member} other {# members}}"
+                      description="Count of members of a workspace"
+                      id="switchTeams.member"
+                      tagName="small"
+                      values={{ membersCount: team.members_count }}
+                    />
                   </div>
                   <div className={styles['setting-content-list-actions']}>
                     <ButtonMain


### PR DESCRIPTION
## Description

Just updating some list styles to better match between areas of settings and converting one table into a list since it does not sort.
Also remove some eslint disables

## How to test?

Just visual changes in the settings area, things should look more consistent, but it would be hopefully hard for most people to notice differences.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
