### PR TITLE
Feature/5599 shared feed workspace logos

### DIFF
--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -137,8 +137,10 @@ const FeedTopBar = ({
     );
   };
 
-  const currentOrg = feed.teams?.edges.find(feedTeam => feedTeam.node.slug === team.slug).node;
-  const teamsWithoutCurrentOrg = feed.teams?.edges.filter(feedTeam => feedTeam.node.slug !== team.slug);
+  const currentOrg = feed.feed_teams?.edges.find(feedTeam => feedTeam.node.team.slug === team.slug).node.team;
+  const teamsWithoutCurrentOrg = feed.feed_teams?.edges
+    .filter(feedTeam => feedTeam.node.team.slug !== team.slug)
+    .filter(feedTeam => Boolean(feedTeam.node.saved_search_id));
 
   return (
     <div className={searchResultsStyles['search-results-top-extra']}>
@@ -159,7 +161,7 @@ const FeedTopBar = ({
               dbid,
               name,
               slug,
-            } = feedTeam.node;
+            } = feedTeam.node.team;
             return (
               <OrgFilterButton
                 avatar={avatar}
@@ -240,13 +242,16 @@ export default createFragmentContainer(FeedTopBar, graphql`
     dbid
     published
     permissions
-    teams(first: 1000) {
+    feed_teams(first: 1000) {
       edges {
         node {
-          dbid
-          avatar
-          name
-          slug
+          saved_search_id
+          team {
+            dbid
+            avatar
+            name
+            slug
+          }
         }
       }
     }

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -21,13 +21,6 @@ const FeedTopBar = ({
   team,
   teamFilters,
 }) => {
-  const hasList = Boolean(feed.saved_search);
-
-  const handleClick = () => {
-    const customListDbid = feed.current_feed_team.saved_search?.dbid || feed.saved_search.dbid;
-    browserHistory.push(`/${team.slug}/list/${customListDbid}`);
-  };
-
   const handleClickAdd = () => {
     browserHistory.push(`/${team.slug}/feed/${feed.dbid}/edit`);
   };
@@ -39,6 +32,7 @@ const FeedTopBar = ({
   const OrgFilterButton = ({
     avatar,
     current,
+    customListDbid,
     dbid,
     enabled,
     name,
@@ -97,7 +91,7 @@ const FeedTopBar = ({
               {
                 [styles.feedTopBarButton]: enabled,
                 [styles.feedTopBarButtonDisabled]: !enabled,
-                [styles.feedTopBarButtonHasList]: current && hasList,
+                [styles.feedTopBarButtonHasList]: current && customListDbid,
               })
             }
             onClick={handleFilterClick}
@@ -107,7 +101,7 @@ const FeedTopBar = ({
               current && (
                 <div className="typography-body2">
                   {
-                    hasList ?
+                    customListDbid ?
                       <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
                         <span className={styles.feedListTitle}>{feed.current_feed_team?.saved_search?.title || feed.saved_search.title}</span>
                       </div> :
@@ -117,7 +111,7 @@ const FeedTopBar = ({
             }
           </button>
         </Tooltip>
-        { current && hasList && (
+        { current && customListDbid && (
           <Tooltip
             arrow
             placement="right"
@@ -134,7 +128,7 @@ const FeedTopBar = ({
                 size="small"
                 theme="lightText"
                 variant="contained"
-                onClick={handleClick}
+                onClick={() => browserHistory.push(`/${team.slug}/list/${customListDbid}`)}
               />
             </span>
           </Tooltip>
@@ -153,6 +147,7 @@ const FeedTopBar = ({
           <OrgFilterButton
             avatar={currentOrg.avatar}
             current
+            customListDbid={feed.current_feed_team?.saved_search?.dbid || feed.saved_search?.dbid}
             dbid={currentOrg.dbid}
             enabled={teamFilters.includes(currentOrg.dbid)}
             name={currentOrg.name}

--- a/src/app/components/feed/FeedTopBar.test.js
+++ b/src/app/components/feed/FeedTopBar.test.js
@@ -9,13 +9,15 @@ const feed = {
     dbid: 1,
     title: 'Test',
   },
-  teams: {
+  feed_teams: {
     edges: [
       {
         node: {
-          dbid: 1,
-          slug: 'test',
-          avatar: 'https://example.com',
+          team: {
+            dbid: 1,
+            slug: 'test',
+            avatar: 'https://example.com',
+          },
         },
       },
     ],


### PR DESCRIPTION
## Description

- Fixes incorrect `hastList` logic: it previously used the value derived from the `Feed` instead of the `FeedTeam`.
- Filters out workspaces not sharing a list

References: CV2-5599

## How to test?

- Go to a Shared Feed
- Check the participating org avatar icon list in the top bar
- Expected: Orgs not sharing a list should not have an icon button present

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
