### PR TITLE
6379 – Update Pender branch in ci-test.yaml

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -216,9 +216,9 @@ jobs:
         export LANG=C.UTF-8
         export LANGUAGE=C.UTF-8
 
-    - name: Setup Pender 
-      run: | 
-        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'develop')
+    - name: Setup Pender
+      run: |
+        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'main')
         echo "Using branch $PENDER_BRANCH for Pender"
         git clone --branch=$PENDER_BRANCH https://github.com/meedan/pender.git
         cd pender
@@ -356,9 +356,9 @@ jobs:
         export LANG=C.UTF-8
         export LANGUAGE=C.UTF-8
 
-    - name: Setup Pender 
-      run: | 
-        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'develop')
+    - name: Setup Pender
+      run: |
+        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'main')
         echo "Using branch $PENDER_BRANCH for Pender"
         git clone --branch=$PENDER_BRANCH https://github.com/meedan/pender.git
         cd pender
@@ -492,8 +492,8 @@ jobs:
     - name: Setup Pender 
       env:
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
-      run: | 
-        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'develop')
+      run: |
+        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'main')
         echo "Using branch $PENDER_BRANCH for Pender"
         git clone --branch=$PENDER_BRANCH https://github.com/meedan/pender.git
         cd pender

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -67,10 +67,10 @@ jobs:
       run: |
         export GITHUB_TAG=0.0.0
         curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt-get update && sudo apt-get install ngrok
-        
-    - name: Setup Pender 
-      run: | 
-        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'develop')
+
+    - name: Setup Pender
+      run: |
+        export PENDER_BRANCH=$((git ls-remote --exit-code --heads https://github.com/meedan/pender.git $GITHUB_BRANCH >/dev/null && echo $GITHUB_BRANCH) || echo 'main')
         echo "Using branch $PENDER_BRANCH for Pender"
         git clone --branch=$PENDER_BRANCH https://github.com/meedan/pender.git
         cd pender


### PR DESCRIPTION
## Description

We renamed the default branch of Pender from 'develop' to 'main'.

References: CV2-6379

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
