### PR TITLE
Provide a way to send out explainers to previous requests when the explainer is added to a media cluster

### DIFF
--- a/localization/react-intl/src/app/components/article/MediaArticles.json
+++ b/localization/react-intl/src/app/components/article/MediaArticles.json
@@ -7,17 +7,17 @@
   {
     "id": "mediaArticles.sendArticlesButton",
     "description": "Label for the button in the alert to send articles.",
-    "defaultMessage": "Send to previous requests"
+    "defaultMessage": "Send to Previous Requests"
   },
   {
     "id": "mediaArticles.unansweredRequestsMessage",
     "description": "Message for the alert when there are unanswered requests.",
-    "defaultMessage": "You can deliver new articles added to users who have previously submitted this media, but did not receive a response in the past 30 days."
+    "defaultMessage": "You can deliver new articles added to users who have previously submitted this media, but did not receive a response in the past <b>30 days</b>."
   },
   {
     "id": "mediaArticles.unansweredRequestsTitle",
     "description": "Title for the alert when explainers are added.",
-    "defaultMessage": "Articles added"
+    "defaultMessage": "Articles Added [{numberOfExplainersToSend}]"
   },
   {
     "id": "mediaArticles.noArticlesAddedToItem",

--- a/localization/react-intl/src/app/components/article/MediaArticles.json
+++ b/localization/react-intl/src/app/components/article/MediaArticles.json
@@ -5,6 +5,21 @@
     "defaultMessage": "Article added successfully!"
   },
   {
+    "id": "mediaArticles.sendArticlesButton",
+    "description": "Label for the button in the alert to send articles.",
+    "defaultMessage": "Send to previous requests"
+  },
+  {
+    "id": "mediaArticles.unansweredRequestsMessage",
+    "description": "Message for the alert when there are unanswered requests.",
+    "defaultMessage": "You can deliver new articles added to users who have previously submitted this media, but did not receive a response in the past 30 days."
+  },
+  {
+    "id": "mediaArticles.unansweredRequestsTitle",
+    "description": "Title for the alert when explainers are added.",
+    "defaultMessage": "Articles added"
+  },
+  {
     "id": "mediaArticles.noArticlesAddedToItem",
     "description": "Message displayed on articles sidebar when an item has no articles.",
     "defaultMessage": "No articles are being delivered to Tipline users who send requests that match this Media."

--- a/localization/react-intl/src/app/components/article/SendExplainersToPreviousRequests.json
+++ b/localization/react-intl/src/app/components/article/SendExplainersToPreviousRequests.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "sendExplainersToPreviousRequests.success",
+    "description": "Banner displayed after an article is successfully sent to previous requests.",
+    "defaultMessage": "Articles successfully scheduled to be delivered!"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.intro",
+    "description": "Message displayed in the confirmation dialog that appears when sending explainers to previous requests.",
+    "defaultMessage": "You can deliver new articles to users who have previously submitted requests with this media, but <b>did not</b> receive a response."
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.selectRangeHelp",
+    "description": "Help content for the range select.",
+    "defaultMessage": "{count, plural, one {Articles will be delivered to <b>one</b> user who have not received articles} other {Articles will be delivered to <b>#</b> users who have not received articles}}"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.selectRangeLabel",
+    "description": "Label for the range select.",
+    "defaultMessage": "Send to users who have not received a response"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.oneDay",
+    "description": "Label for the 24 hours option in the range select.",
+    "defaultMessage": "Last: 24 hours"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.sevenDays",
+    "description": "Label for the 7 days option in the range select.",
+    "defaultMessage": "Last: 7 days"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.thirtyDays",
+    "description": "Label for the 30 days option in the range select.",
+    "defaultMessage": "Last: 30 days"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.alertContent",
+    "description": "Message for the alert that is displayed when the selected range is not 24 hours.",
+    "defaultMessage": "Reminder that messages send to users outside of the past 24 hours are considered <u>business initiated conversations</u> and may incur additional charges."
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.alertTitle",
+    "description": "Title for the alert that is displayed when the selected range is not 24 hours.",
+    "defaultMessage": "Business Conversations"
+  },
+  {
+    "id": "global.cancel",
+    "description": "Generic label for a button or link for a user to press when they wish to abort an in-progress operation",
+    "defaultMessage": "Cancel"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.proceedLabel",
+    "description": "'Send' here is an infinitive verb. Label of the proceed button of the confirmation dialog that appears when sending explainers to previous requests.",
+    "defaultMessage": "Send to Previous Requests"
+  },
+  {
+    "id": "sendExplainersToPreviousRequests.title",
+    "description": "Title of the confirmation dialog that appears when sending explainers to previous requests.",
+    "defaultMessage": "Send to Previous Requests?"
+  }
+]

