### PR TITLE
Refactoring/CV2-5203: Return all items that match a search

### DIFF
--- a/localization/react-intl/src/app/components/media/AutoCompleteMediaItem.json
+++ b/localization/react-intl/src/app/components/media/AutoCompleteMediaItem.json
@@ -43,5 +43,10 @@
     "id": "autoCompleteMediaItem.cantSelectPublished",
     "description": "Tooltip error message about when media can be imported",
     "defaultMessage": "Media cannot be imported from items that have their report published"
+  },
+  {
+    "id": "autoCompleteMediaItem.factcheckInUseTooltip",
+    "description": "Tooltip message displayed on article cards on item page for fact-check type articles.",
+    "defaultMessage": "This Claim & Fact-Check article is already applied to another media cluster<br /><br />Remove it from its current media cluster in order to add it here."
   }
 ]

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -245,6 +245,10 @@ const AutoCompleteMediaItem = (props, context) => {
         let items = response.data.search.medias.edges.map(({ node }) => node);
         if (props.customFilter) {
           items = props.customFilter(items);
+        } else {
+          items = items
+            .filter(({ is_confirmed_similar_to_another_item }) =>
+              !is_confirmed_similar_to_another_item);
         }
         items = items
           .filter(({ dbid }) => dbid !== props.dbid);
@@ -343,6 +347,8 @@ const AutoCompleteMediaItem = (props, context) => {
             if (projectMedia.fact_check?.rating) {
               currentStatus = getStatus(searchResult.team.verification_statuses, projectMedia.fact_check.rating);
             }
+
+            const factCheckInUse = projectMedia.media.type !== 'Blank';
 
             return (
               <div

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -239,16 +239,20 @@ const AutoCompleteMediaItem = (props, context) => {
         return;
       }
 
+      // eslint-disable-next-line
+      console.log('Search response:', response.data.search);
+      // eslint-disable-next-line
+      console.log('custom Filter:', props.customFilter);
       // The rest of this code is synchronous, so it can't be aborted.
       try {
         const { team } = response.data.search;
         let items = response.data.search.medias.edges.map(({ node }) => node);
+        // eslint-disable-next-line
+        console.log('Items:', items);
         if (props.customFilter) {
           items = props.customFilter(items);
-        } else {
-          items = items
-            .filter(({ is_confirmed_similar_to_another_item }) =>
-              !is_confirmed_similar_to_another_item);
+          // eslint-disable-next-line
+          console.log('Filtered items:', items);
         }
         items = items
           .filter(({ dbid }) => dbid !== props.dbid);

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -243,12 +243,8 @@ const AutoCompleteMediaItem = (props, context) => {
       try {
         const { team } = response.data.search;
         let items = response.data.search.medias.edges.map(({ node }) => node);
-        // eslint-disable-next-line
-        console.log('Items:', items);
         if (props.customFilter) {
           items = props.customFilter(items);
-          // eslint-disable-next-line
-          console.log('Filtered items:', items);
         }
         items = items
           .filter(({ dbid }) => dbid !== props.dbid);

--- a/src/app/components/media/AutoCompleteMediaItem.js
+++ b/src/app/components/media/AutoCompleteMediaItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage, FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { Link } from 'react-router';
 import Checkbox from '@material-ui/core/Checkbox';
 import config from 'config'; // eslint-disable-line require-path-exists/exists
@@ -102,7 +102,7 @@ const AutoCompleteMediaItem = (props, context) => {
 
   const query = {
     keyword: encodeURIComponent(searchText),
-    show: props.typesToShow || ['claims', 'links', 'images', 'videos', 'audios'],
+    show: ['claims', 'links', 'images', 'videos', 'audios', 'blank'],
     eslimit: 50,
     archived: [CheckArchivedFlags.NONE, CheckArchivedFlags.UNCONFIRMED],
     show_similar: Boolean(props.customFilter),
@@ -239,10 +239,6 @@ const AutoCompleteMediaItem = (props, context) => {
         return;
       }
 
-      // eslint-disable-next-line
-      console.log('Search response:', response.data.search);
-      // eslint-disable-next-line
-      console.log('custom Filter:', props.customFilter);
       // The rest of this code is synchronous, so it can't be aborted.
       try {
         const { team } = response.data.search;
@@ -351,6 +347,7 @@ const AutoCompleteMediaItem = (props, context) => {
             if (projectMedia.fact_check?.rating) {
               currentStatus = getStatus(searchResult.team.verification_statuses, projectMedia.fact_check.rating);
             }
+
             return (
               <div
                 className={props.multiple ? styles['media-item-autocomplete-multiple'] : 'autocomplete-media-item__select'}
@@ -382,24 +379,41 @@ const AutoCompleteMediaItem = (props, context) => {
                   </Tooltip> : null
                 }
                 { props.selectedItemType === 'fact-check' ?
-                  <ArticleCard
-                    className={selectedDbid === projectMedia.dbid ? styles['media-item-autocomplete-selected-item'] : null}
-                    date={projectMedia.fact_check.updated_at}
-                    handleClick={e => handleClick(e, projectMedia.dbid)}
-                    isPublished={projectMedia.fact_check.report_status === 'published'}
-                    key={projectMedia.id}
-                    languageCode={projectMedia.fact_check.language !== 'und' ? projectMedia.fact_check.language : null}
-                    publishedAt={projectMedia.fact_check.claim_description?.updated_at}
-                    readOnly
-                    statusColor={currentStatus ? currentStatus.style?.color : null}
-                    statusLabel={currentStatus ? currentStatus.label : null}
-                    summary={isFactCheckValueBlank(projectMedia.fact_check.summary) ? projectMedia.fact_check.claim_description?.description : projectMedia.fact_check.summary}
-                    tags={projectMedia.fact_check.tags}
-                    title={isFactCheckValueBlank(projectMedia.fact_check.title) ? projectMedia.fact_check.claim_description?.context : projectMedia.fact_check.title}
-                    url={projectMedia.fact_check.url}
-                    variant="fact-check"
-                    onChangeTags={() => {}}
-                  />
+                  <Tooltip
+                    arrow
+                    disableFocusListener={!factCheckInUse}
+                    disableHoverListener={!factCheckInUse}
+                    disableTouchListener={!factCheckInUse}
+                    title={
+                      factCheckInUse ?
+                        <FormattedHTMLMessage defaultMessage="This Claim & Fact-Check article is already applied to another media cluster<br /><br />Remove it from its current media cluster in order to add it here." description="Tooltip message displayed on article cards on item page for fact-check type articles." id="autoCompleteMediaItem.factcheckInUseTooltip" />
+                        : ''
+                    }
+                  >
+                    <span>
+                      <ArticleCard
+                        className={cx(
+                          selectedDbid === projectMedia.dbid ? styles['media-item-autocomplete-selected-item'] : null,
+                          factCheckInUse ? styles['disabled-card'] : null,
+                        )}
+                        date={projectMedia.fact_check.updated_at}
+                        handleClick={factCheckInUse ? null : (e => handleClick(e, projectMedia.dbid))}
+                        isPublished={projectMedia.fact_check.report_status === 'published'}
+                        key={projectMedia.id}
+                        languageCode={projectMedia.fact_check.language !== 'und' ? projectMedia.fact_check.language : null}
+                        publishedAt={projectMedia.fact_check.claim_description?.updated_at}
+                        readOnly
+                        statusColor={currentStatus ? currentStatus.style?.color : null}
+                        statusLabel={currentStatus ? currentStatus.label : null}
+                        summary={isFactCheckValueBlank(projectMedia.fact_check.summary) ? projectMedia.fact_check.claim_description?.description : projectMedia.fact_check.summary}
+                        tags={projectMedia.fact_check.tags}
+                        title={isFactCheckValueBlank(projectMedia.fact_check.title) ? projectMedia.fact_check.claim_description?.context : projectMedia.fact_check.title}
+                        url={projectMedia.fact_check.url}
+                        variant="fact-check"
+                        onChangeTags={() => {}}
+                      />
+                    </span>
+                  </Tooltip>
                   :
                   <Link className={styles['media-item-autocomplete-link']} to={projectMedia.full_url}>
                     <SmallMediaCard
@@ -461,7 +475,6 @@ AutoCompleteMediaItem.defaultProps = {
   ignoreGeneralContentMask: true,
   multiple: false,
   showFilters: false,
-  typesToShow: ['claims', 'links', 'images', 'videos', 'audios'],
 };
 
 AutoCompleteMediaItem.propTypes = {
@@ -471,7 +484,6 @@ AutoCompleteMediaItem.propTypes = {
   ignoreGeneralContentMask: PropTypes.bool,
   multiple: PropTypes.bool,
   showFilters: PropTypes.bool,
-  typesToShow: PropTypes.arrayOf(PropTypes.string),
   // onSelect: PropTypes.func.isRequired, // func({ value, text } or null) => undefined
 };
 

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -243,7 +243,7 @@ class CreateRelatedMediaDialog extends React.Component {
               <AutoCompleteMediaItem
                 customFilter={this.props.customFilter}
                 dbid={media ? media.dbid : null}
-                // disablePublished={Boolean(this.props.disablePublished)}
+                disablePublished={Boolean(this.props.disablePublished)}
                 ignoreGeneralContentMask={false}
                 key={action}
                 media={media}

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -246,7 +246,7 @@ class CreateRelatedMediaDialog extends React.Component {
               <AutoCompleteMediaItem
                 customFilter={this.props.customFilter}
                 dbid={media ? media.dbid : null}
-                disablePublished={Boolean(this.props.disablePublished)}
+                // disablePublished={Boolean(this.props.disablePublished)}
                 ignoreGeneralContentMask={false}
                 key={action}
                 media={media}

--- a/src/app/components/media/CreateRelatedMediaDialog.js
+++ b/src/app/components/media/CreateRelatedMediaDialog.js
@@ -28,7 +28,6 @@ class CreateRelatedMediaDialog extends React.Component {
       mode: 'existing',
       selectedItem: null, // Used when action = addThisToSimilar
       selectedItems: [], // Used when action = addSimilarToThis
-      typesToShow: props.typesToShow, // When null, shows all non-blank types
     };
   }
 
@@ -39,7 +38,6 @@ class CreateRelatedMediaDialog extends React.Component {
         selectedItem: null,
         selectedItems: [],
         selectedItemType: 'fact-check',
-        typesToShow: ['blank'],
       });
     } else if (action !== null) {
       this.setState({
@@ -47,7 +45,6 @@ class CreateRelatedMediaDialog extends React.Component {
         selectedItem: null,
         selectedItems: [],
         selectedItemType: 'media',
-        typesToShow: null,
       });
     }
   };
@@ -253,7 +250,6 @@ class CreateRelatedMediaDialog extends React.Component {
                 multiple={action === 'addSimilarToThis'}
                 selectedItemType={this.state.selectedItemType}
                 showFilters={Boolean(this.props.showFilters)}
-                typesToShow={this.state.typesToShow}
                 onSelect={this.handleSelectExisting}
               />
             </>

--- a/src/app/components/media/media.module.css
+++ b/src/app/components/media/media.module.css
@@ -413,3 +413,11 @@ body[dir='rtl'] {
     }
   }
 }
+
+.disabled-card {
+  opacity: .45;
+
+  &:hover {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description

Previously, when a fact-check was linked to another item, it was excluded from search results. We modified the query parameter to return all media types to ensure that items appear in search results along with their associated fact-checks. For the fact-check tab, it was only returning items of blank type:
[AutoCompleteMediaItem.js#L105](https://github.com/meedan/check-web/blob/develop/src/app/components/media/AutoCompleteMediaItem.js#L105).

Additionally, added a tooltip to inform users that the fact-check is not applicable and disabled the item to prevent selection.

Reference: CV2-5203

## How to test?

- [ ] Go to an item page and click on "Merge media cluster".
- [ ] Navigate to the "Add to imported Fact Check" tab.
- [ ] Search for a fact-check that is already in use:
- [ ] Verify that it is not clickable.
- [ ] Hover over it and check if a tooltip appears, explaining that the fact-check is already in use.
- [ ] Search for a fact-check that is not in use:
- [ ] Verify that it is selectable.
- [ ] Select it and confirm that it can be added to the item successfully.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
