### PR TITLE
Cv2-6381: Update base image and Ruby version for check-we

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.20.1-buster AS base
+FROM node:14.21.3-bullseye AS base
 MAINTAINER Meedan <sysops@meedan.com>
 
 # Set a UTF-8 capabable locale
@@ -14,8 +14,8 @@ RUN mkdir -p /usr/local/var/run/watchman && touch /usr/local/var/run/watchman/.n
 RUN true \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        ruby2.5 \
-        ruby2.5-dev \
+        ruby2.7 \
+        ruby2.7-dev \
         build-essential \
         graphicsmagick \
         tini \


### PR DESCRIPTION
## Description

Updated base image from node:14.20.1-buster to node:14.21.3-bullseye

Switched from ruby2.5 to ruby2.7 and ruby2.5-dev to ruby2.7-dev


The error that was happening on Check web CI: 
```#15 [web base  4/12] RUN true     && apt-get update     && apt-get install -y --no-install-recommends         ruby2.5         ruby2.5-dev         build-essential         graphicsmagick         tini         nginx     && gem install bundler:1.17.1     && rm -rf /var/lib/apt/lists/*
#15 0.120 Ign:1 http://deb.debian.org/debian buster InRelease
#15 0.135 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
#15 0.148 Ign:3 http://deb.debian.org/debian buster-updates InRelease
#15 0.162 Err:4 http://deb.debian.org/debian buster Release
#15 0.162   404  Not Found [IP: 146.75.106.132 80]
#15 0.177 Err:5 http://deb.debian.org/debian-security buster/updates Release
#15 0.177   404  Not Found [IP: 146.75.106.132 80]
#15 0.190 Err:6 http://deb.debian.org/debian buster-updates Release
#15 0.190   404  Not Found [IP: 146.75.106.132 80]
#15 0.194 Reading package lists...
#15 0.204 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#15 0.204 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
#15 0.204 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#15 ERROR: process "/bin/sh -c true     && apt-get update     && apt-get install -y --no-install-recommends         ruby2.5         ruby2.5-dev         build-essential         graphicsmagick         tini         nginx     && gem install bundler:1.17.1     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
#16 [pender internal] load metadata for docker.io/library/ruby:3.3.3-slim
#16 CANCELED
#8 [chromedriver internal] load metadata for docker.io/selenium/standalone-chrome:125.0
#8 CANCELED
------
failed to solve: process "/bin/sh -c true     && apt-get update     && apt-get install -y --no-install-recommends         ruby2.5         ruby2.5-dev         build-essential         graphicsmagick         tini         nginx     && gem install bundler:1.17.1     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
 > [web base  4/12] RUN true     && apt-get update     && apt-get install -y --no-install-recommends         ruby2.5         ruby2.5-dev         build-essential         graphicsmagick         tini         nginx     && gem install bundler:1.17.1     && rm -rf /var/lib/apt/lists/*:
0.162 Err:4 http://deb.debian.org/debian buster Release
0.162   404  Not Found [IP: 146.75.106.132 80]
0.177 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.177   404  Not Found [IP: 146.75.106.132 80]
0.190 Err:6 http://deb.debian.org/debian buster-updates Release
0.190   404  Not Found [IP: 146.75.106.132 80]
0.194 Reading package lists...
0.204 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.204 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
0.204 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------`

References: CV2-6381

## How to test?

Build and runnning the integration tests

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
