### PR TITLE
6419 – Do not show NavigateAwayDialog if saving

### DIFF
--- a/src/app/components/feed/SaveFeed.js
+++ b/src/app/components/feed/SaveFeed.js
@@ -372,6 +372,7 @@ const SaveFeed = (props) => {
 
   const handleSaveFeedTeam = () => {
     setSaving(true);
+    setIsEditing(false);
     const input = {
       id: feedTeam.id,
       media_saved_search_id: formData.selectedMediaClaimRequestsListId,


### PR DESCRIPTION
## Description

When saving as an invited team, the following notice would pop-up:
'Do you want to leave without saving? You have unsaved changes to your shared feed. …'

This happened because even though we called handleSaveFeedTeam successfully,
and the feed was saved, the `isEditing` state was not set to false.
Which caused NavigateAwayDialog to pop up.

I think as part of the save operation, we should also set `isEditing` to false,
if someone is saving, they are no longer editing.

References: CV2-6419

## How to test?

- As user 1, create a shared feed and invite user 2
- As user 2:
    - accept the invitation,
    - add a saved search,
    - click save
- The user should be redirected to the Feed page

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
