### PR TITLE
Try to build legacy Docker image to fix startup in CV2-6467

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -52,7 +52,7 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
           --load \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-          --file ./Dockerfile ./
+          --file ./production/Dockerfile ./
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
 #    - name: Run Unit Tests
@@ -71,13 +71,13 @@ jobs:
           --cache-from "type=local,src=/tmp/.buildx-cache" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-          --file ./Dockerfile ./
+          --file ./production/Dockerfile ./
         # push docker tag to indicate branch
         docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
-          --file ./Dockerfile ./
+          --file ./production/Dockerfile ./
 
 #    - name: Kick off Terraform deploy in sysops/ if not live
 #      id: sysops-deploy


### PR DESCRIPTION
## Description

This is a quick fix to see if the legacy production/Dockerfile builds will work for manual deployments.

References: CV2-6467

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
