### PR TITLE
Run a deploy when tagged for release.

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -6,6 +6,8 @@ on:
       - 'develop'
       - 'master'
       - '*deploy/*'
+    tags:
+      - 'v*'
 
 jobs:
   build-test-deploy:
@@ -83,8 +85,8 @@ jobs:
           --file ./production/Dockerfile \
           --build-arg DEPLOY_BRANCH=$BRANCH ./
 
-    - name: Kick off Terraform deploy in sysops/ if not live
-      id: sysops-deploy
+    - name: Kick off Terraform deploy in sysops/ for QA deployment
+      id: sysops-deploy-qa
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
       env:
         IMAGE_URI: format('{0}/{1}:{2}', ${{ steps.login-ecr.outputs.registry }}, ${{ github.event.repository.name }}, ${{ github.sha }})
@@ -98,4 +100,18 @@ jobs:
           -u ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }} \
           -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push", "image": "env.IMAGE_URI", "branch": "'$BRANCH'"}}'
         fi
+
+    - name: Kick off Terraform deploy in sysops/ for Live
+      id: sysops-deploy-live
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      env:
+        IMAGE_URI: format('{0}/{1}:{2}', ${{ steps.login-ecr.outputs.registry }}, ${{ github.event.repository.name }}, ${{ github.sha }})
+      run: |
+        curl \
+        -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+        -u ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }} \
+        -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "tag", "image": "env.IMAGE_URI", "branch": "n/a"}}'
+
 

--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'master'
-      - '*deploy/*'
     tags:
       - 'v*'
 
@@ -88,30 +86,22 @@ jobs:
     - name: Kick off Terraform deploy in sysops/ for QA deployment
       id: sysops-deploy-qa
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
-      env:
-        IMAGE_URI: format('{0}/{1}:{2}', ${{ steps.login-ecr.outputs.registry }}, ${{ github.event.repository.name }}, ${{ github.sha }})
-      run: |
-        BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
-        if [[ "$BRANCH" != master ]]; then
-          curl \
-          -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
-          -u ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }} \
-          -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push", "image": "env.IMAGE_URI", "branch": "'$BRANCH'"}}'
-        fi
-
-    - name: Kick off Terraform deploy in sysops/ for Live
-      id: sysops-deploy-live
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      env:
-        IMAGE_URI: format('{0}/{1}:{2}', ${{ steps.login-ecr.outputs.registry }}, ${{ github.event.repository.name }}, ${{ github.sha }})
       run: |
         curl \
         -X POST \
         -H "Accept: application/vnd.github.v3+json" \
         https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
         -u ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }} \
-        -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "tag", "image": "env.IMAGE_URI", "branch": "n/a"}}'
+        -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push"}}'
 
+    - name: Kick off Terraform deploy in sysops/ for Live
+      id: sysops-deploy-live
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        curl \
+        -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+        -u ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }} \
+        -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "tag"}}'
 


### PR DESCRIPTION
## Description

To better adhere to future deployment process and avoid confusion with merge to master this change will kick off a Live deploy in sysops when a release is tagged. This is similar to how presto deployments are performed despite still using the legacy develop and master branches.

References: CV2-6471

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
