### PR TITLE
6465 – Fix text aligment in 'Edit Claim & Fact-Check Article' tab

### DIFF
--- a/src/app/components/article/ArticleForm.module.css
+++ b/src/app/components/article/ArticleForm.module.css
@@ -48,7 +48,7 @@
   padding: 8px;
 
   .article-form-info-labels {
-    align-items: flex-end;
+    align-items: flex-start;
     display: flex;
     flex-flow: column;
     padding-right: 8px;


### PR DESCRIPTION
## Description

The text was being aligned to the end, instead of the start, which
made it look misaligned with the rest of the form elements.

### Images
#### Before
<img width="1281" height="1327" alt="before-fix" src="https://github.com/user-attachments/assets/531db3c6-0485-42b8-b6bb-3299baf0d4f0" />

#### After
<img width="1281" height="1327" alt="after-fix" src="https://github.com/user-attachments/assets/5b85624d-c93d-4fcb-884b-e94ea0e1cf31" />

### Video
#### Before
https://github.com/user-attachments/assets/f18692a3-ed52-4c1e-bcf4-433cb2dcf433

#### After
https://github.com/user-attachments/assets/90c456fb-f49f-45af-a6bd-15e4db00df49

References: CV2-6465

## How to test?

Go to `All Articles`, open `Edit Claim & Fact-Check Article` tab.
Resize the window and confirm that the Article Form Info Labels are always aligned to the right.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
