### PR TITLE
Prevent throwing error when smooch is not installed

### DIFF
--- a/src/app/components/dashboard/TiplineDashboard.js
+++ b/src/app/components/dashboard/TiplineDashboard.js
@@ -48,7 +48,7 @@ const TiplineDashboard = ({
             selectedLanguage={language || 'all'}
             onSubmit={onChangeLanguage}
           />
-          <PlatformSelect platforms={[...new Set([...team.statistics_platforms, ...Object.keys(team.team_bot_installation?.smooch_enabled_integrations)])]} value={platform || 'all'} onChange={onChangePlatform} />
+          <PlatformSelect platforms={[...new Set([...team.statistics_platforms, ...Object.keys(team.team_bot_installation?.smooch_enabled_integrations || {})])]} value={platform || 'all'} onChange={onChangePlatform} />
         </div>
         <div>
           <ExportList filters={{ language, period, platform }} type="tipline_dashboard" />


### PR DESCRIPTION
## Description

Prevents throwing error when smooch is not installed by offering an empty object fallback to `Object.keys()`

References: CV2-6279

## How to test?

Load the Tipline Dashboard to a workspace which doesn't have smooch bot installed.

Expected: It should not crash

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
