### PR TITLE
Fix sorting bug in FeedTopBar caused by missing 'name' prop

### DIFF
--- a/src/app/components/feed/FeedTopBar.js
+++ b/src/app/components/feed/FeedTopBar.js
@@ -54,8 +54,9 @@ const FeedTopBar = ({
             team={currentOrg}
             onClick={handleFilterClick}
           />
-          { teamsWithoutCurrentOrg.map(feedTeam =>
-            (
+          { teamsWithoutCurrentOrg
+            .sort((a, b) => a.node.team.name.localeCompare(b.node.team.name))
+            .map(feedTeam => (
               <OrgFilterButton
                 current={false}
                 enabled={teamFilters.includes(feedTeam.node.team.dbid)}
@@ -64,9 +65,7 @@ const FeedTopBar = ({
                 team={feedTeam.node.team}
                 onClick={handleFilterClick}
               />
-            ),
-          // sort the remaining items alphabetically per locale
-          ).sort((a, b) => a.props.name.localeCompare(b.props.name))}
+            ))}
           <Can permission="update Feed" permissions={feed.permissions}>
             <Tooltip
               arrow
@@ -141,6 +140,7 @@ export default createFragmentContainer(FeedTopBar, graphql`
           team {
             slug
             dbid
+            name
             ...OrgFilterButton_team
           }
         }


### PR DESCRIPTION
## Description

Fix sorting bug in FeedTopBar caused by missing 'name' prop after refactor (CV2-6283)

- Moved sorting logic to occur before mapping over teamsWithoutCurrentOrg
- Replaced invalid a.props.name access with a.node.team.name

Reference: CV2-6377

## How to test?

Manually following the steps to reproduce in the ticket and checking that the error is no longer happening

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
