### PR TITLE
Adding "Article type" filter to articles pages.

### DIFF
--- a/localization/react-intl/src/app/components/search/AddFilterMenu.json
+++ b/localization/react-intl/src/app/components/search/AddFilterMenu.json
@@ -50,6 +50,11 @@
     "defaultMessage": "Media (count)"
   },
   {
+    "id": "addFilterMenu.articleType",
+    "description": "Menu option to enable searching items by article type",
+    "defaultMessage": "Article (type)"
+  },
+  {
     "id": "addFilterMenu.mediaType",
     "description": "Menu option to enable searching items by media type",
     "defaultMessage": "Media (type)"

--- a/src/app/components/article/ArticleFilters.js
+++ b/src/app/components/article/ArticleFilters.js
@@ -41,7 +41,6 @@ const ArticleFilters = ({
   onSubmit,
   statuses,
   teamSlug,
-  type,
 }) => {
   const [filters, setFilters] = React.useState({ ...currentFilters });
 
@@ -170,7 +169,7 @@ const ArticleFilters = ({
             );
           }
 
-          if (filter === 'article_type' && type) {
+          if (filter === 'article_type') {
             return (
               <React.Fragment key={filter}>
                 {connector}
@@ -183,8 +182,10 @@ const ArticleFilters = ({
                     { value: 'fact-check', label: intl.formatMessage(messages.factCheck) },
                   ]}
                   readOnly={articleTypeReadOnly}
-                  selected={[type]}
+                  selected={value || []}
                   single
+                  onChange={(newValue) => { handleOptionChange('article_type', newValue); }}
+                  onRemove={() => handleRemoveFilter('article_type')}
                 />
               </React.Fragment>
             );
@@ -277,7 +278,7 @@ const ArticleFilters = ({
         })}
         <AddFilterMenu
           addedFields={Object.keys(filters)}
-          showOptions={filterOptions}
+          showOptions={filterOptions.concat(['article_type'])}
           team={{}}
           onSelect={handleAddFilter}
         />
@@ -326,7 +327,6 @@ ArticleFilters.defaultProps = {
   defaultFilters: {},
   extra: null,
   filterOptions: [],
-  type: null,
 };
 
 ArticleFilters.propTypes = {
@@ -341,7 +341,6 @@ ArticleFilters.propTypes = {
     label: PropTypes.string.isRequired,
   }).isRequired).isRequired,
   teamSlug: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(['explainer', 'fact-check', null]),
   onSubmit: PropTypes.func.isRequired,
 };
 

--- a/src/app/components/article/Explainers.js
+++ b/src/app/components/article/Explainers.js
@@ -6,12 +6,11 @@ import BookIcon from '../../icons/book.svg';
 
 const Explainers = ({ routeParams }) => (
   <Articles
-    articleTypeReadOnly
+    defaultFilters={{ article_type: 'explainer' }}
     filterOptions={['users', 'tags', 'range', 'language_filter']}
     icon={<BookIcon />}
     teamSlug={routeParams.team}
     title={<FormattedMessage defaultMessage="Explainers" description="Title of the explainers page." id="explainers.title" />}
-    type="explainer"
   />
 );
 

--- a/src/app/components/article/FactChecks.js
+++ b/src/app/components/article/FactChecks.js
@@ -6,12 +6,11 @@ import FactCheckIcon from '../../icons/fact_check.svg';
 
 const FactChecks = ({ routeParams }) => (
   <Articles
-    articleTypeReadOnly
+    defaultFilters={{ article_type: 'fact-check' }}
     filterOptions={['users', 'tags', 'range', 'language_filter', 'published_by', 'report_status', 'verification_status']}
     icon={<FactCheckIcon />}
     teamSlug={routeParams.team}
     title={<FormattedMessage defaultMessage="Claim & Fact-Checks" description="Title of the fact-checks page." id="factChecks.title" />}
-    type="fact-check"
   />
 );
 

--- a/src/app/components/article/ImportedArticles.js
+++ b/src/app/components/article/ImportedArticles.js
@@ -6,13 +6,11 @@ import FileDownloadIcon from '../../icons/file_download.svg';
 
 const ImportedArticles = ({ routeParams }) => (
   <Articles
-    articleTypeReadOnly
-    defaultFilters={{ imported: true }}
+    defaultFilters={{ article_type: 'fact-check', imported: true }}
     filterOptions={['tags', 'range', 'imported', 'language_filter']}
     icon={<FileDownloadIcon />}
     teamSlug={routeParams.team}
     title={<FormattedMessage defaultMessage="Imported" description="Title of the imported articles page." id="importedArticles.title" />}
-    type="fact-check"
   />
 );
 

--- a/src/app/components/article/PublishedArticles.js
+++ b/src/app/components/article/PublishedArticles.js
@@ -6,13 +6,11 @@ import PublishedIcon from '../../icons/playlist_add_check.svg';
 
 const PublishedArticles = ({ routeParams }) => (
   <Articles
-    articleTypeReadOnly
-    defaultFilters={{ report_status: 'published' }}
+    defaultFilters={{ article_type: 'fact-check', report_status: 'published' }}
     filterOptions={['users', 'tags', 'range', 'verification_status', 'language_filter', 'published_by']}
     icon={<PublishedIcon />}
     teamSlug={routeParams.team}
     title={<FormattedMessage defaultMessage="Published" description="Title of the published articles page." id="publishedArticles.title" />}
-    type="fact-check"
   />
 );
 

--- a/src/app/components/search/AddFilterMenu.js
+++ b/src/app/components/search/AddFilterMenu.js
@@ -159,6 +159,18 @@ const AddFilterMenu = ({
       ),
     },
     {
+      id: 'add-filter-menu__article-type',
+      key: 'article_type',
+      icon: <DescriptionIcon />,
+      label: (
+        <FormattedMessage
+          defaultMessage="Article (type)"
+          description="Menu option to enable searching items by article type"
+          id="addFilterMenu.articleType"
+        />
+      ),
+    },
+    {
       id: 'add-filter-menu__media-type',
       key: 'show',
       icon: <DescriptionIcon />,


### PR DESCRIPTION
## Description

Adding "Article type" filter to "All Articles" and "Articles Trash" pages. Also, some refactoring for simplicity, by unifying: `type`, `articleTypeReadOnly` and relying on `defaultFilters.article_type` for most of the logic.

Reference: CV2-5007.

## How to test?

Manually: Make sure that the "Article type" filter works as expected for each articles list page.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).