### PR TITLE
Refactoring/CV2-6283: extract org filter button component to its own file

### DIFF
--- a/localization/react-intl/src/app/components/feed/FeedTopBar.json
+++ b/localization/react-intl/src/app/components/feed/FeedTopBar.json
@@ -1,27 +1,7 @@
 [
   {
-    "id": "feedTopBar.showItems",
-    "description": "Tooltip message displayed on button that the user presses in order to show items from an organization.",
-    "defaultMessage": "Show items from {orgName}"
-  },
-  {
-    "id": "feedTopBar.hideItems",
-    "description": "Tooltip message displayed on button that the user presses in order to hide items from an organization.",
-    "defaultMessage": "Hide items from {orgName}"
-  },
-  {
-    "id": "feedTopBar.noListSelected",
-    "description": "Message displayed on feed top bar when there is no list associated with the feed.",
-    "defaultMessage": "no list selected"
-  },
-  {
-    "id": "feedTopBar.customList",
-    "description": "Tooltip message displayed on button that the user presses in order to navigate to the custom list page.",
-    "defaultMessage": "Go to custom list"
-  },
-  {
     "id": "feedTopBar.addOrg",
-    "description": "Tooltip message displayed on a button that takes the user toa page where they can add an organization to this shared feed with an expectation to collaborate with the organization.",
+    "description": "Tooltip message displayed on a button that takes the user to a page where they can add an organization to this shared feed with an expectation to collaborate with the organization.",
     "defaultMessage": "Add a collaborating organization"
   }
 ]

