### PR TITLE
Fixing alert close button on "send explainer to previous requests" alert box

### DIFF
--- a/src/app/components/article/MediaArticles.js
+++ b/src/app/components/article/MediaArticles.js
@@ -62,6 +62,7 @@ const MediaArticlesComponent = ({
   const [adding, setAdding] = React.useState(false);
   const [confirmReplaceFactCheck, setConfirmReplaceFactCheck] = React.useState(null);
   const [confirmSendExplainers, setConfirmSendExplainers] = React.useState(false);
+  const [showAlert, setShowAlert] = React.useState(true);
   const setFlashMessage = React.useContext(FlashMessageSetterContext);
   const hasArticle = projectMedia.articles_count > 0;
 
@@ -167,7 +168,7 @@ const MediaArticlesComponent = ({
           }}
         />
       </div>
-      {explainerItemDbidsToSend.length > 0 && (
+      {explainerItemDbidsToSend.length > 0 && showAlert && (
         <Alert
           buttonLabel={
             <FormattedMessage
@@ -195,7 +196,7 @@ const MediaArticlesComponent = ({
           }
           variant="success"
           onButtonClick={handleAlertButtonClick}
-          onClose={onUpdate}
+          onClose={() => { setShowAlert(false); }}
         />
       )}
 


### PR DESCRIPTION
## Description

Fixing alert close button on "send explainer to previous requests" alert box.

Reference: CV2-6335.

## How to test?

You should be able to close the alert box that appears when an explainer is added to a media cluster that has unanswered requests.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).