### PR TITLE
Fix/6405 crash in integration settings

### DIFF
--- a/src/app/components/team/WebhookEdit.js
+++ b/src/app/components/team/WebhookEdit.js
@@ -28,6 +28,11 @@ const messages = defineMessages({
     defaultMessage: 'Report Published',
     description: 'Label for the event type when a report is published',
   },
+  create_project_media: {
+    id: 'webhookEdit.eventTypeProjectMediaCreated',
+    defaultMessage: 'Project Media Created',
+    description: 'Label for the event type when a project media is created',
+  },
 });
 
 const createMutation = graphql`

--- a/src/app/components/team/WebhookEntry.js
+++ b/src/app/components/team/WebhookEntry.js
@@ -31,7 +31,7 @@ const WebhookEntry = ({ intl, webhook }) => {
             />
           }
           readOnly
-          value={intl?.formatMessage(messages[selectedEvent]) || selectedEvent}
+          value={messages[selectedEvent] ? intl?.formatMessage(messages[selectedEvent]) : selectedEvent}
         />
         <div className={styles['key-row__buttons']}>
           <WebhookEditContainer webhook={webhook} />

--- a/src/app/components/team/WebhookEntry.test.js
+++ b/src/app/components/team/WebhookEntry.test.js
@@ -15,4 +15,15 @@ describe('<WebhookEntry />', () => {
     expect(wrapper.find('span').hostNodes().text()).toEqual('Test Webhook');
     expect(wrapper.find('strong').hostNodes().text()).toEqual('https://example.com/webhook');
   });
+
+  it('should display the event name correctly', () => {
+    const wrapper = shallowWithIntl(<WebhookEntry intl={mockIntl} webhook={webhook} />);
+    expect(wrapper.find('TextField').prop('value')).toEqual('Publish Report');
+  });
+
+  it('should not crash if event code has no matching message', () => {
+    webhook.events[0].event = 'unknown_event';
+    const wrapper = shallowWithIntl(<WebhookEntry intl={mockIntl} webhook={webhook} />);
+    expect(wrapper.find('TextField').prop('value')).toEqual('unknown_event');
+  });
 });


### PR DESCRIPTION
## Description

Fixes crash in integration settings related to missing message for webhook event

References: CV2-6405

## How to test?

Should load https://checkmedia.org/check-message-demo/settings/integrations and https://checkmedia.org/check-testing/settings/integrations without crashing

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
