### PR TITLE
Alert component adjustments

### DIFF
--- a/src/app/components/BrowserSupport.js
+++ b/src/app/components/BrowserSupport.js
@@ -30,8 +30,8 @@ class BrowserSupport extends Component {
     if (BrowserSupport.shouldShowMessage()) {
       return (
         <Alert
-          banner
           icon
+          placement="banner"
           title={<FormattedMessage defaultMessage="{appName} is optimized for Google Chrome on desktop." description="Banner message encouraging users to use the Google Chrome browser, as their current browser is not supported" id="browserSupport.message" values={{ appName: mapGlobalMessage(this.props.intl, 'appNameHuman') }} />}
           variant="warning"
           onClose={this.close.bind(this)}

--- a/src/app/components/ChangePasswordComponent.js
+++ b/src/app/components/ChangePasswordComponent.js
@@ -107,7 +107,7 @@ function ChangePasswordComponent({
 
   return (
     <div className={cx('int-user-password-change__password-input', inputStyles['form-fieldset'])}>
-      { errorMsg && <><Alert border contained title={errorMsg} variant="error" /><br /></> }
+      { errorMsg && <><Alert border placement="contained" title={errorMsg} variant="error" /><br /></> }
       {showCurrentPassword === true ? (
         <TextField
           className={cx('int-user-password-change__password-input-field', inputStyles['form-fieldset-field'])}

--- a/src/app/components/ChangePasswordComponent.js
+++ b/src/app/components/ChangePasswordComponent.js
@@ -107,7 +107,7 @@ function ChangePasswordComponent({
 
   return (
     <div className={cx('int-user-password-change__password-input', inputStyles['form-fieldset'])}>
-      { errorMsg && <><Alert contained title={errorMsg} variant="error" /><br /></> }
+      { errorMsg && <><Alert border contained title={errorMsg} variant="error" /><br /></> }
       {showCurrentPassword === true ? (
         <TextField
           className={cx('int-user-password-change__password-input-field', inputStyles['form-fieldset-field'])}

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -55,6 +55,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
           content: key => (
             <div className="int-flash-message__toast" key={key}>
               <Alert
+                border
                 className={cx(
                   {
                     [styles['persist-alert-flash-message']]: persist,
@@ -78,6 +79,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
           content: key => (
             <div className="int-flash-message__toast" key={key}>
               <Alert
+                border
                 className={cx(
                   {
                     [styles['persist-alert-flash-message']]: persist,
@@ -102,6 +104,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
         content: key => (
           <div className="int-flash-message__toast" key={key}>
             <Alert
+              border
               className={cx(
                 {
                   [styles['persist-alert-flash-message']]: persist,

--- a/src/app/components/FlashMessage.js
+++ b/src/app/components/FlashMessage.js
@@ -62,7 +62,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
                   })
                 }
                 content={msg}
-                floating
+                placement="floating"
                 variant={variant}
                 onClose={() => { closeSnackbar(key); }}
               />
@@ -86,7 +86,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
                   })
                 }
                 content={<>{createFriendlyErrorMessage(msg)}</>}
-                floating
+                placement="floating"
                 title={<>{createFriendlyErrorMessageTitle(msg)}</>}
                 variant={variant}
                 onClose={() => { closeSnackbar(key); }}
@@ -111,7 +111,7 @@ const FlashMessageProviderWithSnackBar = withSnackbar(({ children, enqueueSnackb
                 })
               }
               content={message}
-              floating
+              placement="floating"
               variant={variant}
               onClose={() => { closeSnackbar(key); }}
             />
@@ -191,9 +191,9 @@ const FlashMessage = withSnackbar(withClientSessionId(({ clientSessionId, enqueu
   if (message) {
     return (
       <Alert
-        banner
         className={cx('home__message', styles['alert-flash-home-message'])}
         content={message}
+        placement="banner"
         variant="info"
         onClose={resetMessage}
       />

--- a/src/app/components/article/ArticleCard.module.css
+++ b/src/app/components/article/ArticleCard.module.css
@@ -3,7 +3,6 @@
   min-width: 500px;
 
   .mediaArticleCardAlert {
-    border-width: 0;
     margin: 0 0 8px;
   }
 

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -386,9 +386,9 @@ const ArticleForm = ({
                     border
                     buttonLabel={<FormattedMessage defaultMessage="Update Report" description="Label of alert button in article form." id="articleForm.reportPublishedLabel" />}
                     className={styles['article-form-alert']}
-                    contained
                     content={<FormattedMessage defaultMessage="To make edits, pause this report. This will stop the report from being sent out to users until it is published again" description="Text of alert box in article form." id="articleForm.reportPublishedBody" />}
                     icon
+                    placement="contained"
                     title={<FormattedMessage defaultMessage="Report is published" description="Title of alert box in article form." id="articleForm.reportPublishedTitle" />}
                     variant="success"
                     onButtonClick={() => handleGoToReport(article.claim_description?.project_media?.dbid)}

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -383,6 +383,7 @@ const ArticleForm = ({
                 }
                 { articleType === 'fact-check' && isPublished && (
                   <Alert
+                    border
                     buttonLabel={<FormattedMessage defaultMessage="Update Report" description="Label of alert button in article form." id="articleForm.reportPublishedLabel" />}
                     className={styles['article-form-alert']}
                     contained

--- a/src/app/components/article/MediaArticleCard.js
+++ b/src/app/components/article/MediaArticleCard.js
@@ -38,9 +38,7 @@ const MediaArticleCard = ({
     <Card className={styles.mediaArticleCard}>
       { variant === 'fact-check' && !publishedAt ?
         <Alert
-          border
           className={styles.mediaArticleCardAlert}
-          contained
           content={
             <FormattedMessage
               defaultMessage="This Fact-Check will not be returned to Tipline users until it is published"
@@ -48,6 +46,7 @@ const MediaArticleCard = ({
               id="mediaArticleCard.unpublishedAlertContent"
             />
           }
+          placement="contained"
           variant="warning"
         />
         : null

--- a/src/app/components/article/MediaArticleCard.js
+++ b/src/app/components/article/MediaArticleCard.js
@@ -38,6 +38,7 @@ const MediaArticleCard = ({
     <Card className={styles.mediaArticleCard}>
       { variant === 'fact-check' && !publishedAt ?
         <Alert
+          border
           className={styles.mediaArticleCardAlert}
           contained
           content={

--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -60,7 +60,6 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
       { (hasFactCheck && hasExplainer) ?
         <Alert
           border
-          contained
           content={
             <FormattedMessage
               defaultMessage="When a claim & fact-check article is added, it will be prioritized as the only article to be delivered as a response to requests that match this item."
@@ -68,6 +67,7 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
               id="mediaArticlesDisplay.readOnlyAlertContent"
             />
           }
+          placement="contained"
           title={
             <FormattedMessage
               defaultMessage="Claim & Fact-Check Added"

--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -59,6 +59,7 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
       }
       { (hasFactCheck && hasExplainer) ?
         <Alert
+          border
           contained
           content={
             <FormattedMessage

--- a/src/app/components/bot/BotPreview.js
+++ b/src/app/components/bot/BotPreview.js
@@ -410,7 +410,6 @@ const BotPreview = ({ me, team }) => {
     <>
       { settingsHaveChanged && (
         <Alert
-          banner
           buttonLabel={
             <FormattedMessage
               defaultMessage="Apply Changes to Live Bot"
@@ -434,6 +433,7 @@ const BotPreview = ({ me, team }) => {
               onClick={() => setConfirmBeforeReset(true)}
             />
           }
+          placement="banner"
           title={
             <FormattedMessage
               defaultMessage="Changes Made to Bot Settings"

--- a/src/app/components/bot/LinkManagement.js
+++ b/src/app/components/bot/LinkManagement.js
@@ -97,6 +97,7 @@ const LinkManagement = ({
               )}
             </FormattedMessage>
             <Alert
+              border
               className={inputStyles['form-fieldset-field']}
               contained
               content={

--- a/src/app/components/bot/LinkManagement.js
+++ b/src/app/components/bot/LinkManagement.js
@@ -99,7 +99,6 @@ const LinkManagement = ({
             <Alert
               border
               className={inputStyles['form-fieldset-field']}
-              contained
               content={
                 <FormattedHTMLMessage
                   defaultMessage="<strong>Before:</strong> https://www.example.com/your-link<br /><strong>After:</strong> https://chck.media/x1y2z3w4/{code}"
@@ -108,6 +107,7 @@ const LinkManagement = ({
                   values={{ code: utmCode ? `?utm_source=${utmCode}` : '' }}
                 />
               }
+              placement="contained"
               title={<FormattedMessage defaultMessage="All links sent via Check will be rewritten." description="Text displayed in the title of a warning box on team details page when link shortening is on" id="teamDetails.warnTitle" />}
               variant="warning"
             />

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -1859,13 +1859,11 @@ const SandboxComponent = ({ admin }) => {
             </div>
             <div className={styles.componentInlineVariants}>
               <Alert
-                banner={alertPlacement === 'banner'}
                 border={alertBorder}
                 buttonLabel={alertButton && <span>alert action</span>}
-                contained={alertPlacement === 'contained'}
                 content={alertContent && <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</span>}
-                floating={alertPlacement === 'floating'}
                 icon={alertIcon}
+                placement={alertPlacement}
                 title={alertTitle && <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>}
                 variant={alertVariant}
                 onClose={alertClosable ? () => {} : null}

--- a/src/app/components/cds/Sandbox.js
+++ b/src/app/components/cds/Sandbox.js
@@ -168,6 +168,7 @@ const SandboxComponent = ({ admin }) => {
   const [alertTitle, setAlertTitle] = React.useState(Boolean(true));
   const [alertContent, setAlertContent] = React.useState(Boolean(true));
   const [alertClosable, setAlertClosable] = React.useState(Boolean(true));
+  const [alertBorder, setAlertBorder] = React.useState(Boolean(false));
   const [toastLink, setToastLink] = React.useState(Boolean(false));
   const [toastBreaks, setToastBreaks] = React.useState(Boolean(false));
 
@@ -1846,11 +1847,20 @@ const SandboxComponent = ({ admin }) => {
                     onChange={() => setAlertClosable(!alertClosable)}
                   />
                 </li>
+                <li>
+                  <SwitchComponent
+                    checked={alertBorder}
+                    label="Border"
+                    labelPlacement="top"
+                    onChange={() => setAlertBorder(!alertBorder)}
+                  />
+                </li>
               </ul>
             </div>
             <div className={styles.componentInlineVariants}>
               <Alert
                 banner={alertPlacement === 'banner'}
+                border={alertBorder}
                 buttonLabel={alertButton && <span>alert action</span>}
                 contained={alertPlacement === 'contained'}
                 content={alertContent && <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</span>}

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -22,18 +22,16 @@ const buttonThemes = {
 const buttonTheme = alertVariant => buttonThemes[alertVariant] || 'info';
 
 const Alert = ({
-  banner,
   border,
   buttonLabel,
   className,
-  contained,
   content,
   customIcon,
   extraActions,
-  floating,
   icon,
   onButtonClick,
   onClose,
+  placement,
   title,
   variant,
 }) => (
@@ -46,9 +44,10 @@ const Alert = ({
         [styles.success]: variant === 'success',
         [styles.warning]: variant === 'warning',
         [styles.error]: variant === 'error',
-        [styles.floating]: floating,
-        [styles.banner]: banner,
-        [styles.contained]: contained,
+        [styles.default]: placement === 'default',
+        [styles.floating]: placement === 'floating',
+        [styles.banner]: placement === 'banner',
+        [styles.contained]: placement === 'contained',
         [styles.border]: border,
       })
     }
@@ -115,23 +114,19 @@ Alert.defaultProps = {
   extraActions: null,
   onButtonClick: null,
   onClose: null,
-  floating: false,
-  banner: false,
-  contained: false,
+  placement: 'default',
   icon: true,
 };
 
 Alert.propTypes = {
-  banner: PropTypes.bool,
   border: PropTypes.bool,
   buttonLabel: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.string,
-  contained: PropTypes.bool,
   content: PropTypes.node,
   customIcon: PropTypes.node,
   extraActions: PropTypes.node,
-  floating: PropTypes.bool,
   icon: PropTypes.bool,
+  placement: PropTypes.oneOf(['default', 'banner', 'contained', 'floating']),
   title: PropTypes.node,
   variant: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
   onButtonClick: PropTypes.func,

--- a/src/app/components/cds/alerts-and-prompts/Alert.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.js
@@ -23,6 +23,7 @@ const buttonTheme = alertVariant => buttonThemes[alertVariant] || 'info';
 
 const Alert = ({
   banner,
+  border,
   buttonLabel,
   className,
   contained,
@@ -48,6 +49,7 @@ const Alert = ({
         [styles.floating]: floating,
         [styles.banner]: banner,
         [styles.contained]: contained,
+        [styles.border]: border,
       })
     }
   >
@@ -107,6 +109,7 @@ Alert.defaultProps = {
   variant: 'info',
   content: null,
   title: null,
+  border: false,
   buttonLabel: null,
   customIcon: null,
   extraActions: null,
@@ -120,6 +123,7 @@ Alert.defaultProps = {
 
 Alert.propTypes = {
   banner: PropTypes.bool,
+  border: PropTypes.bool,
   buttonLabel: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.string,
   contained: PropTypes.bool,

--- a/src/app/components/cds/alerts-and-prompts/Alert.module.css
+++ b/src/app/components/cds/alerts-and-prompts/Alert.module.css
@@ -51,8 +51,11 @@
     }
   }
 
+  &.border {
+    border: solid 2px;
+  }
+
   &.floating {
-    border: solid 2px var(--color-blue-38);
     box-shadow: 0 3px 14px 2px rgba(0 0 0 / .12), 0 8px 10px 1px rgba(0 0 0 / .14), 0 5px 5px -3px rgba(0 0 0 / .2);
     max-width: 320px;
   }
@@ -62,7 +65,6 @@
   }
 
   &.contained {
-    border: solid 2px var(--color-blue-38);
     border-radius: var(--border-radius-medium);
     padding: 12px;
 
@@ -85,7 +87,7 @@
 
   &.success {
     background-color: var(--color-green-97);
-    border-color: var(--color-green-23);
+    border-color: var(--color-green-35);
     color: var(--color-green-23);
   }
 
@@ -97,13 +99,13 @@
 
   &.info {
     background-color: var(--color-blue-98);
-    border-color: var(--color-blue-38);
+    border-color: var(--color-blue-54);
     color: var(--color-blue-38);
   }
 
   &.error {
     background-color: var(--color-pink-96);
-    border-color: var(--color-pink-40);
+    border-color: var(--color-pink-53);
     color: var(--color-pink-40);
   }
 

--- a/src/app/components/cds/alerts-and-prompts/Alert.test.js
+++ b/src/app/components/cds/alerts-and-prompts/Alert.test.js
@@ -7,7 +7,7 @@ describe('<Alert />', () => {
     const wrapper = shallow(<Alert
       content={<span>Bar</span>}
       title={<span>Foo</span>}
-      type="success"
+      variant="success"
     />);
     expect(wrapper.html()).toMatch('Foo');
     const content = wrapper.find('.test__alert-content');

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -51,6 +51,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
         </div>
         {alreadyAccepted && (
           <Alert
+            border
             className={cx(styles['no-admin-alert'])}
             contained
             title={<FormattedMessage defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." id="feedInvitation.alreadyAccepted" />}
@@ -59,6 +60,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
         )}
         {noAdminWorkspaces && (
           <Alert
+            border
             className={cx(styles['no-admin-alert'])}
             contained
             title={<FormattedMessage defaultMessage="You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page." id="feedInvitation.noWorkspaces" />}

--- a/src/app/components/feed/FeedInvitation.js
+++ b/src/app/components/feed/FeedInvitation.js
@@ -53,7 +53,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
           <Alert
             border
             className={cx(styles['no-admin-alert'])}
-            contained
+            placement="contained"
             title={<FormattedMessage defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." id="feedInvitation.alreadyAccepted" />}
             variant="info"
           />
@@ -62,7 +62,7 @@ const FeedInvitationComponent = ({ routeParams, ...props }) => {
           <Alert
             border
             className={cx(styles['no-admin-alert'])}
-            contained
+            placement="contained"
             title={<FormattedMessage defaultMessage="You are not an admin of any workspaces. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not a workspace administrator and as such cannot perform any actions on this page." id="feedInvitation.noWorkspaces" />}
             variant="error"
           />

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -150,7 +150,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
             <Alert
               border
               className={cx(styles['no-admin-alert'])}
-              contained
+              placement="contained"
               title={<FormattedMessage defaultMessage="You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page." id="feedInvitation.notAdmin" />}
               variant="error"
             />
@@ -159,7 +159,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
             <Alert
               border
               className={cx(styles['no-admin-alert'])}
-              contained
+              placement="contained"
               title={<FormattedMessage defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." id="feedInvitation.alreadyAccepted" />}
               variant="info"
             />

--- a/src/app/components/feed/FeedInvitationRespond.js
+++ b/src/app/components/feed/FeedInvitationRespond.js
@@ -148,6 +148,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
           </div>
           { notAdmin && (
             <Alert
+              border
               className={cx(styles['no-admin-alert'])}
               contained
               title={<FormattedMessage defaultMessage="You are not the admin of this workspace. Please contact your workspace administrator if you think this is in error." description="An error message that informs the user that they are not the administrator of this workspace and as such cannot perform any actions on this page." id="feedInvitation.notAdmin" />}
@@ -156,6 +157,7 @@ const FeedInvitationRespondComponent = ({ routeParams, ...props }) => {
           )}
           {alreadyAccepted && (
             <Alert
+              border
               className={cx(styles['no-admin-alert'])}
               contained
               title={<FormattedMessage defaultMessage="You have already accepted this invitation." description="An informational message that appears if the user tries to accept an invitation that they have already accepted." id="feedInvitation.alreadyAccepted" />}

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -694,7 +694,6 @@ const SaveFeed = (props) => {
                 </> : null
               }
               <Alert
-                banner
                 className={styles.paragraphMarginTop}
                 content={
                   <FormattedMessage
@@ -703,6 +702,7 @@ const SaveFeed = (props) => {
                     id="alert.sharedFeedRealTimeAlertContent"
                   />
                 }
+                placement="banner"
                 title={
                   <FormattedMessage
                     defaultMessage="Shared feed data updates may not occur in real time"

--- a/src/app/components/layout/ConfirmDialog.js
+++ b/src/app/components/layout/ConfirmDialog.js
@@ -48,7 +48,7 @@ class ConfirmDialog extends React.Component {
           <h6>{this.props.title}</h6>
         </div>
         <div className={styles['dialog-content']}>
-          { this.props.message && <><Alert contained title={this.props.message} variant="error" /><br /></> }
+          { this.props.message && <><Alert placement="contained" title={this.props.message} variant="error" /><br /></> }
           {this.props.blurb}
           { this.props.handleConfirm ?
             <div className={inputStyles['form-fieldset']}>

--- a/src/app/components/media/CreateMediaSource.js
+++ b/src/app/components/media/CreateMediaSource.js
@@ -172,7 +172,7 @@ function CreateMediaSource({
 
   return (
     <React.Fragment>
-      { message && <><Alert border contained title={message} variant="error" /><br /></> }
+      { message && <><Alert border placement="contained" title={message} variant="error" /><br /></> }
       <div className={inputStyles['form-inner-wrapper']}>
         <div className={styles['media-sources-header']}>
           <div className={styles['media-sources-header-left']}>

--- a/src/app/components/media/CreateMediaSource.js
+++ b/src/app/components/media/CreateMediaSource.js
@@ -172,7 +172,7 @@ function CreateMediaSource({
 
   return (
     <React.Fragment>
-      { message && <><Alert contained title={message} variant="error" /><br /></> }
+      { message && <><Alert border contained title={message} variant="error" /><br /></> }
       <div className={inputStyles['form-inner-wrapper']}>
         <div className={styles['media-sources-header']}>
           <div className={styles['media-sources-header-left']}>

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -242,7 +242,7 @@ class CreateRelatedMediaDialog extends React.Component {
           }
           { mode === 'existing' &&
             <>
-              { this.props.message && <><Alert contained title={this.props.message} variant="error" /><br /></> }
+              { this.props.message && <><Alert border contained title={this.props.message} variant="error" /><br /></> }
               <AutoCompleteMediaItem
                 customFilter={this.props.customFilter}
                 dbid={media ? media.dbid : null}

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -242,7 +242,7 @@ class CreateRelatedMediaDialog extends React.Component {
           }
           { mode === 'existing' &&
             <>
-              { this.props.message && <><Alert border contained title={this.props.message} variant="error" /><br /></> }
+              { this.props.message && <><Alert border placement="contained" title={this.props.message} variant="error" /><br /></> }
               <AutoCompleteMediaItem
                 customFilter={this.props.customFilter}
                 dbid={media ? media.dbid : null}

--- a/src/app/components/media/MediaPlayerCard.js
+++ b/src/app/components/media/MediaPlayerCard.js
@@ -44,7 +44,6 @@ const MediaPlayerCard = ({
     <article className={cx('video-media-card', styles['video-media-card'])}>
       { errorAlert &&
       <Alert
-        banner
         buttonLabel="Download video"
         content={
           <FormattedMessage
@@ -53,6 +52,7 @@ const MediaPlayerCard = ({
             id="mediaPlayer.errorContent"
           />
         }
+        placement="banner"
         title={
           <FormattedMessage
             defaultMessage="A Playback Error Occurred."

--- a/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
+++ b/src/app/components/media/ReportDesigner/ReportDesignerComponent.js
@@ -192,7 +192,6 @@ const ReportDesignerComponent = (props) => {
         {data.state === 'published' ?
           <>
             <Alert
-              banner
               content={
                 <FormattedMessage
                   defaultMessage="To make edits, pause this report. This will stop the report from being sent out to users until it is published again."
@@ -201,6 +200,7 @@ const ReportDesignerComponent = (props) => {
                 />
               }
               icon
+              placement="banner"
               title={
                 <FormattedMessage
                   defaultMessage="Report is published"

--- a/src/app/components/media/WebPageMediaCard.js
+++ b/src/app/components/media/WebPageMediaCard.js
@@ -57,6 +57,7 @@ class WebPageMediaCard extends Component {
             }
             { data.error ?
               <Alert
+                border
                 className={cx('web-page-media-card__error', styles['webpage-media-card-error'])}
                 contained
                 content={

--- a/src/app/components/media/WebPageMediaCard.js
+++ b/src/app/components/media/WebPageMediaCard.js
@@ -59,7 +59,6 @@ class WebPageMediaCard extends Component {
               <Alert
                 border
                 className={cx('web-page-media-card__error', styles['webpage-media-card-error'])}
-                contained
                 content={
                   <FormattedMessage
                     defaultMessage="This item could not be identified. It may have been removed, or may only be visible to users who are logged in. Click the link above to navigate to it."
@@ -67,6 +66,7 @@ class WebPageMediaCard extends Component {
                     id="webPageMediaCard.Error"
                   />
                 }
+                placement="contained"
                 variant="error"
               /> : null
             }

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -501,7 +501,7 @@ function SearchResultsComponent({
         { tooManyResults ?
           <Alert
             border
-            contained
+            placement="contained"
             title={
               <FormattedMessage
                 defaultMessage="Browsing this list is limited to the first {max, number} results. Use the filters above to refine this list."

--- a/src/app/components/search/SearchResults.js
+++ b/src/app/components/search/SearchResults.js
@@ -500,6 +500,7 @@ function SearchResultsComponent({
       <div className={cx('search__results', 'results', styles['search-results-wrapper'])}>
         { tooManyResults ?
           <Alert
+            border
             contained
             title={
               <FormattedMessage

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -392,7 +392,7 @@ class EditTaskDialog extends React.Component {
           />
         </div>
         <div className={dialogStyles['dialog-content']}>
-          { this.props.message && <><Alert contained title={this.props.message} variant="error" /><br /></> }
+          { this.props.message && <><Alert border contained title={this.props.message} variant="error" /><br /></> }
           <div className={inputStyles['form-fieldset']}>
             <FormattedMessage defaultMessage="Enter a title for this annotation" description="Input Placeholder for the Title field for custom annotation field" id="task.TitlePlaceholder">
               {placeholder => (

--- a/src/app/components/task/EditTaskDialog.js
+++ b/src/app/components/task/EditTaskDialog.js
@@ -392,7 +392,7 @@ class EditTaskDialog extends React.Component {
           />
         </div>
         <div className={dialogStyles['dialog-content']}>
-          { this.props.message && <><Alert border contained title={this.props.message} variant="error" /><br /></> }
+          { this.props.message && <><Alert border placement="contained" title={this.props.message} variant="error" /><br /></> }
           <div className={inputStyles['form-fieldset']}>
             <FormattedMessage defaultMessage="Enter a title for this annotation" description="Input Placeholder for the Title field for custom annotation field" id="task.TitlePlaceholder">
               {placeholder => (

--- a/src/app/components/team/InviteDialog.js
+++ b/src/app/components/team/InviteDialog.js
@@ -151,7 +151,7 @@ const InviteDialog = ({
         />
       </div>
       <div className={styles['dialog-content']}>
-        { errorMessage && <><Alert border contained title={errorMessage} variant="error" /><br /></> }
+        { errorMessage && <><Alert border placement="contained" title={errorMessage} variant="error" /><br /></> }
         <div className={inputStyles['form-fieldset']}>
           <div className={inputStyles['form-fieldset-field']}>
             <FormattedMessage defaultMessage="example: team_member@example.org, team_member2@example.org" description="Placeholder for input for invited emails" id="inviteDialog.textInputPlaceholder">

--- a/src/app/components/team/InviteDialog.js
+++ b/src/app/components/team/InviteDialog.js
@@ -151,7 +151,7 @@ const InviteDialog = ({
         />
       </div>
       <div className={styles['dialog-content']}>
-        { errorMessage && <><Alert contained title={errorMessage} variant="error" /><br /></> }
+        { errorMessage && <><Alert border contained title={errorMessage} variant="error" /><br /></> }
         <div className={inputStyles['form-fieldset']}>
           <div className={inputStyles['form-fieldset-field']}>
             <FormattedMessage defaultMessage="example: team_member@example.org, team_member2@example.org" description="Placeholder for input for invited emails" id="inviteDialog.textInputPlaceholder">

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -113,7 +113,7 @@ const NewsletterScheduler = ({
       { lastDeliveryError === 'CONTENT_HASNT_CHANGED' ?
         <Alert
           border
-          contained
+          placement="contained"
           title={
             <FormattedMessage
               defaultMessage="The newsletter was not sent because its content has not been updated since the last successful delivery."
@@ -128,7 +128,7 @@ const NewsletterScheduler = ({
       { lastDeliveryError === 'RSS_ERROR' ?
         <Alert
           border
-          contained
+          placement="contained"
           title={
             <FormattedMessage
               defaultMessage="The newsletter was not sent because no content could be retrieved from the RSS feed."

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -112,6 +112,7 @@ const NewsletterScheduler = ({
 
       { lastDeliveryError === 'CONTENT_HASNT_CHANGED' ?
         <Alert
+          border
           contained
           title={
             <FormattedMessage
@@ -126,6 +127,7 @@ const NewsletterScheduler = ({
 
       { lastDeliveryError === 'RSS_ERROR' ?
         <Alert
+          border
           contained
           title={
             <FormattedMessage

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -75,7 +75,6 @@ const SmoochBotMainMenu = ({
       { Object.keys(enabledIntegrations).filter(platformName => platformName !== 'whatsapp').length > 0 ? // Any platform other than WhatsApp
         <Alert
           border
-          contained
           content={
             <FormattedMessage
               defaultMessage="Please note that some messaging services have different menu display options than others."
@@ -83,6 +82,7 @@ const SmoochBotMainMenu = ({
               id="smoochBotMainMenu.subtitle2"
             />
           }
+          placement="contained"
           variant="info"
         /> : null
       }
@@ -101,7 +101,6 @@ const SmoochBotMainMenu = ({
         <Alert
           border
           className={settingsStyles['tipline-settings-menu-count-alert']}
-          contained
           content={
             <FormattedMessage
               defaultMessage="There are {numberOfOptions} options including all languages on this workspace. Only {numberOfLanguages} languages will be sent to users when they select the 'Languages' option."
@@ -110,6 +109,7 @@ const SmoochBotMainMenu = ({
               values={{ numberOfOptions: optionsCount, numberOfLanguages: (languages.length + 1) }}
             />
           }
+          placement="contained"
           variant="warning"
         /> : null }
 

--- a/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
+++ b/src/app/components/team/SmoochBot/SmoochBotMainMenu.js
@@ -74,6 +74,7 @@ const SmoochBotMainMenu = ({
     <React.Fragment>
       { Object.keys(enabledIntegrations).filter(platformName => platformName !== 'whatsapp').length > 0 ? // Any platform other than WhatsApp
         <Alert
+          border
           contained
           content={
             <FormattedMessage
@@ -98,6 +99,7 @@ const SmoochBotMainMenu = ({
       </div>
       { collapseLanguages ?
         <Alert
+          border
           className={settingsStyles['tipline-settings-menu-count-alert']}
           contained
           content={

--- a/src/app/components/team/SmoochBot/TiplineContentTranslation.js
+++ b/src/app/components/team/SmoochBot/TiplineContentTranslation.js
@@ -116,6 +116,7 @@ const TiplineContentTranslation = ({
       <div className={styles['content-translation-details']}>
         { !value &&
           <Alert
+            border
             className={styles['content-translation-details-default']}
             contained
             content={defaultValue}
@@ -147,6 +148,7 @@ const TiplineContentTranslation = ({
               onClick={() => { setDefaultExpanded(!defaultExpanded); }}
             />
             <Alert
+              border
               className={styles['default-bot-response-content']}
               contained
               content={defaultValue}

--- a/src/app/components/team/SmoochBot/TiplineContentTranslation.js
+++ b/src/app/components/team/SmoochBot/TiplineContentTranslation.js
@@ -118,9 +118,9 @@ const TiplineContentTranslation = ({
           <Alert
             border
             className={styles['content-translation-details-default']}
-            contained
             content={defaultValue}
             icon={false}
+            placement="contained"
             title={intl.formatMessage(messages.defaultText)}
             variant="info"
           />
@@ -150,9 +150,9 @@ const TiplineContentTranslation = ({
             <Alert
               border
               className={styles['default-bot-response-content']}
-              contained
               content={defaultValue}
               icon={false}
+              placement="contained"
               title={intl.formatMessage(messages.defaultText)}
               variant="info"
             />

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -12,6 +12,7 @@ const StatusMessage = ({ message }) => {
 
   return (
     <Alert
+      border
       className={cx(styles['status-message'], 'test__status-message')}
       content={message}
       icon

--- a/src/app/components/team/Statuses/StatusMessage.js
+++ b/src/app/components/team/Statuses/StatusMessage.js
@@ -12,7 +12,6 @@ const StatusMessage = ({ message }) => {
 
   return (
     <Alert
-      border
       className={cx(styles['status-message'], 'test__status-message')}
       content={message}
       icon

--- a/src/app/components/team/TeamDetails.js
+++ b/src/app/components/team/TeamDetails.js
@@ -252,7 +252,6 @@ const TeamDetails = ({
                     <Alert
                       border
                       className={inputStyles['form-fieldset-field']}
-                      contained
                       content={
                         <FormattedHTMLMessage
                           defaultMessage="<strong>Before:</strong> https://www.example.com/your-link<br /><strong>After:</strong> https://chck.media/x1y2z3w4/{code}"
@@ -261,6 +260,7 @@ const TeamDetails = ({
                           values={{ code: utmCode ? `?utm_source=${utmCode}` : '' }}
                         />
                       }
+                      placement="contained"
                       title={<FormattedMessage defaultMessage="All links sent via Check will be rewritten." description="Text displayed in the title of a warning box on team details page when link shortening is on" id="teamDetails.warnTitle" />}
                       variant="warning"
                     />

--- a/src/app/components/team/TeamDetails.js
+++ b/src/app/components/team/TeamDetails.js
@@ -250,6 +250,7 @@ const TeamDetails = ({
                       )}
                     </FormattedMessage>
                     <Alert
+                      border
                       className={inputStyles['form-fieldset-field']}
                       contained
                       content={

--- a/src/app/components/user/ConfirmEmail.js
+++ b/src/app/components/user/ConfirmEmail.js
@@ -15,6 +15,7 @@ const ConfirmEmail = (props) => {
 
   return (
     <Alert
+      border
       buttonLabel={<FormattedMessage defaultMessage="Resend" description="Button label to allow the user to resend their email address confirmation" id="ConfirmEmail.resendConfirmation" />}
       contained
       content={

--- a/src/app/components/user/ConfirmEmail.js
+++ b/src/app/components/user/ConfirmEmail.js
@@ -17,7 +17,6 @@ const ConfirmEmail = (props) => {
     <Alert
       border
       buttonLabel={<FormattedMessage defaultMessage="Resend" description="Button label to allow the user to resend their email address confirmation" id="ConfirmEmail.resendConfirmation" />}
-      contained
       content={
         <FormattedMessage
           defaultMessage="Please check your email to verify your account."
@@ -25,6 +24,7 @@ const ConfirmEmail = (props) => {
           id="ConfirmEmail.content"
         />
       }
+      placement="contained"
       title={<FormattedMessage defaultMessage="Confirm your email" description="Container title for confirming user email address" id="ConfirmEmail.title" />}
       variant="warning"
       onButtonClick={handleResend}

--- a/src/app/components/user/UserEmail.js
+++ b/src/app/components/user/UserEmail.js
@@ -5,7 +5,6 @@ import Alert from '../cds/alerts-and-prompts/Alert';
 const UserEmail = () => (
   <Alert
     border
-    contained
     content={
       <FormattedMessage
         defaultMessage="To send you notifications, we need your email address. If you'd like to receive notifications, please enter your email address."
@@ -13,6 +12,7 @@ const UserEmail = () => (
         id="userEmail.text"
       />
     }
+    placement="contained"
     title={<FormattedMessage defaultMessage="Add your email" description="Alert title for prompting the user to add their email address in order to receive notifications" id="userEmail.alertTitle" />}
     variant="warning"
   />

--- a/src/app/components/user/UserEmail.js
+++ b/src/app/components/user/UserEmail.js
@@ -4,6 +4,7 @@ import Alert from '../cds/alerts-and-prompts/Alert';
 
 const UserEmail = () => (
   <Alert
+    border
     contained
     content={
       <FormattedMessage


### PR DESCRIPTION
## Description

While working on designs for CV2-5171 I needed some different variants of the `<Alert...` component. I decided to make these changes in the code at the same time so they would already be available. I also took the opportunity to do a bit of refactoring for the future:
- Added a `Placement` prop type of `oneOf` instead of individual props
- Added a `Border` prop in order to be able to toggle off the border individually. Also removed a classname override for media origin banner to take advantage of this prop.
- Updated the html so wherever there was a border style, the appropriate prop was added since `Border` defaults to `false`
- Updated the sandbox to include the new `Border` prop
- Sorted prop types when file touched

References: CV2-5171

## How to test?

There should be no visible changes, but this can be confirmed via the Sandbox where I added toggle for the new border prop type

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
