### PR TITLE
Fixing how URL parameter is set when an article is clicked from the "All Articles" list.

### DIFF
--- a/localization/react-intl/src/app/components/user/UserPrivacy.json
+++ b/localization/react-intl/src/app/components/user/UserPrivacy.json
@@ -62,7 +62,7 @@
   {
     "id": "userPrivacy.deleteAccountText",
     "description": "Text to tell the user what will happen to their personal information when their account is removed",
-    "defaultMessage": "If you delete your account, your personal information will be erased. Comments, annotations, and workspace activity will become pseudonymous and remain on {appName}."
+    "defaultMessage": "If you delete your account, your personal information will be erased. Annotations, and workspace activity will become pseudonymous and remain on {appName}."
   },
   {
     "id": "userPrivacy.deleteAccountButton",

--- a/src/app/components/article/Articles.js
+++ b/src/app/components/article/Articles.js
@@ -17,8 +17,8 @@ import ListSort from '../cds/inputs/ListSort';
 import { getStatus, isFactCheckValueBlank } from '../../helpers';
 import {
   getQueryStringValue,
-  pushQueryStringValue,
-  deleteQueryStringValue,
+  deleteAndPushQueryStringValue,
+  deleteQueryStringValues,
   pageSize,
 } from '../../urlHelpers';
 import Loader from '../cds/loading/Loader';
@@ -180,7 +180,7 @@ const ArticlesComponent = ({
   };
 
   const handleCloseSlideout = () => {
-    if (selectedArticle.type) deleteQueryStringValue(selectedArticle.type === 'explainer' ? 'explainerId' : 'factCheckId');
+    if (selectedArticle.type) deleteQueryStringValues(['explainerId', 'factCheckId']);
     setSelectedArticle({});
   };
 
@@ -223,7 +223,7 @@ const ArticlesComponent = ({
       setSelectedArticle({});
       setTimeout(() => {
         setSelectedArticle({ id: article.dbid, type: article.type });
-        pushQueryStringValue(article.type === 'explainer' ? 'explainerId' : 'factCheckId', article.dbid);
+        deleteAndPushQueryStringValue(article.type === 'explainer' ? 'factCheckId' : 'explainerId', article.type === 'explainer' ? 'explainerId' : 'factCheckId', article.dbid);
       }, 10);
     }
   };

--- a/src/app/urlHelpers.js
+++ b/src/app/urlHelpers.js
@@ -14,21 +14,22 @@ function getQueryStringValue(key) {
   return params.get(key);
 }
 
-function pushQueryStringValue(key, value) {
-  const url = new URL(window.location);
-  url.searchParams.set(key, value);
-  window.history.pushState({}, '', url);
-}
-
 function replaceQueryStringValue(key, value) {
   const url = new URL(window.location);
   url.searchParams.set(key, value);
   window.history.replaceState({}, '', url);
 }
 
-function deleteQueryStringValue(key) {
+function deleteQueryStringValues(keys) {
   const url = new URL(window.location);
-  url.searchParams.delete(key);
+  keys.map(key => url.searchParams.delete(key));
+  window.history.pushState({}, '', url);
+}
+
+function deleteAndPushQueryStringValue(deleteKey, pushKey, value) {
+  const url = new URL(window.location);
+  url.searchParams.delete(deleteKey);
+  url.searchParams.set(pushKey, value);
   window.history.pushState({}, '', url);
 }
 
@@ -146,8 +147,8 @@ export {
   getListUrlQueryAndIndex,
   getPathnameAndSearch,
   getQueryStringValue,
-  pushQueryStringValue,
   replaceQueryStringValue,
-  deleteQueryStringValue,
+  deleteQueryStringValues,
+  deleteAndPushQueryStringValue,
   pageSize,
 }; // eslint-disable-line import/prefer-default-export


### PR DESCRIPTION
## Description

Make sure that in the URL we have either `factCheckId` or `explainerId` in the URL, never both.

Reference: CV2-5007.

## How to test?

Manually: From the "All Articles" list, click on different articles, and make sure that the right article is loaded in the slideout and that the URL contains either an `explainerId` or `factCheckId`, never both.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
