### PR TITLE
CV2-5725: Remove weblink header option from newsletters headers list

### DIFF
--- a/localization/react-intl/src/app/components/team/Newsletter/NewsletterHeader.json
+++ b/localization/react-intl/src/app/components/team/Newsletter/NewsletterHeader.json
@@ -5,11 +5,6 @@
     "defaultMessage": "None"
   },
   {
-    "id": "newsletterHeader.headerTypeLinkPreview",
-    "description": "One of the options for a newsletter header type",
-    "defaultMessage": "Link preview (requires a verified account on WhatsApp)"
-  },
-  {
     "id": "newsletterHeader.headerTypeImage",
     "description": "One of the options for a newsletter header type",
     "defaultMessage": "Image"

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -13,11 +13,6 @@ const messages = defineMessages({
     defaultMessage: 'None',
     description: 'One of the options for a newsletter header type',
   },
-  headerTypeLinkPreview: {
-    id: 'newsletterHeader.headerTypeLinkPreview',
-    defaultMessage: 'Link preview (requires a verified account on WhatsApp)',
-    description: 'One of the options for a newsletter header type',
-  },
   headerTypeImage: {
     id: 'newsletterHeader.headerTypeImage',
     defaultMessage: 'Image',
@@ -37,7 +32,6 @@ const messages = defineMessages({
 
 const headerTypes = {
   none: messages.headerTypeNone,
-  link_preview: messages.headerTypeLinkPreview,
   image: messages.headerTypeImage,
   video: messages.headerTypeVideo,
   audio: messages.headerTypeAudio,
@@ -137,7 +131,7 @@ NewsletterHeader.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.bool,
   fileName: PropTypes.string,
-  headerType: PropTypes.oneOf(['', 'none', 'link_preview', 'image', 'video', 'audio']),
+  headerType: PropTypes.oneOf(['', 'none', 'image', 'video', 'audio']),
   intl: intlShape.isRequired,
   overlayText: PropTypes.string,
   setFile: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
 Remove weblink header option from the newsletters headers Menu

References: CV2-5725

## How to test?

- Navigate to the Newsletter Settings page.
- Open the Content Header dropdown menu.
- Confirm that the "Link Preview" option is not displayed in the dropdown.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
