### PR TITLE
Do not show the "Article (type)" filter in media lists.

### DIFF
--- a/src/app/components/search/AllItems.js
+++ b/src/app/components/search/AllItems.js
@@ -17,6 +17,7 @@ export default function AllItems({ routeParams }) {
           'cluster_published_reports',
           'feed_fact_checked_by',
           'published_by',
+          'article_type',
         ]}
         icon={<PermMediaIcon />}
         listSubtitle={<FormattedMessage defaultMessage="Media Clusters List" description="Displayed on top of the tipline lists title on the search results page." id="search.tiplineSubHeader" />}

--- a/src/app/components/search/SavedSearch.js
+++ b/src/app/components/search/SavedSearch.js
@@ -57,6 +57,7 @@ const SavedSearch = ({ routeParams }) => (
                   'cluster_teams',
                   'cluster_published_reports',
                   'published_by',
+                  'article_type',
                 ]}
                 icon={<ListIcon />}
                 listActions={

--- a/src/app/components/team/AssignedToMe.js
+++ b/src/app/components/team/AssignedToMe.js
@@ -42,6 +42,7 @@ const AssignedToMe = ({ routeParams }) => (
                 'cluster_teams',
                 'cluster_published_reports',
                 'published_by',
+                'article_type',
               ]}
               icon={<PersonIcon />}
               listSubtitle={<FormattedMessage defaultMessage="Media Clusters List" description="Displayed on top of the tipline lists title on the search results page." id="search.tiplineSubHeader" />}

--- a/src/app/components/team/Spam.js
+++ b/src/app/components/team/Spam.js
@@ -33,6 +33,7 @@ export default function Spam({ routeParams }) {
           'cluster_published_reports',
           'archived',
           'published_by',
+          'article_type',
         ]}
         icon={<SpamIcon />}
         mediaUrlPrefix={`/${routeParams.team}/media`}

--- a/src/app/components/team/SuggestedMatches.js
+++ b/src/app/components/team/SuggestedMatches.js
@@ -29,6 +29,7 @@ const SuggestedMatches = ({ routeParams }) => {
           'cluster_teams',
           'cluster_published_reports',
           'published_by',
+          'article_type',
         ]}
         icon={<LightbulbIcon />}
         listSubtitle={<FormattedMessage defaultMessage="Media Clusters List" description="Displayed on top of the tipline lists title on the search results page." id="search.tiplineSubHeader" />}

--- a/src/app/components/team/TiplineInbox.js
+++ b/src/app/components/team/TiplineInbox.js
@@ -44,6 +44,7 @@ const TiplineInbox = ({ routeParams }) => (
                 'cluster_teams',
                 'cluster_published_reports',
                 'published_by',
+                'article_type',
               ]}
               icon={<InboxIcon />}
               listSubtitle={<FormattedMessage defaultMessage="Media Clusters List" description="Displayed on top of the tipline lists title on the search results page." id="search.tiplineSubHeader" />}

--- a/src/app/components/team/Trash.js
+++ b/src/app/components/team/Trash.js
@@ -33,6 +33,7 @@ export default function Trash({ routeParams }) {
           'cluster_published_reports',
           'archived',
           'published_by',
+          'article_type',
         ]}
         icon={<DeleteIcon />}
         mediaUrlPrefix={`/${routeParams.team}/media`}


### PR DESCRIPTION
## Description

Do not show the "Article (type)" filter in media lists.

Fixes: CV2-6345.

## How to test?

The "Article (type)" filter should not be listed in the media list pages.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
