### PR TITLE
Handle NotSupportedError in video playback to prevent Sentry errors

### DIFF
--- a/src/app/components/cds/media-cards/MediaControls.js
+++ b/src/app/components/cds/media-cards/MediaControls.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
 import MediaTimeline from './MediaTimeline';
 import MediaVolume from './MediaVolume';
 import MediaPlaybackSpeed from './MediaPlaybackSpeed';
@@ -33,12 +32,18 @@ const MediaControls = ({
   }, []);
 
   const togglePlay = () => {
-    if (isPlaying) {
-      videoRef.current?.pause();
-      setIsPlaying(false);
-    } else {
-      videoRef.current?.play();
-      setIsPlaying(true);
+    try {
+      if (isPlaying) {
+        videoRef.current?.pause();
+        setIsPlaying(false);
+      } else {
+        videoRef.current?.play();
+        setIsPlaying(true);
+      }
+    } catch (err) {
+      if (err.name === 'NotSupportedError') {
+        setIsPlaying(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Description

Fix NotSupportedError: The element has no supported sources issue, which occurs when attempting to play an unsupported video format.

Reference: CV2-5113

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
