### PR TITLE
Update Tipline Message Volume Tooltip with incoming and outgoing numbers

### DIFF
--- a/localization/react-intl/src/app/components/dashboard/TimelineTiplineMessageVolume.json
+++ b/localization/react-intl/src/app/components/dashboard/TimelineTiplineMessageVolume.json
@@ -5,8 +5,13 @@
     "defaultMessage": "Tipline Message Volume"
   },
   {
-    "id": "timelineTiplineMessageVolume.tooltip",
+    "id": "timelineTiplineMessageVolume.tooltipIncoming",
     "description": "Tooltip for the tipline message volume widget",
-    "defaultMessage": "• {messageCount} Messages"
+    "defaultMessage": "• {messageCount} Incoming Messages"
+  },
+  {
+    "id": "timelineTiplineMessageVolume.tooltipOutgoing",
+    "description": "Tooltip for the tipline message volume widget",
+    "defaultMessage": "• {messageCount} Outgoing Messages"
   }
 ]

--- a/src/app/components/dashboard/TimelineTiplineMessageVolume.js
+++ b/src/app/components/dashboard/TimelineTiplineMessageVolume.js
@@ -10,6 +10,8 @@ const TimelineTiplineMessageVolume = ({ statistics }) => (
       Object.entries(statistics.number_of_messages_by_date).map(([date, value]) => ({
         date: `${date}T23:59:59.000Z`,
         value,
+        incomingValue: statistics.number_of_incoming_messages_by_date[date],
+        outgoingValue: statistics.number_of_outgoing_messages_by_date[date],
       }))
     }
     title={
@@ -19,13 +21,25 @@ const TimelineTiplineMessageVolume = ({ statistics }) => (
         id="timelineTiplineMessageVolume.title"
       />
     }
-    tooltipFormatter={value => [(
-      <FormattedMessage
-        defaultMessage="• {messageCount} Messages"
-        description="Tooltip for the tipline message volume widget"
-        id="timelineTiplineMessageVolume.tooltip"
-        values={{ messageCount: value }}
-      />
+    tooltipFormatter={(value, name, props) => [(
+      <>
+        <div>
+          <FormattedMessage
+            defaultMessage="• {messageCount} Incoming Messages"
+            description="Tooltip for the tipline message volume widget"
+            id="timelineTiplineMessageVolume.tooltipIncoming"
+            values={{ messageCount: props.payload.incomingValue }}
+          />
+        </div>
+        <div>
+          <FormattedMessage
+            defaultMessage="• {messageCount} Outgoing Messages"
+            description="Tooltip for the tipline message volume widget"
+            id="timelineTiplineMessageVolume.tooltipOutgoing"
+            values={{ messageCount: props.payload.outgoingValue }}
+          />
+        </div>
+      </>
     )]}
   />
 );
@@ -39,5 +53,7 @@ TimelineTiplineMessageVolume.propTypes = {
 export default createFragmentContainer(TimelineTiplineMessageVolume, graphql`
   fragment TimelineTiplineMessageVolume_statistics on TeamStatistics {
     number_of_messages_by_date
+    number_of_incoming_messages_by_date
+    number_of_outgoing_messages_by_date
   }
 `);

--- a/src/app/components/dashboard/TiplineDashboard.js
+++ b/src/app/components/dashboard/TiplineDashboard.js
@@ -109,7 +109,7 @@ TiplineDashboard.propTypes = {
   period: PropTypes.string.isRequired,
   platform: PropTypes.string,
   team: PropTypes.shape({
-    data_report: PropTypes.object,
+    data_report: PropTypes.array,
     get_language: PropTypes.string.isRequired,
     get_languages: PropTypes.string.isRequired,
     slug: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description

Get number of incoming and outgoing messages by date from the backend and display in the tipline message volume line chart tooltip

References: CV2-5849

## How to test?

Go to the Tipline Dashboard and hover over the Tipline Message Volume line chart. The tooltips should now display numbers for Incoming and Outgoing messages.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
