### PR TITLE
Fix: Update readOnly Logic for WhatsApp Integration in SmoochBotIntegrations

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
+++ b/src/app/components/team/SmoochBot/SmoochBotIntegrations.js
@@ -187,7 +187,7 @@ const SmoochBotIntegrations = ({ enabledIntegrations, installationId, settings }
           label="WhatsApp"
           online={isOnline('whatsapp')}
           permanentDisconnection
-          readOnly={isWabaSet || isCapiSet}
+          readOnly={!(isWabaSet || isCapiSet)}
           skipUrlConfirmation
           type="whatsapp"
           url="https://airtable.com/shrAhYXEFGe7F9QHr"


### PR DESCRIPTION
## Description

This PR fixes an issue where the WhatsApp integration button in SmoochBotIntegrations was incorrectly disabled due to incorrect readOnly prop logic. The button should be enabled (not read-only) when at least one of isWabaSet or isCapiSet is true, as this means the integration is active and can be uninstalled.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
