### PR TITLE
Sort Claim & Fact-Checks descending

### DIFF
--- a/src/app/components/dashboard/VerticalBarFactChecksByRating.js
+++ b/src/app/components/dashboard/VerticalBarFactChecksByRating.js
@@ -19,7 +19,7 @@ const VerticalBarFactChecksByRating = ({ language, statistics, team }) => (
             name: getStatus(team.verification_statuses, name, language).label || name,
             value,
             color: getStatusStyle(getStatus(team.verification_statuses, name), 'color'),
-          }))
+          })).sort((a, b) => b.value - a.value) // Sort in descending order
         }
         title={title}
       />


### PR DESCRIPTION
## Description

Sort Claim & Fact-Checks by rating in descending order in the Articles Dashboard.

References: CV2-5662

## How to test?

Go to the Articles Dashboard and verify that the Claim & Fact-Checks vertical bar bar chart are sorted from highest count to lowest.Please describe how to test the changes (manually and/or automatically).

![image](https://github.com/user-attachments/assets/25960557-5b84-4bb1-a45d-0c86825ce65f)

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
