### PR TITLE
Remove link_preview option from header type dropdown when not in availableHeaderTypes

### DIFF
--- a/localization/react-intl/src/app/components/team/Newsletter/NewsletterHeader.json
+++ b/localization/react-intl/src/app/components/team/Newsletter/NewsletterHeader.json
@@ -10,6 +10,11 @@
     "defaultMessage": "Image"
   },
   {
+    "id": "newsletterHeader.headerTypeLinkPreview",
+    "description": "One of the options for a newsletter header type",
+    "defaultMessage": "Link preview (requires a verified account on WhatsApp)"
+  },
+  {
     "id": "newsletterHeader.headerTypeVideo",
     "description": "One of the options for a newsletter header type",
     "defaultMessage": "Video"

--- a/src/app/components/team/Newsletter/NewsletterHeader.js
+++ b/src/app/components/team/Newsletter/NewsletterHeader.js
@@ -18,6 +18,11 @@ const messages = defineMessages({
     defaultMessage: 'Image',
     description: 'One of the options for a newsletter header type',
   },
+  headerTypeLinkPreview: {
+    id: 'newsletterHeader.headerTypeLinkPreview',
+    defaultMessage: 'Link preview (requires a verified account on WhatsApp)',
+    description: 'One of the options for a newsletter header type',
+  },
   headerTypeVideo: {
     id: 'newsletterHeader.headerTypeVideo',
     defaultMessage: 'Video',
@@ -33,6 +38,7 @@ const messages = defineMessages({
 const headerTypes = {
   none: messages.headerTypeNone,
   image: messages.headerTypeImage,
+  link_preview: messages.headerTypeLinkPreview,
   video: messages.headerTypeVideo,
   audio: messages.headerTypeAudio,
 };
@@ -71,11 +77,17 @@ const NewsletterHeader = ({
       value={headerType}
       onChange={(e) => { onUpdateField('headerType', e.target.value); }}
     >
-      {Object.keys(headerTypes).map(type => (
-        <option disabled={!availableHeaderTypes.includes(type)} key={type} value={type}>
-          {intl.formatMessage(headerTypes[type])}
-        </option>
-      ))}
+      {Object.keys(headerTypes)
+        .filter(type => type !== 'link_preview' || availableHeaderTypes.includes('link_preview'))
+        .map(type => (
+          <option
+            disabled={!availableHeaderTypes.includes(type)}
+            key={type}
+            value={type}
+          >
+            {intl.formatMessage(headerTypes[type])}
+          </option>
+        ))}
     </Select>
 
     { (headerType === 'image' || headerType === 'video' || headerType === 'audio') ?
@@ -131,7 +143,7 @@ NewsletterHeader.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.bool,
   fileName: PropTypes.string,
-  headerType: PropTypes.oneOf(['', 'none', 'image', 'video', 'audio']),
+  headerType: PropTypes.oneOf(['', 'none', 'image', 'link_preview', 'video', 'audio']),
   intl: intlShape.isRequired,
   overlayText: PropTypes.string,
   setFile: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
Filter `'link_preview'` to only be displayed when available in availableHeaderTypes.This change removes 'link_preview' from the Newsletter page, while still allowing it to appear in the New Tipline Resource section

Reference: CV2-5725 
## How to test?

Navigate to the Newsletter Settings page.
Open the Content Header dropdown menu.
Confirm that the "Link Preview" option is not displayed in the dropdown.

Navigate to New Tipline Resource
Open the Content Header dropdown menu.
Confirm that the "Link Preview" option is displayed in the dropdown.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
