### PR TITLE
Update integration test due to recent changes introduced in CV2-6325

### DIFF
--- a/test/spec/status_spec.rb
+++ b/test/spec/status_spec.rb
@@ -20,12 +20,11 @@ shared_examples 'status' do
     wait_for_selector('#confirm-dialog__confirm-action-button').click
     wait_for_selector_none('.edit-status-dialog__dismiss')
     expect(@driver.page_source.include?('newStatus')).to be(true)
-    expect(@driver.page_source.include?('Unstarted')).to be(false)
     # make another status as default
-    wait_for_selector_list('.status-actions__menu')[3].click
+    wait_for_selector_list('.status-actions__menu')[2].click
     wait_for_selector('.status-actions__make-default').click
     # delete status
-    wait_for_selector_list('.status-actions__menu')[2].click
+    wait_for_selector_list('.status-actions__menu')[1].click
     wait_for_selector('.status-actions__delete').click
     wait_for_selector('#confirm-dialog__confirm-action-button').click
     wait_for_selector_none('.status-actions__delete', :css, 3)


### PR DESCRIPTION
## Description

Fix test:
This test was broken due to recent changes introduced in CV2-6325, where verification statuses are now sorted alphabetically. The test was still asserting based on the previous (unsorted) order, which caused it to fail. This fix updates the test to reflect the new, correct alphabetical order of statuses.
References: CV2-6325

## How to test?

running the smoke tests

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
