### PR TITLE
Adding a `key` prop to the `<Media />` component in order to ensure it remounts if the media changes

### DIFF
--- a/src/app/components/media/MediaPageLayout.js
+++ b/src/app/components/media/MediaPageLayout.js
@@ -24,7 +24,7 @@ export default function MediaPageLayout({
       ) : null}
       <div className={styles['media-actions-bar']}>
         <MediaActionsBar
-          key={`media-actions-bar-${listUrl}-${projectMediaId}`
+          key={`media-actions-bar-${listUrl}-${projectMediaId}`}
           listIndex={listIndex}
           listQuery={listQuery}
           listUrl={listUrl}
@@ -33,7 +33,7 @@ export default function MediaPageLayout({
       </div>
       <div className={cx('test__media', styles['media-item'])}>
         <Media
-          key={`media-${listUrl}-${projectMediaId}`
+          key={`media-${listUrl}-${projectMediaId}`}
           projectMediaId={projectMediaId}
           view={view}
         />

--- a/src/app/components/media/MediaPageLayout.js
+++ b/src/app/components/media/MediaPageLayout.js
@@ -24,7 +24,7 @@ export default function MediaPageLayout({
       ) : null}
       <div className={styles['media-actions-bar']}>
         <MediaActionsBar
-          key={`${listUrl}-${projectMediaId}` /* TODO test MediaActionsBar is sane, then nix key */}
+          key={`media-actions-bar-${listUrl}-${projectMediaId}`
           listIndex={listIndex}
           listQuery={listQuery}
           listUrl={listUrl}
@@ -32,7 +32,11 @@ export default function MediaPageLayout({
         />
       </div>
       <div className={cx('test__media', styles['media-item'])}>
-        <Media projectMediaId={projectMediaId} view={view} />
+        <Media
+          key={`media-${listUrl}-${projectMediaId}`
+          projectMediaId={projectMediaId}
+          view={view}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

There is an issue (hard to reproduce) where, in the item page, the title component updates to the new media but the rest of the page still shows the old media. We traced it to a missing key prop on the component that renders the rest of the page. The title component had one, which is why it updated correctly. This fix ensures that component also gets properly re-mounted with the new media.

Fixes: CV2-6282.

## How to test?

Hard to test! 

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).