### PR TITLE
Upgrading actions/cache to v4

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -32,7 +32,7 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: /tmp/.buildx-cache


### PR DESCRIPTION
## Description

Upgrading `actions/cache` to v4 in GitHub Actions. Fixes a broken workflow.

References: No Jira ticket attached.

## How to test?

CI should pass now. It was failing with a deprecation working.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
