### PR TITLE
No sudo needed when installing the passenger signing key

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -48,7 +48,7 @@ RUN true \
 RUN true \
     && curl https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt \
        | gpg --dearmor \
-       | sudo tee /etc/apt/trusted.gpg.d/phusion.gpg >/dev/null
+       | tee /etc/apt/trusted.gpg.d/phusion.gpg >/dev/null
 
 RUN true \
     && echo deb https://oss-binaries.phusionpassenger.com/apt/passenger bullseye main \


### PR DESCRIPTION
## Description

Remove call to sudo when installing the passenger signing key. Not necessary.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
