### PR TITLE
"All Articles" list.

### DIFF
--- a/localization/react-intl/src/app/components/article/AllArticles.json
+++ b/localization/react-intl/src/app/components/article/AllArticles.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "allArticles.title",
+    "description": "Title of the all articles page.",
+    "defaultMessage": "All Articles"
+  }
+]

--- a/localization/react-intl/src/app/components/article/Articles.json
+++ b/localization/react-intl/src/app/components/article/Articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "articles.sortTitle",
+    "description": "Label for sort criteria option displayed in a drop-down in the articles page.",
+    "defaultMessage": "Title"
+  },
+  {
+    "id": "articles.sortLanguage",
+    "description": "Label for sort criteria option displayed in a drop-down in the articles page.",
+    "defaultMessage": "Language"
+  },
+  {
+    "id": "articles.sortDate",
+    "description": "Label for sort criteria option displayed in a drop-down in the articles page.",
+    "defaultMessage": "Updated (date)"
+  },
+  {
     "id": "articles.updateTagsSuccess",
     "description": "Banner displayed after article tags are updated successfully.",
     "defaultMessage": "Tags updated successfully."

--- a/localization/react-intl/src/app/components/article/Explainers.json
+++ b/localization/react-intl/src/app/components/article/Explainers.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": "explainers.sortTitle",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Title"
-  },
-  {
-    "id": "explainers.sortLanguage",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Language"
-  },
-  {
-    "id": "explainers.sortDate",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Updated (date)"
-  },
-  {
     "id": "explainers.title",
     "description": "Title of the explainers page.",
     "defaultMessage": "Explainers"

--- a/localization/react-intl/src/app/components/article/FactChecks.json
+++ b/localization/react-intl/src/app/components/article/FactChecks.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": "factChecks.sortTitle",
-    "description": "Label for sort criteria option displayed in a drop-down in the fact-checks page.",
-    "defaultMessage": "Title"
-  },
-  {
-    "id": "factChecks.sortLanguage",
-    "description": "Label for sort criteria option displayed in a drop-down in the fact-checks page.",
-    "defaultMessage": "Language"
-  },
-  {
-    "id": "factChecks.sortDate",
-    "description": "Label for sort criteria option displayed in a drop-down in the fact-checks page.",
-    "defaultMessage": "Updated (date)"
-  },
-  {
     "id": "factChecks.title",
     "description": "Title of the fact-checks page.",
     "defaultMessage": "Claim & Fact-Checks"

--- a/localization/react-intl/src/app/components/article/ImportedArticles.json
+++ b/localization/react-intl/src/app/components/article/ImportedArticles.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": "explainers.sortTitle",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Title"
-  },
-  {
-    "id": "explainers.sortLanguage",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Language"
-  },
-  {
-    "id": "explainers.sortDate",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Updated (date)"
-  },
-  {
     "id": "importedArticles.title",
     "description": "Title of the imported articles page.",
     "defaultMessage": "Imported"

--- a/localization/react-intl/src/app/components/article/PublishedArticles.json
+++ b/localization/react-intl/src/app/components/article/PublishedArticles.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": "explainers.sortTitle",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Title"
-  },
-  {
-    "id": "explainers.sortLanguage",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Language"
-  },
-  {
-    "id": "explainers.sortDate",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Updated (date)"
-  },
-  {
     "id": "publishedArticles.title",
     "description": "Title of the published articles page.",
     "defaultMessage": "Published"

--- a/localization/react-intl/src/app/components/article/TrashedArticles.json
+++ b/localization/react-intl/src/app/components/article/TrashedArticles.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": "explainers.sortTitle",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Title"
-  },
-  {
-    "id": "explainers.sortLanguage",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Language"
-  },
-  {
-    "id": "explainers.sortDate",
-    "description": "Label for sort criteria option displayed in a drop-down in the explainers page.",
-    "defaultMessage": "Updated (date)"
-  },
-  {
     "id": "trashedArticles.title",
     "description": "Title of the trashed articles page.",
     "defaultMessage": "Trash"

--- a/localization/react-intl/src/app/components/drawer/DrawerArticles.json
+++ b/localization/react-intl/src/app/components/drawer/DrawerArticles.json
@@ -10,6 +10,11 @@
     "defaultMessage": "Dashboard"
   },
   {
+    "id": "articlesComponent.allArticles",
+    "description": "Label for a list displayed on the left sidebar that includes all articles",
+    "defaultMessage": "All Articles"
+  },
+  {
     "id": "articlesComponent.claimAndFactChecks",
     "description": "Label for a list displayed on the left sidebar that includes items that have claim & fact-checks",
     "defaultMessage": "Claim & Fact-Checks"

--- a/src/app/components/Root.js
+++ b/src/app/components/Root.js
@@ -39,10 +39,10 @@ import Explainers from './article/Explainers';
 import FactChecks from './article/FactChecks';
 import ImportedArticles from './article/ImportedArticles';
 import PublishedArticles from './article/PublishedArticles';
+import TrashedArticles from './article/TrashedArticles';
+import AllArticles from './article/AllArticles';
 import TiplineDashBoard from './dashboard/TiplineDashboard';
 import ArticlesDashboard from './dashboard/ArticlesDashboard';
-
-import TrashedArticles from './article/TrashedArticles';
 
 class Root extends Component {
   static logPageView() {
@@ -126,6 +126,7 @@ class Root extends Component {
                   <Route component={ImportedArticles} path=":team/articles/imported-fact-checks" />
                   <Route component={PublishedArticles} path=":team/articles/published" />
                   <Route component={TrashedArticles} path=":team/articles/trash" />
+                  <Route component={AllArticles} path=":team/articles/all" />
                   <Route component={NotFound} path="*" public />
                 </Route>
               </Router>

--- a/src/app/components/article/AllArticles.js
+++ b/src/app/components/article/AllArticles.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import Articles from './Articles';
+import DescriptionIcon from '../../icons/description.svg';
+
+const AllArticles = ({ routeParams }) => (
+  <Articles
+    articleTypeReadOnly={false}
+    defaultFilters={{ article_type: null }}
+    filterOptions={['users', 'tags', 'range']}
+    icon={<DescriptionIcon />}
+    teamSlug={routeParams.team}
+    title={<FormattedMessage defaultMessage="All Articles" description="Title of the all articles page." id="allArticles.title" />}
+    type={null}
+  />
+);
+
+AllArticles.defaultProps = {};
+
+AllArticles.propTypes = {
+  routeParams: PropTypes.shape({
+    team: PropTypes.string.isRequired, // slug
+  }).isRequired,
+};
+
+export default AllArticles;

--- a/src/app/components/article/ArticleFilters.js
+++ b/src/app/components/article/ArticleFilters.js
@@ -182,7 +182,7 @@ const ArticleFilters = ({
             );
           }
 
-          if (filter === 'article_type') {
+          if (filter === 'article_type' && typeFilter[0]) {
             return (
               <React.Fragment key={filter}>
                 {connector}
@@ -354,7 +354,7 @@ ArticleFilters.propTypes = {
     label: PropTypes.string.isRequired,
   }).isRequired).isRequired,
   teamSlug: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(['explainer', 'fact-check']).isRequired,
+  type: PropTypes.oneOf(['explainer', 'fact-check', null]).isRequired,
   onChangeArticleType: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
 };

--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { QueryRenderer, graphql, commitMutation } from 'react-relay/compat';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
 import ArticleFilters from './ArticleFilters';
 import { ClaimFactCheckFormQueryRenderer } from './ClaimFactCheckForm';
 import { ExplainerFormQueryRenderer } from './ExplainerForm';
@@ -25,6 +25,46 @@ import Loader from '../cds/loading/Loader';
 import PageTitle from '../PageTitle';
 import searchStyles from '../search/search.module.css';
 import searchResultsStyles from '../search/SearchResults.module.css';
+
+const messages = defineMessages({
+  sortTitle: {
+    id: 'articles.sortTitle',
+    defaultMessage: 'Title',
+    description: 'Label for sort criteria option displayed in a drop-down in the articles page.',
+  },
+  sortLanguage: {
+    id: 'articles.sortLanguage',
+    defaultMessage: 'Language',
+    description: 'Label for sort criteria option displayed in a drop-down in the articles page.',
+  },
+  sortDate: {
+    id: 'articles.sortDate',
+    defaultMessage: 'Updated (date)',
+    description: 'Label for sort criteria option displayed in a drop-down in the articles page.',
+  },
+});
+
+const updateMutationExplainer = graphql`
+  mutation ArticlesUpdateExplainerMutation($input: UpdateExplainerInput!) {
+    updateExplainer(input: $input) {
+      explainer {
+        id
+        tags
+      }
+    }
+  }
+`;
+
+const updateMutationFactCheck = graphql`
+  mutation ArticlesUpdateFactCheckMutation($input: UpdateFactCheckInput!) {
+    updateFactCheck(input: $input) {
+      fact_check {
+        id
+        tags
+      }
+    }
+  }
+`;
 
 // This converts the filters keys to the argument names expected by the articles field in the GraphQL query
 // The original keys are used in `ArticleFilters` to display the filters
@@ -65,7 +105,7 @@ const adjustFilters = (filters) => {
   return newFilters;
 };
 
-const ArticlesComponent = ({
+const ArticlesComponentWithoutIntl = ({
   articleTypeReadOnly,
   articles,
   articlesCount,
@@ -73,25 +113,41 @@ const ArticlesComponent = ({
   filterOptions,
   filters,
   icon,
+  intl,
   onChangeArticleType,
   onChangeSearchParams,
   page,
   reloadData,
   sort,
-  sortOptions,
   sortType,
   statuses,
   team,
   title,
   type,
-  updateMutation,
 }) => {
+  const sortOptions = [
+    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
+    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
+    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
+  ];
+
   let articleDbidFromUrl = null;
+  let articleTypeFromUrl = getQueryStringValue('factCheckId');
+  if (articleDbidFromUrl) {
+    articleTypeFromUrl = 'fact-check';
+  } else {
+    articleDbidFromUrl = getQueryStringValue('explainerId');
+    if (articleDbidFromUrl) {
+      articleTypeFromUrl = 'explainer';
+    }
+  }
 
-  if (type === 'fact-check') articleDbidFromUrl = getQueryStringValue('factCheckId');
-  if (type === 'explainer') articleDbidFromUrl = getQueryStringValue('explainerId');
+  const articleTypeFilter = {};
+  if (type) {
+    articleTypeFilter.article_type = type;
+  }
 
-  const [selectedArticleDbid, setSelectedArticleDbid] = React.useState(articleDbidFromUrl);
+  const [selectedArticle, setSelectedArticle] = React.useState({ id: articleDbidFromUrl, type: articleTypeFromUrl });
 
   // Track when number of articles increases: When it happens, it's because a new article was created, so refresh the list
   const [totalArticlesCount, setTotalArticlesCount] = React.useState(team.totalArticlesCount);
@@ -125,8 +181,8 @@ const ArticlesComponent = ({
   };
 
   const handleCloseSlideout = () => {
-    setSelectedArticleDbid(null);
-    deleteQueryStringValue(type === 'explainer' ? 'explainerId' : 'factCheckId');
+    if (selectedArticle.type) deleteQueryStringValue(selectedArticle.type === 'explainer' ? 'explainerId' : 'factCheckId');
+    setSelectedArticle({});
   };
 
   const onCompleted = () => {
@@ -149,7 +205,7 @@ const ArticlesComponent = ({
       'error');
   };
 
-  const handleUpdateTags = (id, tags) => {
+  const handleUpdateTags = (id, tags, updateMutation) => {
     commitMutation(Relay.Store, {
       mutation: updateMutation,
       variables: {
@@ -164,11 +220,11 @@ const ArticlesComponent = ({
   };
 
   const handleClick = (article) => {
-    if (article.dbid !== selectedArticleDbid) {
-      setSelectedArticleDbid(null);
+    if (article.dbid !== selectedArticle.id) {
+      setSelectedArticle({});
       setTimeout(() => {
-        setSelectedArticleDbid(article.dbid);
-        pushQueryStringValue(type === 'explainer' ? 'explainerId' : 'factCheckId', article.dbid);
+        setSelectedArticle({ id: article.dbid, type: article.type });
+        pushQueryStringValue(article.type === 'explainer' ? 'explainerId' : 'factCheckId', article.dbid);
       }, 10);
     }
   };
@@ -212,8 +268,8 @@ const ArticlesComponent = ({
           />
           <ArticleFilters
             articleTypeReadOnly={articleTypeReadOnly}
-            currentFilters={{ ...filters, article_type: type }}
-            defaultFilters={{ ...defaultFilters, article_type: type }}
+            currentFilters={{ ...filters, ...articleTypeFilter }}
+            defaultFilters={{ ...defaultFilters, ...articleTypeFilter }}
             filterOptions={filterOptions}
             statuses={statuses.statuses}
             teamSlug={team.slug}
@@ -235,7 +291,7 @@ const ArticlesComponent = ({
                 pageSize={pageSize}
                 onChangePage={handleChangePage}
               />
-              <ExportList filters={adjustFilters(filters)} type={type.replace('-', '_')} />
+              <ExportList filters={adjustFilters(filters)} type={type ? type.replace('-', '_') : 'articles'} />
             </div>
           </div>
           : null
@@ -254,6 +310,16 @@ const ArticlesComponent = ({
 
         <div className={searchResultsStyles['search-results-scroller']}>
           {articles.map((article) => {
+            let articleType = null;
+            let updateMutation = null;
+            if (article.nodeType === 'Explainer') {
+              articleType = 'explainer';
+              updateMutation = updateMutationExplainer;
+            } else if (article.nodeType === 'FactCheck') {
+              articleType = 'fact-check';
+              updateMutation = updateMutationFactCheck;
+            }
+
             let currentStatus = null;
             if (article.rating) {
               currentStatus = getStatus(statuses, article.rating);
@@ -264,7 +330,7 @@ const ArticlesComponent = ({
             return (
               <ArticleCard
                 date={article.updated_at}
-                handleClick={() => handleClick(article)}
+                handleClick={() => handleClick({ ...article, type: articleType })}
                 isPublished={article.report_status === 'published'}
                 key={article.id}
                 languageCode={article.language !== 'und' ? article.language : null}
@@ -277,24 +343,24 @@ const ArticlesComponent = ({
                 teamSlug={team.slug}
                 title={isFactCheckValueBlank(article.title) ? article.claim_description?.description : article.title}
                 url={article.url}
-                variant={type}
-                onChangeTags={(tags) => { handleUpdateTags(article.id, tags); }}
+                variant={articleType}
+                onChangeTags={(tags) => { handleUpdateTags(article.id, tags, updateMutation); }}
               />
             );
           })}
         </div>
 
         <>
-          {selectedArticleDbid && type === 'fact-check' && (
+          {selectedArticle.type === 'fact-check' && (
             <ClaimFactCheckFormQueryRenderer
-              factCheckId={selectedArticleDbid}
+              factCheckId={selectedArticle.id}
               teamSlug={team.slug}
               onClose={handleCloseSlideout}
             />
           )}
-          {selectedArticleDbid && type === 'explainer' && (
+          {selectedArticle.type === 'explainer' && (
             <ExplainerFormQueryRenderer
-              explainerId={selectedArticleDbid}
+              explainerId={selectedArticle.id}
               teamSlug={team.slug}
               onClose={handleCloseSlideout}
             />
@@ -305,11 +371,10 @@ const ArticlesComponent = ({
   );
 };
 
-ArticlesComponent.defaultProps = {
+ArticlesComponentWithoutIntl.defaultProps = {
   page: 1,
   sort: 'updated_at',
   sortType: 'DESC',
-  sortOptions: [],
   filterOptions: [],
   filters: {},
   defaultFilters: {},
@@ -319,7 +384,7 @@ ArticlesComponent.defaultProps = {
   onChangeArticleType: null,
 };
 
-ArticlesComponent.propTypes = {
+ArticlesComponentWithoutIntl.propTypes = {
   articles: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
@@ -344,12 +409,9 @@ ArticlesComponent.propTypes = {
   filterOptions: PropTypes.arrayOf(PropTypes.string),
   filters: PropTypes.object,
   icon: PropTypes.node.isRequired,
+  intl: intlShape.isRequired,
   page: PropTypes.number,
   sort: PropTypes.oneOf(['title', 'language', 'updated_at']),
-  sortOptions: PropTypes.arrayOf(PropTypes.exact({
-    value: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired, // Localizable string
-  })),
   sortType: PropTypes.oneOf(['ASC', 'DESC']),
   statuses: PropTypes.object,
   team: PropTypes.shape({
@@ -357,11 +419,12 @@ ArticlesComponent.propTypes = {
     slug: PropTypes.string.isRequired,
   }).isRequired,
   title: PropTypes.node.isRequired, // <FormattedMessage />
-  type: PropTypes.oneOf(['explainer', 'fact-check']).isRequired,
-  updateMutation: PropTypes.object.isRequired,
+  type: PropTypes.oneOf(['explainer', 'fact-check', null]).isRequired,
   onChangeArticleType: PropTypes.func,
   onChangeSearchParams: PropTypes.func.isRequired,
 };
+
+const ArticlesComponent = injectIntl(ArticlesComponentWithoutIntl);
 
 // Used in unit test
 // eslint-disable-next-line import/no-unused-modules
@@ -373,11 +436,9 @@ const Articles = ({
   filterOptions,
   icon,
   onChangeArticleType,
-  sortOptions,
   teamSlug,
   title,
   type,
-  updateMutation,
 }) => {
   const [searchParams, setSearchParams] = React.useState({
     page: 1,
@@ -426,6 +487,7 @@ const Articles = ({
               ) {
                 edges {
                   node {
+                    nodeType: __typename
                     ... on Explainer {
                       id
                       dbid
@@ -477,13 +539,11 @@ const Articles = ({
                 page={page}
                 reloadData={retry}
                 sort={sort}
-                sortOptions={sortOptions}
                 sortType={sortType}
                 statuses={props.team.verification_statuses}
                 team={props.team}
                 title={title}
                 type={type}
-                updateMutation={updateMutation}
                 onChangeArticleType={onChangeArticleType}
                 onChangeSearchParams={handleChangeSearchParams}
               />
@@ -509,9 +569,9 @@ const Articles = ({
 
 Articles.defaultProps = {
   articleTypeReadOnly: true,
-  sortOptions: [],
   filterOptions: [],
   defaultFilters: {},
+  type: null,
   onChangeArticleType: null,
 };
 
@@ -520,14 +580,9 @@ Articles.propTypes = {
   defaultFilters: PropTypes.object,
   filterOptions: PropTypes.arrayOf(PropTypes.string),
   icon: PropTypes.node.isRequired,
-  sortOptions: PropTypes.arrayOf(PropTypes.exact({
-    value: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired, // Localizable string
-  })),
   teamSlug: PropTypes.string.isRequired,
   title: PropTypes.node.isRequired, // <FormattedMessage />
-  type: PropTypes.oneOf(['explainer', 'fact-check']).isRequired,
-  updateMutation: PropTypes.object.isRequired,
+  type: PropTypes.oneOf(['explainer', 'fact-check', null]),
   onChangeArticleType: PropTypes.func,
 };
 

--- a/src/app/components/article/Explainers.js
+++ b/src/app/components/article/Explainers.js
@@ -1,66 +1,25 @@
 import React from 'react';
-import { graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Articles from './Articles';
 import BookIcon from '../../icons/book.svg';
 
-const messages = defineMessages({
-  sortTitle: {
-    id: 'explainers.sortTitle',
-    defaultMessage: 'Title',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortLanguage: {
-    id: 'explainers.sortLanguage',
-    defaultMessage: 'Language',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortDate: {
-    id: 'explainers.sortDate',
-    defaultMessage: 'Updated (date)',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-});
-
-const Explainers = ({ intl, routeParams }) => {
-  const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
-    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
-    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
-  ];
-
-  const updateMutation = graphql`
-    mutation ExplainersUpdateExplainerMutation($input: UpdateExplainerInput!) {
-      updateExplainer(input: $input) {
-        explainer {
-          id
-          tags
-        }
-      }
-    }
-  `;
-
-  return (
-    <Articles
-      filterOptions={['users', 'tags', 'range', 'language_filter']}
-      icon={<BookIcon />}
-      sortOptions={sortOptions}
-      teamSlug={routeParams.team}
-      title={<FormattedMessage defaultMessage="Explainers" description="Title of the explainers page." id="explainers.title" />}
-      type="explainer"
-      updateMutation={updateMutation}
-    />
-  );
-};
+const Explainers = ({ routeParams }) => (
+  <Articles
+    filterOptions={['users', 'tags', 'range', 'language_filter']}
+    icon={<BookIcon />}
+    teamSlug={routeParams.team}
+    title={<FormattedMessage defaultMessage="Explainers" description="Title of the explainers page." id="explainers.title" />}
+    type="explainer"
+  />
+);
 
 Explainers.defaultProps = {};
 
 Explainers.propTypes = {
-  intl: intlShape.isRequired,
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired, // slug
   }).isRequired,
 };
 
-export default injectIntl(Explainers);
+export default Explainers;

--- a/src/app/components/article/FactChecks.js
+++ b/src/app/components/article/FactChecks.js
@@ -1,66 +1,25 @@
 import React from 'react';
-import { graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Articles from './Articles';
 import FactCheckIcon from '../../icons/fact_check.svg';
 
-const messages = defineMessages({
-  sortTitle: {
-    id: 'factChecks.sortTitle',
-    defaultMessage: 'Title',
-    description: 'Label for sort criteria option displayed in a drop-down in the fact-checks page.',
-  },
-  sortLanguage: {
-    id: 'factChecks.sortLanguage',
-    defaultMessage: 'Language',
-    description: 'Label for sort criteria option displayed in a drop-down in the fact-checks page.',
-  },
-  sortDate: {
-    id: 'factChecks.sortDate',
-    defaultMessage: 'Updated (date)',
-    description: 'Label for sort criteria option displayed in a drop-down in the fact-checks page.',
-  },
-});
-
-const FactChecks = ({ intl, routeParams }) => {
-  const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
-    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
-    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
-  ];
-
-  const updateMutation = graphql`
-    mutation FactChecksUpdateFactCheckMutation($input: UpdateFactCheckInput!) {
-      updateFactCheck(input: $input) {
-        fact_check {
-          id
-          tags
-        }
-      }
-    }
-  `;
-
-  return (
-    <Articles
-      filterOptions={['users', 'tags', 'range', 'language_filter', 'published_by', 'report_status', 'verification_status']}
-      icon={<FactCheckIcon />}
-      sortOptions={sortOptions}
-      teamSlug={routeParams.team}
-      title={<FormattedMessage defaultMessage="Claim & Fact-Checks" description="Title of the fact-checks page." id="factChecks.title" />}
-      type="fact-check"
-      updateMutation={updateMutation}
-    />
-  );
-};
+const FactChecks = ({ routeParams }) => (
+  <Articles
+    filterOptions={['users', 'tags', 'range', 'language_filter', 'published_by', 'report_status', 'verification_status']}
+    icon={<FactCheckIcon />}
+    teamSlug={routeParams.team}
+    title={<FormattedMessage defaultMessage="Claim & Fact-Checks" description="Title of the fact-checks page." id="factChecks.title" />}
+    type="fact-check"
+  />
+);
 
 FactChecks.defaultProps = {};
 
 FactChecks.propTypes = {
-  intl: intlShape.isRequired,
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired, // slug
   }).isRequired,
 };
 
-export default injectIntl(FactChecks);
+export default FactChecks;

--- a/src/app/components/article/ImportedArticles.js
+++ b/src/app/components/article/ImportedArticles.js
@@ -1,67 +1,26 @@
 import React from 'react';
-import { graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Articles from './Articles';
 import FileDownloadIcon from '../../icons/file_download.svg';
 
-const messages = defineMessages({
-  sortTitle: {
-    id: 'explainers.sortTitle',
-    defaultMessage: 'Title',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortLanguage: {
-    id: 'explainers.sortLanguage',
-    defaultMessage: 'Language',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortDate: {
-    id: 'explainers.sortDate',
-    defaultMessage: 'Updated (date)',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-});
-
-const ImportedArticles = ({ intl, routeParams }) => {
-  const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
-    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
-    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
-  ];
-
-  const updateMutation = graphql`
-    mutation ImportedArticlesUpdateExplainerMutation($input: UpdateExplainerInput!) {
-      updateExplainer(input: $input) {
-        explainer {
-          id
-          tags
-        }
-      }
-    }
-  `;
-
-  return (
-    <Articles
-      defaultFilters={{ imported: true }}
-      filterOptions={['tags', 'range', 'imported', 'language_filter']}
-      icon={<FileDownloadIcon />}
-      sortOptions={sortOptions}
-      teamSlug={routeParams.team}
-      title={<FormattedMessage defaultMessage="Imported" description="Title of the imported articles page." id="importedArticles.title" />}
-      type="fact-check"
-      updateMutation={updateMutation}
-    />
-  );
-};
+const ImportedArticles = ({ routeParams }) => (
+  <Articles
+    defaultFilters={{ imported: true }}
+    filterOptions={['tags', 'range', 'imported', 'language_filter']}
+    icon={<FileDownloadIcon />}
+    teamSlug={routeParams.team}
+    title={<FormattedMessage defaultMessage="Imported" description="Title of the imported articles page." id="importedArticles.title" />}
+    type="fact-check"
+  />
+);
 
 ImportedArticles.defaultProps = {};
 
 ImportedArticles.propTypes = {
-  intl: intlShape.isRequired,
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired, // slug
   }).isRequired,
 };
 
-export default injectIntl(ImportedArticles);
+export default ImportedArticles;

--- a/src/app/components/article/PublishedArticles.js
+++ b/src/app/components/article/PublishedArticles.js
@@ -1,67 +1,26 @@
 import React from 'react';
-import { graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Articles from './Articles';
 import PublishedIcon from '../../icons/playlist_add_check.svg';
 
-const messages = defineMessages({
-  sortTitle: {
-    id: 'explainers.sortTitle',
-    defaultMessage: 'Title',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortLanguage: {
-    id: 'explainers.sortLanguage',
-    defaultMessage: 'Language',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortDate: {
-    id: 'explainers.sortDate',
-    defaultMessage: 'Updated (date)',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-});
-
-const PublishedArticles = ({ intl, routeParams }) => {
-  const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
-    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
-    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
-  ];
-
-  const updateMutation = graphql`
-    mutation PublishedArticlesUpdateExplainerMutation($input: UpdateExplainerInput!) {
-      updateExplainer(input: $input) {
-        explainer {
-          id
-          tags
-        }
-      }
-    }
-  `;
-
-  return (
-    <Articles
-      defaultFilters={{ report_status: 'published' }}
-      filterOptions={['users', 'tags', 'range', 'verification_status', 'language_filter', 'published_by']}
-      icon={<PublishedIcon />}
-      sortOptions={sortOptions}
-      teamSlug={routeParams.team}
-      title={<FormattedMessage defaultMessage="Published" description="Title of the published articles page." id="publishedArticles.title" />}
-      type="fact-check"
-      updateMutation={updateMutation}
-    />
-  );
-};
+const PublishedArticles = ({ routeParams }) => (
+  <Articles
+    defaultFilters={{ report_status: 'published' }}
+    filterOptions={['users', 'tags', 'range', 'verification_status', 'language_filter', 'published_by']}
+    icon={<PublishedIcon />}
+    teamSlug={routeParams.team}
+    title={<FormattedMessage defaultMessage="Published" description="Title of the published articles page." id="publishedArticles.title" />}
+    type="fact-check"
+  />
+);
 
 PublishedArticles.defaultProps = {};
 
 PublishedArticles.propTypes = {
-  intl: intlShape.isRequired,
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired, // slug
   }).isRequired,
 };
 
-export default injectIntl(PublishedArticles);
+export default PublishedArticles;

--- a/src/app/components/article/TrashedArticles.js
+++ b/src/app/components/article/TrashedArticles.js
@@ -1,67 +1,17 @@
 import React from 'react';
-import { graphql } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Articles from './Articles';
 import TrashIcon from '../../icons/delete.svg';
 
-const messages = defineMessages({
-  sortTitle: {
-    id: 'explainers.sortTitle',
-    defaultMessage: 'Title',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortLanguage: {
-    id: 'explainers.sortLanguage',
-    defaultMessage: 'Language',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-  sortDate: {
-    id: 'explainers.sortDate',
-    defaultMessage: 'Updated (date)',
-    description: 'Label for sort criteria option displayed in a drop-down in the explainers page.',
-  },
-});
-
-const updateMutationExplainer = graphql`
-  mutation TrashedArticlesUpdateExplainerMutation($input: UpdateExplainerInput!) {
-    updateExplainer(input: $input) {
-      explainer {
-        id
-        tags
-      }
-    }
-  }
-`;
-
-const updateMutationFactCheck = graphql`
-  mutation TrashedArticlesUpdateFactCheckMutation($input: UpdateFactCheckInput!) {
-    updateFactCheck(input: $input) {
-      fact_check {
-        id
-        tags
-      }
-    }
-  }
-`;
-
-const TrashedArticles = ({ intl, routeParams }) => {
+const TrashedArticles = ({ routeParams }) => {
   const [type, setType] = React.useState('fact-check');
-  const [updateMutation, setUpdateMutation] = React.useState(updateMutationFactCheck);
-
-  const sortOptions = [
-    { value: 'title', label: intl.formatMessage(messages.sortTitle) },
-    { value: 'language', label: intl.formatMessage(messages.sortLanguage) },
-    { value: 'updated_at', label: intl.formatMessage(messages.sortDate) },
-  ];
 
   const handleChangeArticleType = (newType) => {
     if (newType === 'explainer') {
       setType(newType);
-      setUpdateMutation(updateMutationExplainer);
     } else if (newType === 'fact-check') {
       setType('fact-check');
-      setUpdateMutation(updateMutationFactCheck);
     } else {
       setType(null);
     }
@@ -73,11 +23,9 @@ const TrashedArticles = ({ intl, routeParams }) => {
       defaultFilters={{ trashed: true }}
       filterOptions={['users', 'tags', 'range']}
       icon={<TrashIcon />}
-      sortOptions={sortOptions}
       teamSlug={routeParams.team}
       title={<FormattedMessage defaultMessage="Trash" description="Title of the trashed articles page." id="trashedArticles.title" />}
       type={type}
-      updateMutation={updateMutation}
       onChangeArticleType={handleChangeArticleType}
     />
   );
@@ -86,10 +34,9 @@ const TrashedArticles = ({ intl, routeParams }) => {
 TrashedArticles.defaultProps = {};
 
 TrashedArticles.propTypes = {
-  intl: intlShape.isRequired,
   routeParams: PropTypes.shape({
     team: PropTypes.string.isRequired, // slug
   }).isRequired,
 };
 
-export default injectIntl(TrashedArticles);
+export default TrashedArticles;

--- a/src/app/components/drawer/DrawerArticles.js
+++ b/src/app/components/drawer/DrawerArticles.js
@@ -11,6 +11,7 @@ import TrashIcon from '../../icons/delete.svg';
 import FileDownloadIcon from '../../icons/file_download.svg';
 import BookIcon from '../../icons/book.svg';
 import BarChartIcon from '../../icons/bar_chart.svg';
+import DescriptionIcon from '../../icons/description.svg';
 import styles from './Projects/Projects.module.css';
 
 const DrawerArticlesComponent = ({ team }) => {
@@ -60,6 +61,28 @@ const DrawerArticlesComponent = ({ team }) => {
               <div className={styles.listLabel}>
                 <FormattedMessage defaultMessage="Dashboard" description="Label for the dashboard displayed on the left sidebar" id="articlesComponent.dashboard" tagName="span" />
               </div>
+            </li>
+          </Link>
+          <Link
+            className={styles.linkList}
+            to={`/${team.slug}/articles/all`}
+            onClick={() => { handleSpecialLists('all'); }}
+          >
+            <li
+              className={cx(
+                'projects-list__all',
+                styles.listItem,
+                styles.listItem_containsCount,
+                {
+                  [styles.listItem_active]: activeItem.type === 'all',
+                })
+              }
+            >
+              <DescriptionIcon className={styles.listIcon} />
+              <div className={styles.listLabel}>
+                <FormattedMessage defaultMessage="All Articles" description="Label for a list displayed on the left sidebar that includes all articles" id="articlesComponent.allArticles" tagName="span" />
+              </div>
+              <DrawerListCounter numberOfItems={team.articlesCount} />
             </li>
           </Link>
           <Link
@@ -191,6 +214,7 @@ const DrawerArticles = () => {
         query DrawerArticlesQuery($teamSlug: String!) {
           team(slug: $teamSlug) {
             slug
+            articlesCount: articles_count
             factChecksCount: articles_count(article_type: "fact-check")
             explainersCount: articles_count(article_type: "explainer")
             publishedCount: articles_count(article_type: "fact-check", report_status: "published")

--- a/src/app/components/drawer/DrawerRail.js
+++ b/src/app/components/drawer/DrawerRail.js
@@ -180,7 +180,7 @@ const DrawerRail = ({
                   })
                 }
                 id="side-rail__articles"
-                to={`/${team.slug}/articles/fact-checks`}
+                to={`/${team.slug}/articles/all`}
                 onClick={() => setDrawerTypeChange('articles')}
               >
                 <DescriptionIcon />


### PR DESCRIPTION
## Description

This PR adds a new article list called "All Articles." As the name suggests, it includes all articles (fact-checks and explainers) and serves as the default option when "Articles" is clicked in the sidebar.

As part of this work, this PR also significantly refactors the article list components. The logic for update mutations and sorting options, which was previously duplicated across multiple components, has been moved to the abstract "Articles.js" component.

Reference: CV2-5007.

## How to test?

For all articles lists (including this new "all articles" list), please test:

- [ ] Filters
- [ ] Sorting
- [ ] Clicking on an article to view/edit it in the slide-out
- [ ] Accessing an article from the URL (e.g., with `explainerId=` or `factCheckId=` in the URL)
- [ ] Export list

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).