### PR TITLE
CV2-6467: Add missing DEPLOY_BRANCH build argument to Dockerfile

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -52,7 +52,8 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
           --load \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-          --file ./production/Dockerfile ./
+          --file ./production/Dockerfile \
+          --build-arg DEPLOY_BRANCH=$BRANCH ./
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
 #    - name: Run Unit Tests
@@ -71,7 +72,8 @@ jobs:
           --cache-from "type=local,src=/tmp/.buildx-cache" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-          --file ./production/Dockerfile ./
+          --file ./production/Dockerfile \
+          --build-arg DEPLOY_BRANCH=$BRANCH ./
         # push docker tag to indicate branch
         docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \


### PR DESCRIPTION
## Description

Previously, the curl command was trying to download from an invalid URL with a missing branch name, causing issues like:

`#23 [base 14/19] RUN curl --silent https://raw.githubusercontent.com/meedan/check-api//public/relay.json -o /app/latest/relay.json
#23 DONE 0.1s`

References: CV2-6467

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
