### PR TITLE
CV2-5821 added active but unused platform into dropdown list of platforms

### DIFF
--- a/src/app/components/dashboard/TiplineDashboard.js
+++ b/src/app/components/dashboard/TiplineDashboard.js
@@ -48,7 +48,7 @@ const TiplineDashboard = ({
             selectedLanguage={language || 'all'}
             onSubmit={onChangeLanguage}
           />
-          <PlatformSelect platforms={team.statistics_platforms} value={platform || 'all'} onChange={onChangePlatform} />
+          <PlatformSelect platforms={[...new Set([...team.statistics_platforms, ...Object.keys(team.team_bot_installation?.smooch_enabled_integrations)])]} value={platform || 'all'} onChange={onChangePlatform} />
         </div>
         <div>
           <ExportList filters={{ language, period, platform }} type="tipline_dashboard" />
@@ -115,6 +115,7 @@ TiplineDashboard.propTypes = {
     slug: PropTypes.string.isRequired,
     statistics: PropTypes.object.isRequired,
     statistics_platforms: PropTypes.array.isRequired,
+    team_bot_installation: PropTypes.object.isRequired,
   }).isRequired,
   onChangeLanguage: PropTypes.func.isRequired,
   onChangePeriod: PropTypes.func.isRequired,
@@ -150,6 +151,9 @@ const TiplineDashboardQueryRenderer = ({ routeParams }) => {
                 get_languages
                 data_report
                 statistics_platforms
+                team_bot_installation(bot_identifier: "smooch") {
+                  smooch_enabled_integrations(force: true)
+                }
                 statistics(period: $period, platform: $platform, language: $language) {
                   ...ListTopMediaTags_statistics
                   ...ListTopRequestedMediaClusters_statistics


### PR DESCRIPTION
## Description

Added in unused but active tiplines to the platform dropdown list, per Jessie's request 

References: CV2-5821

## How to test?

Add a new tipline (or just overwrite team_bot_installation.smooch_enabled_integrations and fake it) that doesn't have data, and verify it's in the dropdown Platform list 

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