--- a/localization/react-intl/src/app/components/feed/OrgFilterButton.json
+++ b/localization/react-intl/src/app/components/feed/OrgFilterButton.json
@@ -1,13 +1,13 @@
 [
   {
-    "id": "feedTopBar.showItems",
-    "description": "Tooltip message displayed on button that the user presses in order to show items from an organization.",
-    "defaultMessage": "Show items from {orgName}"
-  },
-  {
     "id": "feedTopBar.hideItems",
     "description": "Tooltip message displayed on button that the user presses in order to hide items from an organization.",
     "defaultMessage": "Hide items from {orgName}"
+  },
+  {
+    "id": "feedTopBar.showItems",
+    "description": "Tooltip message displayed on button that the user presses in order to show items from an organization.",
+    "defaultMessage": "Show items from {orgName}"
   },
   {
     "id": "feedTopBar.noListSelected",

--- a/localization/react-intl/src/app/components/feed/OrgFilterButton.json
+++ b/localization/react-intl/src/app/components/feed/OrgFilterButton.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "feedTopBar.showItems",
+    "description": "Tooltip message displayed on button that the user presses in order to show items from an organization.",
+    "defaultMessage": "Show items from {orgName}"
+  },
+  {
+    "id": "feedTopBar.hideItems",
+    "description": "Tooltip message displayed on button that the user presses in order to hide items from an organization.",
+    "defaultMessage": "Hide items from {orgName}"
+  },
+  {
+    "id": "feedTopBar.noListSelected",
+    "description": "Message displayed on feed top bar when there is no list associated with the feed.",
+    "defaultMessage": "no list selected"
+  },
+  {
+    "id": "feedTopBar.customList",
+    "description": "Tooltip message displayed on button that the user presses in order to navigate to the custom list page.",
+    "defaultMessage": "Go to custom list"
+  }
+]

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -49,7 +49,6 @@ const FeedTopBar = ({
         <div className={`${styles.feedTopBarLeft} feed-top-bar`}>
           <OrgFilterButton
             current
-            customListDbid={feed.current_feed_team?.saved_search?.dbid || feed.saved_search?.dbid}
             enabled={teamFilters.includes(currentOrg.dbid)}
             feed={feed}
             savedSearch={feed.current_feed_team?.saved_search || feed.saved_search}
@@ -60,7 +59,6 @@ const FeedTopBar = ({
             (
               <OrgFilterButton
                 current={false}
-                customListDbid={feedTeam.node.saved_search_id}
                 enabled={teamFilters.includes(feedTeam.node.team.dbid)}
                 feed={feed}
                 key={feedTeam.node.team.dbid}

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -50,7 +50,6 @@ const FeedTopBar = ({
           <OrgFilterButton
             current
             enabled={teamFilters.includes(currentOrg.dbid)}
-            feed={feed}
             savedSearch={feed.current_feed_team?.saved_search || feed.saved_search}
             team={currentOrg}
             onClick={handleFilterClick}
@@ -60,7 +59,6 @@ const FeedTopBar = ({
               <OrgFilterButton
                 current={false}
                 enabled={teamFilters.includes(feedTeam.node.team.dbid)}
-                feed={feed}
                 key={feedTeam.node.team.dbid}
                 savedSearch={feedTeam.node.saved_search}
                 team={feedTeam.node.team}

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -52,6 +51,7 @@ const FeedTopBar = ({
             avatar={currentOrg.avatar}
             current
             customListDbid={feed.current_feed_team?.saved_search?.dbid || feed.saved_search?.dbid}
+            customListTitle={feed.current_feed_team?.saved_search?.title || feed.saved_search?.title}
             dbid={currentOrg.dbid}
             enabled={teamFilters.includes(currentOrg.dbid)}
             feed={feed}

--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -48,39 +48,29 @@ const FeedTopBar = ({
       <div className={styles.feedTopBarContainer}>
         <div className={`${styles.feedTopBarLeft} feed-top-bar`}>
           <OrgFilterButton
-            avatar={currentOrg.avatar}
             current
             customListDbid={feed.current_feed_team?.saved_search?.dbid || feed.saved_search?.dbid}
-            customListTitle={feed.current_feed_team?.saved_search?.title || feed.saved_search?.title}
-            dbid={currentOrg.dbid}
             enabled={teamFilters.includes(currentOrg.dbid)}
             feed={feed}
-            name={currentOrg.name}
-            slug={currentOrg.slug}
+            savedSearch={feed.current_feed_team?.saved_search || feed.saved_search}
+            team={currentOrg}
             onClick={handleFilterClick}
           />
-          { teamsWithoutCurrentOrg.map((feedTeam) => {
-            const {
-              avatar,
-              dbid,
-              name,
-              slug,
-            } = feedTeam.node.team;
-            return (
+          { teamsWithoutCurrentOrg.map(feedTeam =>
+            (
               <OrgFilterButton
-                avatar={avatar}
                 current={false}
-                dbid={dbid}
-                enabled={teamFilters.includes(dbid)}
+                customListDbid={feedTeam.node.saved_search_id}
+                enabled={teamFilters.includes(feedTeam.node.team.dbid)}
                 feed={feed}
-                key={dbid}
-                name={name}
-                slug={slug}
+                key={feedTeam.node.team.dbid}
+                savedSearch={feedTeam.node.saved_search}
+                team={feedTeam.node.team}
                 onClick={handleFilterClick}
               />
-            );
+            ),
           // sort the remaining items alphabetically per locale
-          }).sort((a, b) => a.props.name.localeCompare(b.props.name))}
+          ).sort((a, b) => a.props.name.localeCompare(b.props.name))}
           <Can permission="update Feed" permissions={feed.permissions}>
             <Tooltip
               arrow
@@ -132,7 +122,6 @@ FeedTopBar.propTypes = {
   setTeamFilters: PropTypes.func.isRequired,
   team: PropTypes.shape({
     slug: PropTypes.string.isRequired,
-    avatar: PropTypes.string,
   }).isRequired,
   teamFilters: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
@@ -144,7 +133,6 @@ export { FeedTopBar };
 export default createFragmentContainer(FeedTopBar, graphql`
   fragment FeedTopBar_team on Team {
     slug
-    avatar
   }
   fragment FeedTopBar_feed on Feed {
     dbid
@@ -155,23 +143,20 @@ export default createFragmentContainer(FeedTopBar, graphql`
         node {
           saved_search_id
           team {
-            dbid
-            avatar
-            name
             slug
+            dbid
+            ...OrgFilterButton_team
           }
         }
       }
     }
     current_feed_team {
       saved_search {
-        dbid
-        title
+        ...OrgFilterButton_savedSearch
       }
     }
     saved_search {
-      dbid
-      title
+      ...OrgFilterButton_savedSearch
     }
   }
 `);

--- a/src/app/components/feed/FeedTopBar.test.js
+++ b/src/app/components/feed/FeedTopBar.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FeedTopBar } from './FeedTopBar';
-import { mountWithIntlProvider } from '../../../../test/unit/helpers/intl-test';
+import { shallowWithIntl } from '../../../../test/unit/helpers/intl-test';
 
 const feed = {
   published: true,
@@ -32,30 +32,14 @@ const teamFiltersAll = [1];
 
 describe('<FeedTopBar />', () => {
   it('should render FeedTopBar component', () => {
-    const feedTopBarComponent = mountWithIntlProvider(<FeedTopBar feed={feed} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
+    const feedTopBarComponent = shallowWithIntl(<FeedTopBar feed={feed} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
     const feedTopBar = feedTopBarComponent.find('.feed-top-bar');
     expect(feedTopBar).toHaveLength(1);
   });
 
   it('should not render anything if feed is not published', () => {
-    const feedTopBarComponent = mountWithIntlProvider(<FeedTopBar feed={{ ...feed, published: false }} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
+    const feedTopBarComponent = shallowWithIntl(<FeedTopBar feed={{ ...feed, published: false }} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
     const feedTopBar = feedTopBarComponent.find('.feed-top-bar');
     expect(feedTopBar).toHaveLength(0);
-  });
-
-  it('should render list name if there is a list', () => {
-    let feedTopBarComponent = mountWithIntlProvider(<FeedTopBar feed={feed} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
-    let feedTopBar = feedTopBarComponent.find('.feed-top-bar-list');
-    expect(feedTopBar).toHaveLength(1);
-
-    feedTopBarComponent = mountWithIntlProvider(<FeedTopBar feed={{ ...feed, saved_search: null }} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
-    feedTopBar = feedTopBarComponent.find('.feed-top-bar-list');
-    expect(feedTopBar).toHaveLength(0);
-  });
-
-  it('should render shared custom list icon', () => {
-    const feedTopBarComponent = mountWithIntlProvider(<FeedTopBar feed={feed} setTeamFilters={() => {}} team={team} teamFilters={teamFiltersAll} />);
-    const feedTopBar = feedTopBarComponent.find('button.int-feed-top-bar__icon-button--settings');
-    expect(feedTopBar).toHaveLength(1);
   });
 });

--- a/src/app/components/feed/OrgFilterButton.js
+++ b/src/app/components/feed/OrgFilterButton.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { browserHistory } from 'react-router';
+import cx from 'classnames/bind';
+import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
+import Tooltip from '../cds/alerts-and-prompts/Tooltip';
+import ShareIcon from '../../icons/share.svg';
+import TeamAvatar from '../team/TeamAvatar';
+import styles from './FeedTopBar.module.css';
+
+const OrgFilterButton = ({
+  avatar,
+  current,
+  customListDbid,
+  dbid,
+  enabled,
+  feed,
+  name,
+  onClick,
+  slug,
+}) => {
+  let message;
+  if (!enabled) {
+    message = (
+      <FormattedMessage
+        defaultMessage="Show items from {orgName}"
+        description="Tooltip message displayed on button that the user presses in order to show items from an organization."
+        id="feedTopBar.showItems"
+        values={{
+          orgName: name,
+        }}
+      />
+    );
+  } else {
+    message = (
+      <FormattedMessage
+        defaultMessage="Hide items from {orgName}"
+        description="Tooltip message displayed on button that the user presses in order to hide items from an organization."
+        id="feedTopBar.hideItems"
+        values={{
+          orgName: name,
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.feedTopBarItemWrapper}>
+      <Tooltip
+        arrow
+        placement="top"
+        title={message}
+      >
+        <button
+          className={cx(
+            'feed-top-bar-item',
+            'int-feed-top-bar__button--filter-org',
+            styles.feedTopBarItem,
+            {
+              [styles.feedTopBarButton]: enabled,
+              [styles.feedTopBarButtonDisabled]: !enabled,
+              [styles.feedTopBarButtonHasList]: current && customListDbid,
+            })
+          }
+          onClick={() => onClick(dbid, enabled)}
+        >
+          <TeamAvatar className={styles.feedListAvatar} size="24px" team={{ avatar, slug }} />
+          {
+            current && (
+              <div className="typography-body2">
+                {
+                  customListDbid ?
+                    <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
+                      <span className={styles.feedListTitle}>{feed.current_feed_team?.saved_search?.title || feed.saved_search.title}</span>
+                    </div> :
+                    <span className={styles.feedNoListTitle}><FormattedMessage defaultMessage="no list selected" description="Message displayed on feed top bar when there is no list associated with the feed." id="feedTopBar.noListSelected" /></span>
+                }
+              </div>)
+          }
+        </button>
+      </Tooltip>
+      { current && customListDbid && (
+        <Tooltip
+          arrow
+          placement="right"
+          title={<FormattedMessage
+            defaultMessage="Go to custom list"
+            description="Tooltip message displayed on button that the user presses in order to navigate to the custom list page."
+            id="feedTopBar.customList"
+          />}
+        >
+          <span className={styles.feedTopBarCustomListButton}>
+            <ButtonMain
+              className={cx(styles.feedListIcon, 'int-feed-top-bar__icon-button--settings')}
+              iconCenter={<ShareIcon />}
+              size="small"
+              theme="lightText"
+              variant="contained"
+              onClick={() => browserHistory.push(`/${slug}/list/${customListDbid}`)}
+            />
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
+OrgFilterButton.propTypes = {
+  avatar: PropTypes.string.isRequired,
+  current: PropTypes.bool.isRequired,
+  customListDbid: PropTypes.number.isRequired,
+  dbid: PropTypes.number.isRequired,
+  enabled: PropTypes.bool.isRequired,
+  feed: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default OrgFilterButton;

--- a/src/app/components/feed/OrgFilterButton.js
+++ b/src/app/components/feed/OrgFilterButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
 import { browserHistory } from 'react-router';
 import cx from 'classnames/bind';
@@ -10,16 +11,15 @@ import TeamAvatar from '../team/TeamAvatar';
 import styles from './FeedTopBar.module.css';
 
 const OrgFilterButton = ({
-  avatar,
   current,
-  customListDbid,
-  customListTitle,
-  dbid,
   enabled,
-  name,
   onClick,
-  slug,
+  savedSearch,
+  team,
 }) => {
+  const {
+    avatar, dbid, name, slug,
+  } = team;
   let message;
   if (!enabled) {
     message = (
@@ -60,7 +60,7 @@ const OrgFilterButton = ({
             {
               [styles.feedTopBarButton]: enabled,
               [styles.feedTopBarButtonDisabled]: !enabled,
-              [styles.feedTopBarButtonHasList]: current && customListDbid,
+              [styles.feedTopBarButtonHasList]: current && savedSearch?.dbid,
             })
           }
           onClick={() => onClick(dbid, enabled)}
@@ -70,9 +70,9 @@ const OrgFilterButton = ({
             current && (
               <div className="typography-body2">
                 {
-                  customListDbid ?
+                  savedSearch?.dbid ?
                     <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
-                      <span className={styles.feedListTitle}>{customListTitle}</span>
+                      <span className={styles.feedListTitle}>{savedSearch?.title}</span>
                     </div> :
                     <span className={styles.feedNoListTitle}><FormattedMessage defaultMessage="no list selected" description="Message displayed on feed top bar when there is no list associated with the feed." id="feedTopBar.noListSelected" /></span>
                 }
@@ -80,7 +80,7 @@ const OrgFilterButton = ({
           }
         </button>
       </Tooltip>
-      { current && customListDbid && (
+      { current && savedSearch?.dbid && (
         <Tooltip
           arrow
           placement="right"
@@ -97,7 +97,7 @@ const OrgFilterButton = ({
               size="small"
               theme="lightText"
               variant="contained"
-              onClick={() => browserHistory.push(`/${slug}/list/${customListDbid}`)}
+              onClick={() => browserHistory.push(`/${slug}/list/${savedSearch.dbid}`)}
             />
           </span>
         </Tooltip>
@@ -106,15 +106,33 @@ const OrgFilterButton = ({
   );
 };
 
+OrgFilterButton.defaultProps = {
+  savedSearch: null,
+};
+
 OrgFilterButton.propTypes = {
-  avatar: PropTypes.string.isRequired,
   current: PropTypes.bool.isRequired,
-  customListDbid: PropTypes.number.isRequired,
-  dbid: PropTypes.number.isRequired,
   enabled: PropTypes.bool.isRequired,
-  name: PropTypes.string.isRequired,
-  slug: PropTypes.string.isRequired,
+  savedSearch: PropTypes.shape({
+    dbid: PropTypes.number,
+    title: PropTypes.string,
+  }),
   onClick: PropTypes.func.isRequired,
 };
 
-export default OrgFilterButton;
+// Used in unit test
+// eslint-disable-next-line import/no-unused-modules
+export { OrgFilterButton };
+
+export default createFragmentContainer(OrgFilterButton, graphql`
+  fragment OrgFilterButton_team on PublicTeam {
+    avatar
+    dbid
+    name
+    slug
+  }
+  fragment OrgFilterButton_savedSearch on SavedSearch {
+    dbid
+    title
+  }
+`);

--- a/src/app/components/feed/OrgFilterButton.js
+++ b/src/app/components/feed/OrgFilterButton.js
@@ -20,30 +20,22 @@ const OrgFilterButton = ({
   const {
     avatar, dbid, name, slug,
   } = team;
-  let message;
-  if (!enabled) {
-    message = (
-      <FormattedMessage
-        defaultMessage="Show items from {orgName}"
-        description="Tooltip message displayed on button that the user presses in order to show items from an organization."
-        id="feedTopBar.showItems"
-        values={{
-          orgName: name,
-        }}
-      />
-    );
-  } else {
-    message = (
-      <FormattedMessage
-        defaultMessage="Hide items from {orgName}"
-        description="Tooltip message displayed on button that the user presses in order to hide items from an organization."
-        id="feedTopBar.hideItems"
-        values={{
-          orgName: name,
-        }}
-      />
-    );
-  }
+
+  const message = enabled ? (
+    <FormattedMessage
+      defaultMessage="Hide items from {orgName}"
+      description="Tooltip message displayed on button that the user presses in order to hide items from an organization."
+      id="feedTopBar.hideItems"
+      values={{ orgName: name }}
+    />
+  ) : (
+    <FormattedMessage
+      defaultMessage="Show items from {orgName}"
+      description="Tooltip message displayed on button that the user presses in order to show items from an organization."
+      id="feedTopBar.showItems"
+      values={{ orgName: name }}
+    />
+  );
 
   return (
     <div className={styles.feedTopBarItemWrapper}>

--- a/src/app/components/feed/OrgFilterButton.js
+++ b/src/app/components/feed/OrgFilterButton.js
@@ -13,9 +13,9 @@ const OrgFilterButton = ({
   avatar,
   current,
   customListDbid,
+  customListTitle,
   dbid,
   enabled,
-  feed,
   name,
   onClick,
   slug,
@@ -72,7 +72,7 @@ const OrgFilterButton = ({
                 {
                   customListDbid ?
                     <div className={`${styles.feedTopBarList} feed-top-bar-list`}>
-                      <span className={styles.feedListTitle}>{feed.current_feed_team?.saved_search?.title || feed.saved_search.title}</span>
+                      <span className={styles.feedListTitle}>{customListTitle}</span>
                     </div> :
                     <span className={styles.feedNoListTitle}><FormattedMessage defaultMessage="no list selected" description="Message displayed on feed top bar when there is no list associated with the feed." id="feedTopBar.noListSelected" /></span>
                 }
@@ -112,7 +112,6 @@ OrgFilterButton.propTypes = {
   customListDbid: PropTypes.number.isRequired,
   dbid: PropTypes.number.isRequired,
   enabled: PropTypes.bool.isRequired,
-  feed: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/src/app/components/feed/OrgFilterButton.test.js
+++ b/src/app/components/feed/OrgFilterButton.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
 import { OrgFilterButton } from './OrgFilterButton';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import TeamAvatar from '../team/TeamAvatar';
+
 
 describe('<OrgFilterButton />', () => {
   const team = {
@@ -20,32 +22,74 @@ describe('<OrgFilterButton />', () => {
   it('should display saved search title and "go to custom list" button when there is a saved search', () => {
     const wrapper = mountWithIntl(
       <OrgFilterButton
-        team={team}
-        savedSearch={savedSearch}
         current
         enabled
+        savedSearch={savedSearch}
+        team={team}
         onClick={onClickMock}
-      />
+      />,
     );
 
     expect(wrapper.find('.feed-top-bar-item').exists()).toBe(true);
     expect(wrapper.text()).toContain('Test Saved Search');
-    const goToCustomListButton = wrapper.find('.int-feed-top-bar__icon-button--settings');
-    expect(goToCustomListButton.exists()).toBe(true);
+    expect(wrapper.find('.int-feed-top-bar__icon-button--settings').exists()).toBe(true);
   });
 
-  it('should displays "no list selected" when there is no saved search', () => {
+  it('should display "no list selected" when there is no saved search', () => {
     const wrapper = mountWithIntl(
       <OrgFilterButton
-        team={team}
-        savedSearch={null}
         current
         enabled
+        savedSearch={null}
+        team={team}
         onClick={onClickMock}
-      />
+      />,
     );
 
     expect(wrapper.text()).toContain('no list selected');
   });
 
+  it('should render the avatar correctly', () => {
+    const wrapper = mountWithIntl(
+      <OrgFilterButton
+        current
+        enabled
+        savedSearch={savedSearch}
+        team={team}
+        onClick={onClickMock}
+      />,
+    );
+
+    expect(TeamAvatar).toHaveLength(1);
+    expect(wrapper.find('.int-feed-top-bar__button--filter-org')).toHaveLength(1);
+  });
+
+
+  it('should not display the "go to custom list" button when savedSearch is null', () => {
+    const wrapper = mountWithIntl(
+      <OrgFilterButton
+        current
+        enabled
+        savedSearch={null}
+        team={team}
+        onClick={onClickMock}
+      />,
+    );
+    expect(wrapper.find('.int-feed-top-bar__icon-button--settings').exists()).toBe(false);
+  });
+
+  it('should not display the "go to custom list" button or saved search title when current is false', () => {
+    const wrapper = mountWithIntl(
+      <OrgFilterButton
+        current={false}
+        enabled
+        savedSearch={savedSearch}
+        team={team}
+        onClick={onClickMock}
+      />,
+    );
+
+    expect(wrapper.find('.int-feed-top-bar__icon-button--settings').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Test Saved Search');
+  });
 });

--- a/src/app/components/feed/OrgFilterButton.test.js
+++ b/src/app/components/feed/OrgFilterButton.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { OrgFilterButton } from './OrgFilterButton';
+
+describe('<OrgFilterButton />', () => {
+  const team = {
+    avatar: 'avatar.png',
+    dbid: 1,
+    name: 'Test Team',
+    slug: 'test-team',
+  };
+
+  const savedSearch = {
+    dbid: 101,
+    title: 'Test Saved Search',
+  };
+
+  const onClickMock = jest.fn();
+
+  it('should display saved search title and "go to custom list" button when there is a saved search', () => {
+    const wrapper = mountWithIntl(
+      <OrgFilterButton
+        team={team}
+        savedSearch={savedSearch}
+        current
+        enabled
+        onClick={onClickMock}
+      />
+    );
+
+    expect(wrapper.find('.feed-top-bar-item').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Test Saved Search');
+    const goToCustomListButton = wrapper.find('.int-feed-top-bar__icon-button--settings');
+    expect(goToCustomListButton.exists()).toBe(true);
+  });
+
+  it('should displays "no list selected" when there is no saved search', () => {
+    const wrapper = mountWithIntl(
+      <OrgFilterButton
+        team={team}
+        savedSearch={null}
+        current
+        enabled
+        onClick={onClickMock}
+      />
+    );
+
+    expect(wrapper.text()).toContain('no list selected');
+  });
+
+});


### PR DESCRIPTION
## Description

- [X] Extract OrgFilterButton into its own file 
- [X] Move handleFilterClick logic from OrgFilterButton to the parent FeedTopBar, and pass it as a prop (onClick)
- [X] Add PropTypes to the new OrgFilterButton component
- [X] Add unit tests for OrgFilterButton
- [X] Update unit tests for FeedTopBar
- [X] Add fragments for OrgFilterButton

Reference: CV2-6283

## How to test?

- Manually on Feed pages or running the unit tests

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
