### PR TITLE
Fix/CV2-6262: Do not display Messenger template messages in chat history

### DIFF
--- a/src/app/components/cds/chat/ChatFeed.test.js
+++ b/src/app/components/cds/chat/ChatFeed.test.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import ChatFeed from './ChatFeed';
+import Message from './Message';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+
+describe('<ChatFeed />', () => {
+  it('should skip Messenger template messages and render only valid messages', () => {
+    const history = [
+      {
+        dbid: 1,
+        event: null,
+        payload: {
+          text: null,
+          override: {
+            messenger: {
+              payload: {
+                tag: 'ACCOUNT_UPDATE',
+                messaging_type: 'MESSAGE_TAG',
+              },
+            },
+          },
+        },
+        sent_at: '1744455089',
+      },
+      {
+        dbid: 2,
+        direction: 'outgoing',
+        language: "en",
+        platform: "Facebook Messenger",
+        uid: "pizza112",
+        external_id: "pizza1723",
+        payload: {
+          text: 'Valid message',
+        },
+        sent_at: '1744455090',
+        state: 'sent',
+        media_url: null,
+        id: 'pizza112dsd',
+      },
+      {
+        dbid: 3,
+        event: null,
+        payload: {
+          text: '*FACT CHECK: NO Guinness World Record for Duterte birthday rallies*',
+          override: {
+            messenger: {
+              payload: {
+                tag: 'ACCOUNT_UPDATE',
+                message: {
+                  text: '*FACT CHECK: NO Guinness World Record for Duterte birthday rallies*',
+                },
+                messaging_type: 'MESSAGE_TAG',
+              },
+            },
+          },
+        },
+        sent_at: '1744455091',
+      },
+    ];
+
+    const wrapper = mountWithIntl(
+      <ChatFeed history={history} intl={{ locale: 'en' }} />,
+    );
+
+    expect(wrapper.find(Message).length).toBe(1); // Only one valid messages are rendered
+    expect(wrapper.text()).toContain('Valid message');
+    expect(wrapper.text()).not.toContain('*FACT CHECK: NO Guinness World Record for Duterte birthday rallies*');
+    expect(wrapper.text()).not.toContain('Unsupported message');
+  });
+});

--- a/src/app/components/cds/chat/Message.test.js
+++ b/src/app/components/cds/chat/Message.test.js
@@ -17,8 +17,6 @@ describe('<Message />', () => {
       />,
     );
 
-    // eslint-disable-next-line
-    // console.log(wrapper.debug());
     expect(wrapper.find('.typography-body1').text()).toContain('Unsupported message');
     expect(wrapper.find(IconBot).length).toBe(1);
   });

--- a/src/app/components/cds/chat/Message.test.js
+++ b/src/app/components/cds/chat/Message.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Message from './Message';
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+import IconBot from '../../../icons/smart_toy.svg';
+
+describe('<Message />', () => {
+  it('should display the unsupported message fallback when text is null', () => {
+    const wrapper = mountWithIntl(
+      <Message
+        content=""
+        dateTime="2025-04-15T12:00:00Z"
+        meessageId={32535974}
+        messageEvent={null}
+        userMessage={false}
+        userOnRight={false}
+        userSelection={false}
+      />,
+    );
+
+    // eslint-disable-next-line
+    // console.log(wrapper.debug());
+    expect(wrapper.find('.typography-body1').text()).toContain('Unsupported message');
+    expect(wrapper.find(IconBot).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

- [X]  Filter Messenger template messages (tag: ACCOUNT_UPDATE and message_type: MESSAGE_TAG) sent after 24h from being displayed in the chat, in order to avoid duplicates and unsupported messages
- [X] Add unit test in Messenger.test.js to reproduce and cover the issue
- [X]  Add unit test in ChatFeed.test.js to ensure the solution works as expected

References: CV2-6262

## How to test?

- Run the unit tests
- Manually check the chat history in the UI to ensure that unsupported or duplicate Messenger template messages are no longer shown after the 24h window

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
