### PR TITLE
Refactoring/CV2-6206: cleanup relay unused fields

### DIFF
--- a/src/app/components/media/MediaCardLargeActions.js
+++ b/src/app/components/media/MediaCardLargeActions.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
@@ -163,7 +162,6 @@ export default createFragmentContainer(MediaExpandedActions, graphql`
     picture
     url
     extracted_text: annotation(annotation_type: "extracted_text") {
-      data
       __typename
     }
     ...TranscriptionButton_projectMedia

--- a/src/app/components/media/MediaCardLargeActions.js
+++ b/src/app/components/media/MediaCardLargeActions.js
@@ -162,12 +162,12 @@ export default createFragmentContainer(MediaExpandedActions, graphql`
     }
     picture
     url
-    transcription: annotation(annotation_type: "transcription") {
-      data
-    }
     extracted_text: annotation(annotation_type: "extracted_text") {
       data
+      __typename
     }
+    ...TranscriptionButton_projectMedia
     ...MediaLanguageSwitcher_projectMedia
   }
 `);
+

--- a/src/app/components/media/TranscriptionButton.js
+++ b/src/app/components/media/TranscriptionButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
-import { graphql, commitMutation } from 'react-relay/compat';
+import { graphql, commitMutation, createFragmentContainer } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import TranscribeIcon from '../../icons/transcribe.svg';
@@ -117,4 +117,12 @@ TranscriptionButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-export default withSetFlashMessage(TranscriptionButton);
+export default createFragmentContainer(withSetFlashMessage(TranscriptionButton), {
+  projectMedia: graphql`
+    fragment TranscriptionButton_projectMedia on ProjectMedia {
+      transcription: annotation(annotation_type: "transcription") {
+        data
+      }
+    }
+  `,
+});

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -757,7 +757,6 @@ export default createFragmentContainer(injectIntl(SearchFields), graphql`
     slug
     ...SaveList_team
     verification_statuses
-    get_tipline_inbox_filters
     smooch_bot: team_bot_installation(bot_identifier: "smooch") {
       id
     }

--- a/src/app/components/search/SearchFields/index.js
+++ b/src/app/components/search/SearchFields/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';
@@ -753,16 +752,8 @@ SearchFields.contextTypes = {
 export default createFragmentContainer(injectIntl(SearchFields), graphql`
   fragment SearchFields_team on Team {
     id
-    dbid
     slug
     ...SaveList_team
     verification_statuses
-    smooch_bot: team_bot_installation(bot_identifier: "smooch") {
-      id
-    }
-    alegre_bot: team_bot_installation(bot_identifier: "alegre") {
-      id
-      alegre_settings
-    }
   }
 `);

--- a/src/app/components/team/TeamBots.js
+++ b/src/app/components/team/TeamBots.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Relay from 'react-relay/classic';
+import { createFragmentContainer, graphql } from 'react-relay/compat';
 import { FormattedMessage } from 'react-intl';
 import Collapse from '@material-ui/core/Collapse';
 import cx from 'classnames/bind';
@@ -184,4 +185,54 @@ class TeamBots extends Component {
   }
 }
 
-export default TeamBots;
+export default createFragmentContainer(TeamBots, {
+  root: graphql`
+    fragment TeamBots_root on RootLevel {
+      current_user {
+        is_admin
+      }
+      current_team {
+        id
+        dbid
+        ...ApiKeys_team
+        ...Webhooks_team
+        team_bot_installations(first: 10000) {
+          edges {
+            node {
+              id
+              json_settings
+              lock_version
+              bot_user {
+                id
+              }
+              team_bot: bot_user {
+                id
+                dbid
+              }
+            }
+          }
+        }
+      }
+      team_bots_listed(first: 10000) {
+        edges {
+          node {
+            id
+            dbid
+            name
+            default
+            identifier
+            description: get_description
+            installation {
+              id
+              json_settings
+              team_bot: bot_user {
+                id
+                dbid
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+});

--- a/src/app/components/team/TeamIntegrations.js
+++ b/src/app/components/team/TeamIntegrations.js
@@ -1,12 +1,9 @@
-/* eslint-disable relay/unused-fields */
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay/compat';
 import Relay from 'react-relay/classic';
 import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
 import cx from 'classnames/bind';
 import SettingsHeader from './SettingsHeader';
-import ApiKeys from './ApiKeys'; // eslint-disable-line no-unused-vars
-import Webhooks from './Webhooks'; // eslint-disable-line no-unused-vars
 import TeamBots from './TeamBots';
 import settingsStyles from './Settings.module.css';
 
@@ -15,64 +12,7 @@ const TeamIntegrations = () => (<QueryRenderer
   query={graphql`
     query TeamIntegrationsQuery {
       root {
-        current_user {
-          is_admin
-        }
-        current_team {
-          id
-          dbid
-          ...ApiKeys_team
-          ...Webhooks_team
-          team_bot_installations(first: 10000) {
-            edges {
-              node {
-                id
-                json_settings
-                lock_version
-                bot_user {
-                  id
-                }
-                team {
-                  id
-                  dbid
-                }
-                team_bot: bot_user {
-                  id
-                  dbid
-                }
-              }
-            }
-          }
-        }
-        team_bots_listed(first: 10000) {
-          edges {
-            node {
-              id
-              dbid
-              avatar
-              name
-              default
-              identifier
-              description: get_description
-              team_author {
-                name
-                slug
-              }
-              installation {
-                id
-                json_settings
-                team {
-                  id
-                  dbid
-                }
-                team_bot: bot_user {
-                  id
-                  dbid
-                }
-              }
-            }
-          }
-        }
+        ...TeamBots_root
       }
     }
   `}
@@ -98,7 +38,7 @@ const TeamIntegrations = () => (<QueryRenderer
             }
           />
           <div className={cx('team-integrations', settingsStyles['setting-details-wrapper'])}>
-            <TeamBots {...props} />
+            <TeamBots root={props.root} />
           </div>
         </>
       );


### PR DESCRIPTION
## Description

Removed unused fields from:

- [X] TeamIntegrations
- [X] MediaCardLargeActions
- [X] SearchFields

New fragments added:

- [X] TranscriptionButton_projectMedia
- [X] TeamBots_root 

References: CV2-6206

## How to test?

- running the integration tests
- Manually verify the following pages:
- Team Integration Pages
- Media Page
- Search Page

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
