### PR TITLE
Fix missing Docker images error on Check Web CI build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ then
 else
   if [[ $GITHUB_JOB_NAME == 'integration-and-unit-tests' ]]
   then
-    docker compose build web api api-background pender pender-background
+    docker compose build web api api-background pender pender-background postgres elasticsearch
     docker compose -f docker-compose.yml -f docker-test.yml up -d web api api-background pender pender-background chromedriver
   else
     if [[ $GITHUB_JOB_NAME == 'media-similarity-tests' ]]


### PR DESCRIPTION
## Description

Check Web CI was failing due to missing Docker images for postgres and elasticsearch:
`Container check-web-postgres-1  
Error response from daemon: No such image: check-web-postgres:latest
Container check-web-elasticsearch-1  
Error response from daemon: No such image: check-web-elasticsearch:latest
`
Added the missing Docker images (postgres and elasticsearch) to the build step.

References: CV2-6426

## How to test?
Running the tests on CI

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
