### PR TITLE
Fixing "create list" mutation call.

### DIFF
--- a/src/app/components/drawer/Projects/NewProject.js
+++ b/src/app/components/drawer/Projects/NewProject.js
@@ -65,6 +65,7 @@ const NewProject = ({
     const input = {
       title: newTitle,
       team_id: team.dbid,
+      list_type: 'media',
     };
 
     commitMutation(Store, {


### PR DESCRIPTION
## Description

The "create list" mutation requires a new mandatory argument `list_type`. The fix is to make sure that this argument is set.

Fixes: CV2-6349.

## How to test?

Using the UI, make sure you can create a list from the sidebar.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