--- a/localization/react-intl/src/app/components/cds/requests-annotations/RequestReceipt.json
+++ b/localization/react-intl/src/app/components/cds/requests-annotations/RequestReceipt.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": "requestReceipt.factCheckSent",
-    "description": "Message displayed when user request has a fact-check sent",
-    "defaultMessage": "Fact-check sent on {date}"
+    "id": "requestReceipt.articleSent",
+    "description": "Message displayed when user request has an article sent",
+    "defaultMessage": "Article sent on {date}"
   },
   {
-    "id": "requestReceipt.factCheckDelivered",
-    "description": "Message displayed when user request has a fact-check delivered",
-    "defaultMessage": "Fact-check delivered on {date}"
+    "id": "requestReceipt.articleDelivered",
+    "description": "Message displayed when user request has an article delivered",
+    "defaultMessage": "Article delivered on {date}"
   },
   {
     "id": "requestReceipt.updateSent",
-    "description": "Message displayed when user request has a fact-check update sent",
+    "description": "Message displayed when user request has an article update sent",
     "defaultMessage": "Correction sent on {date}"
   },
   {
     "id": "requestReceipt.updateDelivered",
-    "description": "Message displayed when user request has a fact-check update delivered",
+    "description": "Message displayed when user request has an article update delivered",
     "defaultMessage": "Correction delivered on {date}"
   },
   {

--- a/src/app/components/article/Articles.module.css
+++ b/src/app/components/article/Articles.module.css
@@ -112,3 +112,9 @@
     }
   }
 }
