### PR TITLE
Remove all references to  annotation

### DIFF
--- a/src/app/components/user/UserPrivacy.js
+++ b/src/app/components/user/UserPrivacy.js
@@ -180,7 +180,7 @@ const UserPrivacy = (props, context) => {
             <FormattedMessage defaultMessage="Delete your account" description="Page title for the user to delete their account" id="userPrivacy.delete" />
           </div>
           <FormattedMessage
-            defaultMessage="If you delete your account, your personal information will be erased. Comments, annotations, and workspace activity will become pseudonymous and remain on {appName}."
+            defaultMessage="If you delete your account, your personal information will be erased. Annotations, and workspace activity will become pseudonymous and remain on {appName}."
             description="Text to tell the user what will happen to their personal information when their account is removed"
             id="userPrivacy.deleteAccountText"
             tagName="p"

--- a/src/app/relay/mutations/DeleteAnnotationMutation.js
+++ b/src/app/relay/mutations/DeleteAnnotationMutation.js
@@ -16,7 +16,7 @@ class DeleteAnnotationMutation extends Relay.Mutation {
     case 'source':
       return Relay.QL`fragment on DestroyAnnotationPayload { deletedId, source { id } }`;
     case 'project_media':
-      return Relay.QL`fragment on DestroyAnnotationPayload { deletedId, project_media { log, tags, comments, tasks, last_status, last_status_obj { id } } }`;
+      return Relay.QL`fragment on DestroyAnnotationPayload { deletedId, project_media { log, tags, tasks, last_status, last_status_obj { id } } }`;
     case 'task':
       return Relay.QL`fragment on DestroyAnnotationPayload { deletedId, task { id } }`;
     default:

--- a/src/app/relay/mutations/optimisticProjectMedia.js
+++ b/src/app/relay/mutations/optimisticProjectMedia.js
@@ -56,7 +56,6 @@ const optimisticProjectMedia = (media, proj, context, customTeam) => {
           'read ProjectMedia': true,
           'update ProjectMedia': false,
           'destroy ProjectMedia': false,
-          'create Comment': false,
           'create Flag': false,
           'create Status': false,
           'create Tag': false,


### PR DESCRIPTION
## Description

We are cleaning up references to `Comment` annotation type, which has been deprecated. 

References: CV2-6063

## How to test?

Confirm that no all tests pass and no references to `Comment` remain in the codebase.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
