### PR TITLE
5217 – Enable articles list selection in shared feeds: final tweaks

### DIFF
--- a/src/app/components/cds/inputs/Select.js
+++ b/src/app/components/cds/inputs/Select.js
@@ -81,7 +81,7 @@ const Select = ({
             <ChevronDownIcon />
           </div>
         </div>
-        { onRemove ?
+        { onRemove && inputProps.value ?
           <Tooltip arrow title={<FormattedMessage defaultMessage="Undo selection" description="Tooltip for button on Select component to remove current selection" id="select.removeSelection" />}>
             <span>
               <ButtonMain
@@ -144,4 +144,3 @@ Select.propTypes = {
 };
 
 export default Select;
-

--- a/src/app/components/feed/FeedDataPointsSection.js
+++ b/src/app/components/feed/FeedDataPointsSection.js
@@ -199,7 +199,7 @@ const FeedDataPointsSection = ({
                 id="feedDataPoints.mediaContentFooter"
                 values={{
                   mediaDataArticleLink: (
-                    <a href="https://help.checkmedia.org/en/articles/8542417-shared-feed-creation#h_7414a7ab59" rel="noopener noreferrer" target="_blank"> {/* FIXME: Put the correct link here */}
+                    <a href="https://help.checkmedia.org/en/articles/6473124-all-you-need-to-know-about-shared-feeds#h_8a42c6b5de" rel="noopener noreferrer" target="_blank">
                       <FormattedMessage
                         defaultMessage="media & requests data"
                         description="Text of the link to an article that explains media and requests data. This link is displayed on the media/requests data points section on the save feed page."


### PR DESCRIPTION
## Description

- Updated Knowledge Base link to the media & requests data as requested by Jessie
- Updated 'Clear' button behavior: 'the "Clear" button should not appear when no list is selected': I thought this is probably not a specific behavior to the list in the `SaveFeed` component, so I updated the `Select` component itself. 

References: CV2-5217

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