+
+.sendExplainersToPreviousRequests {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/app/components/article/ExplainerForm.js
+++ b/src/app/components/article/ExplainerForm.js
@@ -12,6 +12,9 @@ import { getErrorMessageForRelayModernProblem } from '../../helpers';
 const addMutation = graphql`
   mutation ExplainerFormCreateExplainerItemMutation($input: CreateExplainerItemInput!) {
     createExplainerItem(input: $input) {
+      explainer_item {
+        dbid
+      }
       project_media {
         id
       }
@@ -104,7 +107,7 @@ const ExplainerForm = ({
           onFailure(err);
         } else {
           onSuccess();
-          onCreate();
+          onCreate(response2);
         }
       },
       onError: (err) => {

--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -69,7 +69,7 @@ const MediaArticlesComponent = ({
     return <Loader size="large" theme="white" variant="inline" />;
   }
 
-  const onCompleted = (nodeType, response) => {
+  const onCompleted = (response) => {
     setFlashMessage(
       <FormattedMessage
         defaultMessage="Article added successfully!"
@@ -112,7 +112,7 @@ const MediaArticlesComponent = ({
         variables: {
           input,
         },
-        onCompleted: response => onCompleted(nodeType, response),
+        onCompleted,
         onError,
       });
     }

--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -161,7 +161,10 @@ const MediaArticlesComponent = ({
           disabled={projectMedia.type === 'Blank'}
           projectMedia={projectMedia}
           team={team}
-          onCreate={onUpdate}
+          onCreate={(response) => {
+            const explainerItemDbid = response?.createExplainerItem?.explainer_item?.dbid;
+            onUpdate(explainerItemDbid);
+          }}
         />
       </div>
       {explainerItemDbidsToSend.length > 0 && (

--- a/src/app/components/article/SendExplainersToPreviousRequests.js
+++ b/src/app/components/article/SendExplainersToPreviousRequests.js
@@ -206,6 +206,10 @@ SendExplainersToPreviousRequests.propTypes = {
   onSubmit: PropTypes.func.isRequired,
 };
 
+// Used in unit test
+// eslint-disable-next-line import/no-unused-modules
+export { SendExplainersToPreviousRequests };
+
 export default createFragmentContainer(SendExplainersToPreviousRequests, graphql`
   fragment SendExplainersToPreviousRequests_projectMedia on ProjectMedia {
     ranges: number_of_tipline_requests_that_never_received_articles_by_time

--- a/src/app/components/article/SendExplainersToPreviousRequests.js
+++ b/src/app/components/article/SendExplainersToPreviousRequests.js
@@ -1,0 +1,209 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+import { graphql, commitMutation, createFragmentContainer } from 'react-relay/compat';
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import ConfirmProceedDialog from '../layout/ConfirmProceedDialog';
+import Alert from '../cds/alerts-and-prompts/Alert';
+import Select from '../cds/inputs/Select';
+import CalendarIcon from '../../icons/calendar_month.svg';
+import { FlashMessageSetterContext } from '../FlashMessage';
+import GenericUnknownErrorMessage from '../GenericUnknownErrorMessage';
+import { getErrorMessage } from '../../helpers';
+import styles from './Articles.module.css';
+
+const SendExplainersToPreviousRequests = ({
+  explainerItemDbidsToSend,
+  onClose,
+  onSubmit,
+  projectMedia,
+}) => {
+  const initialRange = Object.keys(projectMedia.ranges).find(key => projectMedia.ranges[key] > 0) || 1; // Default the select to the smallest time window that has a count over 0
+  const [range, setRange] = React.useState(parseInt(initialRange, 10)); // 1 day ago, 7 days ago or 30 days ago
+  const [count, setCount] = React.useState(projectMedia.ranges[`${initialRange}`]);
+  const [sending, setSending] = React.useState(false);
+  const setFlashMessage = React.useContext(FlashMessageSetterContext);
+
+  const showAlert = (parseInt(range, 10) !== 1);
+
+  const handleChange = (e) => {
+    const { value } = e.target;
+    setRange(parseInt(value, 10));
+    setCount(projectMedia.ranges[`${value}`]);
+  };
+
+  const onCompleted = () => {
+    setFlashMessage(
+      <FormattedMessage
+        defaultMessage="Articles successfully scheduled to be delivered!"
+        description="Banner displayed after an article is successfully sent to previous requests."
+        id="sendExplainersToPreviousRequests.success"
+      />,
+      'success');
+    setSending(false);
+    onSubmit();
+    onClose();
+  };
+
+  const onError = (error) => {
+    const errorMessage = getErrorMessage(error);
+    const errorComponent = errorMessage || <GenericUnknownErrorMessage />;
+    setFlashMessage(errorComponent);
+    setSending(false);
+  };
+
+  const callMutationForExplainerItem = (dbid) => {
+    const mutation = graphql`
+      mutation SendExplainersToPreviousRequestsMutation($input: SendExplainersToPreviousRequestsInput!) {
+        sendExplainersToPreviousRequests(input: $input) {
+          success
+        }
+      }
+    `;
+    commitMutation(Relay.Store, {
+      mutation,
+      variables: {
+        input: {
+          dbid,
+          range,
+        },
+      },
+      onCompleted,
+      onError,
+    });
+  };
+
+  const handleProceed = () => {
+    setSending(true);
+    explainerItemDbidsToSend.forEach((dbid) => {
+      callMutationForExplainerItem(dbid);
+    });
+  };
+
+  return (
+    <ConfirmProceedDialog
+      body={
+        <div className={styles.sendExplainersToPreviousRequests}>
+          <div className="typography-body1">
+            <FormattedHTMLMessage
+              defaultMessage="You can deliver new articles to users who have previously submitted requests with this media, but <b>did not</b> receive a response."
+              description="Message displayed in the confirmation dialog that appears when sending explainers to previous requests."
+              id="sendExplainersToPreviousRequests.intro"
+            />
+          </div>
+          <Select
+            helpContent={
+              <FormattedHTMLMessage
+                defaultMessage="{count, plural, one {Articles will be delivered to <b>one</b> user who have not received articles} other {Articles will be delivered to <b>#</b> users who have not received articles}}"
+                description="Help content for the range select."
+                id="sendExplainersToPreviousRequests.selectRangeHelp"
+                values={{ count }}
+              />
+            }
+            iconLeft={<CalendarIcon />}
+            label={
+              <FormattedMessage
+                defaultMessage="Send to users who have not received a response"
+                description="Label for the range select."
+                id="sendExplainersToPreviousRequests.selectRangeLabel"
+              />
+            }
+            value={range}
+            onChange={handleChange}
+          >
+            <FormattedMessage
+              defaultMessage="Last: 24 hours"
+              description="Label for the 24 hours option in the range select."
+              id="sendExplainersToPreviousRequests.oneDay"
+            >
+              { text => <option value={1}>{text}</option> }
+            </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="Last: 7 days"
+              description="Label for the 7 days option in the range select."
+              id="sendExplainersToPreviousRequests.sevenDays"
+            >
+              { text => <option value={7}>{text}</option> }
+            </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="Last: 30 days"
+              description="Label for the 30 days option in the range select."
+              id="sendExplainersToPreviousRequests.thirtyDays"
+            >
+              { text => <option value={30}>{text}</option> }
+            </FormattedMessage>
+          </Select>
+          { showAlert && (
+            <Alert
+              content={
+                <FormattedHTMLMessage
+                  defaultMessage="Reminder that messages send to users outside of the past 24 hours are considered <u>business initiated conversations</u> and may incur additional charges."
+                  description="Message for the alert that is displayed when the selected range is not 24 hours."
+                  id="sendExplainersToPreviousRequests.alertContent"
+                />
+              }
+              icon
+              placement="default"
+              title={
+                <FormattedMessage
+                  defaultMessage="Business Conversations"
+                  description="Title for the alert that is displayed when the selected range is not 24 hours."
+                  id="sendExplainersToPreviousRequests.alertTitle"
+                />
+              }
+              variant="warning"
+            />
+          )}
+        </div>
+      }
+      cancelLabel={
+        <FormattedMessage
+          defaultMessage="Cancel"
+          description="Generic label for a button or link for a user to press when they wish to abort an in-progress operation"
+          id="global.cancel"
+        />
+      }
+      open
+      proceedDisabled={count === 0 || explainerItemDbidsToSend.length === 0 || sending}
+      proceedLabel={
+        <FormattedMessage
+          defaultMessage="Send to Previous Requests"
+          description="'Send' here is an infinitive verb. Label of the proceed button of the confirmation dialog that appears when sending explainers to previous requests."
+          id="sendExplainersToPreviousRequests.proceedLabel"
+        />
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Send to Previous Requests?"
+          description="Title of the confirmation dialog that appears when sending explainers to previous requests."
+          id="sendExplainersToPreviousRequests.title"
+        />
+      }
+      onCancel={onClose}
+      onProceed={handleProceed}
+    />
+  );
+};
+
+SendExplainersToPreviousRequests.defaultProps = {
+  explainerItemDbidsToSend: [],
+};
+
+SendExplainersToPreviousRequests.propTypes = {
+  explainerItemDbidsToSend: PropTypes.arrayOf(PropTypes.number),
+  projectMedia: PropTypes.shape({
+    ranges: PropTypes.exact({
+      1: PropTypes.number.isRequired,
+      7: PropTypes.number.isRequired,
+      30: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+export default createFragmentContainer(SendExplainersToPreviousRequests, graphql`
+  fragment SendExplainersToPreviousRequests_projectMedia on ProjectMedia {
+    ranges: number_of_tipline_requests_that_never_received_articles_by_time
+  }
+`);

--- a/src/app/components/article/SendExplainersToPreviousRequests.js
+++ b/src/app/components/article/SendExplainersToPreviousRequests.js
@@ -32,17 +32,21 @@ const SendExplainersToPreviousRequests = ({
     setCount(projectMedia.ranges[`${value}`]);
   };
 
-  const onCompleted = () => {
-    setFlashMessage(
-      <FormattedMessage
-        defaultMessage="Articles successfully scheduled to be delivered!"
-        description="Banner displayed after an article is successfully sent to previous requests."
-        id="sendExplainersToPreviousRequests.success"
-      />,
-      'success');
+  const onCompleted = (response) => {
+    if (!response?.sendExplainersToPreviousRequests?.success) {
+      setFlashMessage(<GenericUnknownErrorMessage />);
+    } else {
+      setFlashMessage(
+        <FormattedMessage
+          defaultMessage="Articles successfully scheduled to be delivered!"
+          description="Banner displayed after an article is successfully sent to previous requests."
+          id="sendExplainersToPreviousRequests.success"
+        />,
+        'success');
+      onSubmit();
+      onClose();
+    }
     setSending(false);
-    onSubmit();
-    onClose();
   };
 
   const onError = (error) => {

--- a/src/app/components/article/SendExplainersToPreviousRequests.test.js
+++ b/src/app/components/article/SendExplainersToPreviousRequests.test.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { shallowWithIntl, mountWithIntl } from '../../../../test/unit/helpers/intl-test';
+import { SendExplainersToPreviousRequests } from './SendExplainersToPreviousRequests';
+
+const onClose = () => {};
+const onSubmit = () => {};
+const projectMedia = {
+  ranges: {
+    1: 1,
+    7: 2,
+    30: 3,
+  },
+};
+const defaultProps = { onClose, onSubmit, projectMedia, explainerItemDbidsToSend: [1, 2] };
+
+describe('<SendExplainersToPreviousRequests />', () => {
+  it('should render the component', () => {
+    const wrapper = shallowWithIntl(<SendExplainersToPreviousRequests {...defaultProps} />);
+    expect(wrapper.find('ConfirmProceedDialog')).toHaveLength(1);
+  });
+
+  it('should show the alert for 7 or 30 days but not for 1 day', () => {
+    let wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...defaultProps} projectMedia={{ ranges: { 1: 0, 7: 1, 30: 0 } }} />);
+    expect(wrapper.find('Alert')).toHaveLength(1);
+
+    wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...defaultProps} projectMedia={{ ranges: { 1: 0, 7: 0, 30: 1 } }} />);
+    expect(wrapper.find('Alert')).toHaveLength(1);
+
+    wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...defaultProps} projectMedia={{ ranges: { 1: 1, 7: 0, 30: 0 } }} />);
+    expect(wrapper.find('Alert')).toHaveLength(0);
+  });
+
+  it('should show counter based on selected range', () => {
+    const wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...defaultProps} projectMedia={{ ranges: { 1: 1, 7: 10, 30: 100 } }} />);
+    expect(wrapper.text()).toContain('Articles will be delivered to one user');
+
+    wrapper.find('select').simulate('change', { target: { value: 7 } });
+    expect(wrapper.text()).toContain('Articles will be delivered to 10 users');
+
+    wrapper.find('select').simulate('change', { target: { value: 30 } });
+    expect(wrapper.text()).toContain('Articles will be delivered to 100 users');
+
+    wrapper.find('select').simulate('change', { target: { value: 1 } });
+    expect(wrapper.text()).toContain('Articles will be delivered to one user');
+  });
+
+  it('should disable the button if there are no users', () => {
+    const props = { ...defaultProps, projectMedia: { ranges: { 1: 1, 7: 0, 30: 0 } } };
+
+    let wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...props} explainerItemDbidsToSend={[]} />);
+    let button = wrapper.find('#confirm-dialog__confirm-action-button');
+    expect(button.prop('disabled')).toBe(true);
+
+    wrapper = mountWithIntl(<SendExplainersToPreviousRequests {...props} />);
+    button = wrapper.find('#confirm-dialog__confirm-action-button');
+    expect(button.prop('disabled')).toBe(false);
+
+    wrapper.find('select').simulate('change', { target: { value: 7 } });
+    button = wrapper.find('#confirm-dialog__confirm-action-button');
+    expect(button.prop('disabled')).toBe(true);
+
+    wrapper.find('select').simulate('change', { target: { value: 30 } });
+    button = wrapper.find('#confirm-dialog__confirm-action-button');
+    expect(button.prop('disabled')).toBe(true);
+
+    wrapper.find('select').simulate('change', { target: { value: 1 } });
+    button = wrapper.find('#confirm-dialog__confirm-action-button');
+    expect(button.prop('disabled')).toBe(false);
+  });
+});

