### PR TITLE
Clarify alert for explainers when media already has a fact-check attached

### DIFF
--- a/localization/react-intl/src/app/components/article/MediaArticlesDisplay.json
+++ b/localization/react-intl/src/app/components/article/MediaArticlesDisplay.json
@@ -7,11 +7,11 @@
   {
     "id": "mediaArticlesDisplay.readOnlyAlertContent",
     "description": "Description of the alert message displayed on data points section of the edit feed page.",
-    "defaultMessage": "When a claim & fact-check article is added, it will be prioritized as the only article to be delivered as a response to requests that match this item."
+    "defaultMessage": "Your explainer will not be sent to users because this media already has a fact-check attached."
   },
   {
     "id": "mediaArticlesDisplay.readOnlyAlertTitle",
     "description": "Title of the alert message displayed on data points section of the edit feed page.",
-    "defaultMessage": "Claim & Fact-Check Added"
+    "defaultMessage": "Already Has Fact-Check"
   }
 ]

--- a/src/app/components/article/MediaArticlesDisplay.js
+++ b/src/app/components/article/MediaArticlesDisplay.js
@@ -62,7 +62,7 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
         <Alert
           content={
             <FormattedMessage
-              defaultMessage="When a claim & fact-check article is added, it will be prioritized as the only article to be delivered as a response to requests that match this item."
+              defaultMessage="Your explainer will not be sent to users because this media already has a fact-check attached."
               description="Description of the alert message displayed on data points section of the edit feed page."
               id="mediaArticlesDisplay.readOnlyAlertContent"
             />
@@ -70,7 +70,7 @@ const MediaArticlesDisplay = ({ onUpdate, projectMedia }) => {
           placement="contained"
           title={
             <FormattedMessage
-              defaultMessage="Claim & Fact-Check Added"
+              defaultMessage="Already Has Fact-Check"
               description="Title of the alert message displayed on data points section of the edit feed page."
               id="mediaArticlesDisplay.readOnlyAlertTitle"
             />


### PR DESCRIPTION
## Description

Improve the alert message to clarify to the users that the explainer will not be sent because a fact-check already exists
Reference: CV2-6385

## How to test?

- Go to a media item that already has a fact-check.
- Attempt to add an explainer.
- Confirm that the updated alert message appears as described above.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
