### PR TITLE
Get saved_search_id on mutation response and safety check to avoid crash

### DIFF
--- a/src/app/components/feed/FeedActions.js
+++ b/src/app/components/feed/FeedActions.js
@@ -122,7 +122,7 @@ const FeedActions = ({
               <Alert
                 content={
                   <ul className="bulleted-list">
-                    <li>{feed.saved_search.title}</li>
+                    <li>{feed.saved_search?.title}</li>
                   </ul>
                 }
                 title={

--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -62,6 +62,7 @@ const updateMutation = graphql`
     updateFeed(input: $input) {
       feed {
         dbid
+        saved_search_id
         saved_search {
           is_part_of_feeds
         }


### PR DESCRIPTION
## Description

Get saved_search_id on mutation response and safety check to avoid crash

References: CV2-5827

## How to test?

- Create a Feed, share a list with it
- Edit the Feed, remove the sharing of the list and save
- The app should not Crash

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
