### PR TITLE
CV2-6186 redirect to not found page if team slug is bad

### DIFF
--- a/src/app/components/drawer/DrawerNavigation.js
+++ b/src/app/components/drawer/DrawerNavigation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay/classic';
+import { browserHistory } from 'react-router';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Drawer from '@material-ui/core/Drawer';
 import DrawerRail from './DrawerRail';
@@ -34,12 +35,16 @@ const DrawerNavigation = (parentProps) => {
             query={graphql`
               query DrawerNavigationQuery($teamSlug: String!) {
                 find_public_team(slug: $teamSlug) {
+                  dbid
                   ...DrawerRail_team
                 }
               }
             `}
             render={({ error, props }) => {
               if (!error && props) {
+                if (!props.find_public_team.dbid) {
+                  browserHistory.push('/check/not-found');
+                }
                 return (
                   <>
                     <DrawerRail


### PR DESCRIPTION
## Description

find_public_team won't error when given an incorrect id or slug, but the properties will be undefined.  If the dbid is undefined, we redirect to the check/not-found page rather than showing a half-broken page.  From there, the rail links use the last used team so the user can navigate back to the last team that worked. 

References: CV2-6186

## How to test?

Go to <base-url>/team-slug with a team that does not exist.  The user should now be redirected to check/not-found.  

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
