### PR TITLE
improve video fullscreen toggle logic and replace deprecated document.fullscreen

### DIFF
--- a/src/app/components/layout/AspectRatio.js
+++ b/src/app/components/layout/AspectRatio.js
@@ -49,14 +49,15 @@ const AspectRatio = ({
   }, []);
 
   const handleOnExpand = () => {
-    // If this is video, use the button to enter or exit fullscreen for the container div depending on whether we are already in fullscreen
     if (isVideoFile) {
-      if (isFullscreenVideo && document?.fullscreen) {
+      if (isFullscreenVideo && document?.fullscreenElement) {
         document.exitFullscreen();
         setIsFullscreenVideo(false);
       } else {
-        document.querySelectorAll(`.${uniqueClassName}`)[0].parentElement.requestFullscreen();
-        setIsFullscreenVideo(true);
+        const el = document.querySelectorAll(`.${uniqueClassName}`)?.[0]?.parentElement;
+        if (el && el.requestFullscreen) {
+          el.requestFullscreen().then(() => setIsFullscreenVideo(true));
+        }
       }
     } else {
       setExpandedContent(expandedImage);


### PR DESCRIPTION
## Description

Fix TypeError: document.querySelectorAll(".".concat(v))[0].parentElement.requestFullscreen is not a function

- [X] Replaced deprecated `document.fullscreen` with `document.fullscreenElement` 
- [X] Avoided Sentry errors by ensuring `requestFullscreen` is a valid function

Reference: CV2-5114

## How to test?

- Go to the page of an uploaded video item
- Click the expand (fullscreen) button
- Check that no error is displayed
- Click to exit full screen and check that no error is displayed

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
