### PR TITLE
CV2-6454: Disable create blank media from UI

### DIFF
--- a/src/app/components/article/ClaimFactCheckForm.js
+++ b/src/app/components/article/ClaimFactCheckForm.js
@@ -231,8 +231,6 @@ const ClaimFactCheckForm = ({
     const input = { ...claim };
     if (projectMedia) {
       input.project_media_id = projectMedia.dbid;
-    } else {
-      input.enable_create_blank_media = true;
     }
     commitMutation(Relay.Store, {
       mutation: createClaimMutation,


### PR DESCRIPTION
## Description

Disable create a blank media by remove `enable_create_blank_media` arg.

References: CV2-6454

## How to test?

Re-run automated tests.

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
