### PR TITLE
2955 – Refresh an item tags after bulk changes

### DIFF
--- a/src/app/components/media/MediaActionsBar.js
+++ b/src/app/components/media/MediaActionsBar.js
@@ -479,6 +479,7 @@ class MediaActionsBar extends React.PureComponent {
     return (
       <Relay.RootContainer
         Component={MediaActionsBarContainer}
+        forceFetch
         renderFetched={data => <MediaActionsBarContainer {...this.props} {...data} />}
         route={route}
       />


### PR DESCRIPTION
## Description
When we bulk added/deleted tags and then clicked an item, the MediaActionsBar
was not updated with the latest tags. This change forces a re-fetch of the
data to ensure the MediaActionsBar reflects the current state of the tags.

References: CV2-2955

## How to test?

From the All Media Clusters page use the `Bulk Change` menu do add or remove tags.
Click one of the updated items, the list of tags in the MediaActionsBar should reflect the latest changes.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
