### PR TITLE
Fix: add missing graphql field after the refactoring

### DIFF
--- a/src/app/components/user/UserInfoEdit.js
+++ b/src/app/components/user/UserInfoEdit.js
@@ -488,6 +488,7 @@ export default createFragmentContainer(withSetFlashMessage(injectIntl(UserInfoEd
         id
         dbid
         created_at
+        image
       }
     }
   `,


### PR DESCRIPTION
## Description

Add the missing field in the user edit query to display the image in the user Profile

Reference: CV2-6270

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
