### PR TITLE
Renaming media channel "imported" to "batch" in order to be consistent with the respective "articles" channel

### DIFF
--- a/src/app/components/search/SearchFields/SearchFieldChannel.js
+++ b/src/app/components/search/SearchFields/SearchFieldChannel.js
@@ -30,9 +30,9 @@ const messages = defineMessages({
     description: 'Filter option that refers to items created via a tipline',
   },
   imported: {
-    id: 'searchFieldChannel.imported',
-    defaultMessage: 'Imported',
-    description: 'Filter option that refers to items imported from external systems',
+    id: 'searchFieldChannel.batchImported',
+    defaultMessage: 'Batch',
+    description: 'Filter option that refers to items batch-imported from external systems',
   },
   webForm: {
     id: 'searchFieldChannel.webForm',


### PR DESCRIPTION
## Description

Renaming media channel "imported" to "batch" in order to be consistent with the respective "articles" channel.

Reference: CV2-6039.

## How to test?

Manually: The former "Imported" option for the media "Channels" search filter should now read "Batch".

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
