### PR TITLE
Save Exception to localStorage for easier debugging

### DIFF
--- a/src/app/components/error/ErrorBoundary.js
+++ b/src/app/components/error/ErrorBoundary.js
@@ -13,6 +13,14 @@ const messages = defineMessages({
   },
 });
 
+const saveError = (error) => {
+  window.localStorage.setItem('checkError', JSON.stringify({
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  }));
+};
+
 const notifySentry = (
   error,
   component,
@@ -42,6 +50,7 @@ class ErrorBoundary extends React.Component {
     this.state = { hasError: false };
 
     window.onerror = (message, source, lineno, colno, error) => {
+      saveError(error);
       notifySentry(error, 'window');
     };
   }
@@ -62,6 +71,7 @@ class ErrorBoundary extends React.Component {
       }
     };
 
+    saveError(error);
     notifySentry(error, component, callIntercom);
   }
 


### PR DESCRIPTION
## Description

Navigating away using `window.location.assign` causes the console to clear and makes us lose track of the errors in there.
This commit will save error data to localStorage for easier debugging. 

References: CV2-6195

## How to test?

Type  `window.localStorage.getItem('checkError')` on the console after an error happens to find details about the last caught exception.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