--- a/src/app/components/article/SendExplainersToPreviousRequests.test.js
+++ b/src/app/components/article/SendExplainersToPreviousRequests.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { shallowWithIntl, mountWithIntl } from '../../../../test/unit/helpers/intl-test';
 import { SendExplainersToPreviousRequests } from './SendExplainersToPreviousRequests';
+import { shallowWithIntl, mountWithIntl } from '../../../../test/unit/helpers/intl-test';
 
 const onClose = () => {};
 const onSubmit = () => {};
@@ -11,7 +11,12 @@ const projectMedia = {
     30: 3,
   },
 };
-const defaultProps = { onClose, onSubmit, projectMedia, explainerItemDbidsToSend: [1, 2] };
+const defaultProps = {
+  onClose,
+  onSubmit,
+  projectMedia,
+  explainerItemDbidsToSend: [1, 2],
+};
 
 describe('<SendExplainersToPreviousRequests />', () => {
   it('should render the component', () => {

--- a/src/app/components/cds/requests-annotations/RequestReceipt.js
+++ b/src/app/components/cds/requests-annotations/RequestReceipt.js
@@ -12,24 +12,24 @@ import styles from './RequestReceipt.module.css';
 
 const messages = defineMessages({
   smooch_report_sent_at: {
-    id: 'requestReceipt.factCheckSent',
-    defaultMessage: 'Fact-check sent on {date}',
-    description: 'Message displayed when user request has a fact-check sent',
+    id: 'requestReceipt.articleSent',
+    defaultMessage: 'Article sent on {date}',
+    description: 'Message displayed when user request has an article sent',
   },
   smooch_report_received_at: {
-    id: 'requestReceipt.factCheckDelivered',
-    defaultMessage: 'Fact-check delivered on {date}',
-    description: 'Message displayed when user request has a fact-check delivered',
+    id: 'requestReceipt.articleDelivered',
+    defaultMessage: 'Article delivered on {date}',
+    description: 'Message displayed when user request has an article delivered',
   },
   smooch_report_correction_sent_at: {
     id: 'requestReceipt.updateSent',
     defaultMessage: 'Correction sent on {date}',
-    description: 'Message displayed when user request has a fact-check update sent',
+    description: 'Message displayed when user request has an article update sent',
   },
   smooch_report_update_received_at: {
     id: 'requestReceipt.updateDelivered',
     defaultMessage: 'Correction delivered on {date}',
-    description: 'Message displayed when user request has a fact-check update delivered',
+    description: 'Message displayed when user request has an article update delivered',
   },
   timeout_search_requests: {
     id: 'requestReceipt.noFeedback',

--- a/src/app/components/cds/requests-annotations/RequestReceipt.test.js
+++ b/src/app/components/cds/requests-annotations/RequestReceipt.test.js
@@ -45,21 +45,21 @@ describe('<RequestReceipt />', () => {
     expect(wrapper.find(SearchIcon).length).toEqual(1);
   });
 
-  it('should display "Fact-check sent on" label', () => {
+  it('should display "Article sent on" label', () => {
     const events = [
       { type: 'smooch_report_sent_at', date: 1681234567 },
     ];
     const wrapper = mountWithIntl(<RequestReceipt events={events} />);
-    expect(wrapper.text()).toContain('Fact-check sent on');
+    expect(wrapper.text()).toContain('Article sent on');
     expect(wrapper.find(FactCheckIcon).length).toBe(1);
   });
 
-  it('should display "Fact-check delivered on" label', () => {
+  it('should display "Article delivered on" label', () => {
     const events = [
       { type: 'smooch_report_received_at', date: 1681237890 },
     ];
     const wrapper = mountWithIntl(<RequestReceipt events={events} />);
-    expect(wrapper.text()).toContain('Fact-check delivered on');
+    expect(wrapper.text()).toContain('Article delivered on');
     expect(wrapper.find(FactCheckIcon).length).toBe(1);
   });
 
@@ -79,7 +79,7 @@ describe('<RequestReceipt />', () => {
     ];
     const wrapper = mountWithIntl(<RequestReceipt events={events} />);
     expect(wrapper.find(FactCheckIcon).length).toEqual(1);
-    expect(wrapper.text()).toContain('Fact-check delivered on');
+    expect(wrapper.text()).toContain('Article delivered on');
   });
 
   it('should render multiple events in the tooltip', () => {
@@ -91,7 +91,7 @@ describe('<RequestReceipt />', () => {
     const tooltip = wrapper.find(Tooltip);
     const tooltipContent = mountWithIntl(tooltip.prop('title'));
 
-    expect(tooltipContent.find('li').at(0).text()).toContain('Fact-check sent on');
+    expect(tooltipContent.find('li').at(0).text()).toContain('Article sent on');
     expect(tooltipContent.find('li').at(1).text()).toContain('Search result – negative feedback');
   });
 });


### PR DESCRIPTION
## Description

- [x] When explainers are added to a media cluster (so, as a result of the respective GraphQL mutation), show an alert box (from the existing CDS `<Alert />` component) if there are requests who never received an article (use the new GraphQL field `ProjectMediaType.has_tipline_requests_that_never_received_articles` for this).
- [x] When the button on that alert box is clicked, open a dialog (the existing confirmation dialog can be used for that) where the time range can be chosen.
  - [x] When the value in the time range drop-down changes, show the relevant count from the new `ProjectMediaType.number_of_tipline_requests_that_never_received_articles_by_time` field.
  - [x] Default the select to the smallest time window that has a count over 0
  - [x] Show an alert when options longer than 24 hours are chosen.
- [x] Upon confirmation, call the new mutation `sendExplainersToPreviousRequests` with the selected time range as argument.
- [x] Show confirmation toast (using existing CDS component) when mutation is submitted.
- [x] Implement unit tests for new components.

Reference: CV2-6335.

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).