### PR TITLE
CV2-3711:  RSS feed notification persists after pausing or scheduling new newsletters

### DIFF
--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -120,18 +120,18 @@ const NewsletterScheduler = ({
       </div>
 
       { showDeliveryError && lastDeliveryError === 'CONTENT_HASNT_CHANGED' &&
-      <Alert
-        border
-        placement="contained"
-        title={
-          <FormattedMessage
-            defaultMessage="The newsletter was not sent because its content has not been updated since the last successful delivery."
-            description="Text displayed in an error box on newsletter settings page when RSS content has not changed"
-            id="newsletterScheduler.errorContentHasntChanged"
-          />
-        }
-        variant="error"
-      />
+        <Alert
+          border
+          placement="contained"
+          title={
+            <FormattedMessage
+              defaultMessage="The newsletter was not sent because its content has not been updated since the last successful delivery."
+              description="Text displayed in an error box on newsletter settings page when RSS content has not changed"
+              id="newsletterScheduler.errorContentHasntChanged"
+            />
+          }
+          variant="error"
+        />
       }
 
       { showDeliveryError && lastDeliveryError === 'RSS_ERROR' &&

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate, injectIntl, intlShape } from 'react-intl';
 import cx from 'classnames/bind';
@@ -50,6 +50,16 @@ const NewsletterScheduler = ({
   const weekDays = getWeekDays(intl.locale);
   const weekDaysLabels = weekDays.labels;
   const weekDaysValues = weekDays.values;
+  const [showDeliveryError, setShowDeliveryError] = useState(!!lastDeliveryError);
+
+  useEffect(() => {
+    setShowDeliveryError(!!lastDeliveryError);
+  }, [lastDeliveryError]);
+
+  const handleUpdate = (field, value) => {
+    setShowDeliveryError(false);
+    onUpdate(field, value);
+  };
 
   return (
     <div className={`${styles['newsletter-scheduler']} ${scheduled ? styles['newsletter-scheduled'] : styles['newsletter-paused']}`}>
@@ -109,22 +119,22 @@ const NewsletterScheduler = ({
         }
       </div>
 
-      { lastDeliveryError === 'CONTENT_HASNT_CHANGED' ?
-        <Alert
-          border
-          placement="contained"
-          title={
-            <FormattedMessage
-              defaultMessage="The newsletter was not sent because its content has not been updated since the last successful delivery."
-              description="Text displayed in an error box on newsletter settings page when RSS content has not changed"
-              id="newsletterScheduler.errorContentHasntChanged"
-            />
-          }
-          variant="error"
-        /> : null
+      { showDeliveryError && lastDeliveryError === 'CONTENT_HASNT_CHANGED' &&
+      <Alert
+        border
+        placement="contained"
+        title={
+          <FormattedMessage
+            defaultMessage="The newsletter was not sent because its content has not been updated since the last successful delivery."
+            description="Text displayed in an error box on newsletter settings page when RSS content has not changed"
+            id="newsletterScheduler.errorContentHasntChanged"
+          />
+        }
+        variant="error"
+      />
       }
 
-      { lastDeliveryError === 'RSS_ERROR' ?
+      { showDeliveryError && lastDeliveryError === 'RSS_ERROR' ?
         <Alert
           border
           placement="contained"
@@ -211,7 +221,7 @@ const NewsletterScheduler = ({
             size="default"
             theme="alert"
             variant="contained"
-            onClick={() => { onUpdate('scheduled', false); }}
+            onClick={() => handleUpdate('scheduled', false)}
           /> :
           <ButtonMain
             disabled={disabled}
@@ -222,7 +232,7 @@ const NewsletterScheduler = ({
             size="default"
             theme="validation"
             variant="contained"
-            onClick={() => { onUpdate('scheduled', true); }}
+            onClick={() => handleUpdate('scheduled', true)}
           />
         }
         { subscribersCount !== null &&
@@ -243,7 +253,7 @@ const NewsletterScheduler = ({
 
 NewsletterScheduler.defaultProps = {
   sendEvery: ['wednesday'],
-  sendOn: '',
+  sendOn: null,
   time: '09:00',
   subscribersCount: null,
   parentErrors: {},

--- a/src/app/components/team/Newsletter/NewsletterScheduler.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.js
@@ -134,7 +134,7 @@ const NewsletterScheduler = ({
       />
       }
 
-      { showDeliveryError && lastDeliveryError === 'RSS_ERROR' ?
+      { showDeliveryError && lastDeliveryError === 'RSS_ERROR' &&
         <Alert
           border
           placement="contained"
@@ -146,7 +146,7 @@ const NewsletterScheduler = ({
             />
           }
           variant="error"
-        /> : null
+        />
       }
 
       <div className={styles['newsletter-scheduler-schedule']}>

--- a/src/app/components/team/Newsletter/NewsletterScheduler.test.js
+++ b/src/app/components/team/Newsletter/NewsletterScheduler.test.js
@@ -1,20 +1,63 @@
-import { getWeekDays } from './NewsletterScheduler';
+import React from 'react';
+import NewsletterScheduler, { getWeekDays } from './NewsletterScheduler';
+
+import { mountWithIntl } from '../../../../../test/unit/helpers/intl-test';
+
+const baseProps = {
+  scheduled: false,
+  lastDeliveryError: null,
+  day: 1,
+  time: '10:00',
+  timezone: 'America/New_York',
+  type: 'static',
+  onUpdate: () => {},
+};
 
 describe('<NewsletterScheduler />', () => {
-  it('returns localized week day', () => {
+  it('should returns localized week day', () => {
     const firstDayOfWeek = getWeekDays('pt-BR').labels[0];
     expect(firstDayOfWeek).toBe('dom.');
   });
 
-  it('returns days of the week starting by Sunday for America timezone', () => {
+  it('should returns days of the week starting by Sunday for America timezone', () => {
     process.env.TZ = 'America/New_York';
     const firstDayOfWeek = getWeekDays('en-US').labels[0];
     expect(firstDayOfWeek).toBe('Sun');
   });
 
-  it('returns days of the week starting by Sunday for India timezone', () => {
+  it('should returns days of the week starting by Sunday for India timezone', () => {
     process.env.TZ = 'Asia/Calcutta';
     const firstDayOfWeek = getWeekDays('en-US').labels[0];
     expect(firstDayOfWeek).toBe('Sun');
+  });
+
+  it('should shows CONTENT_HASNT_CHANGED alert when lastDeliveryError is set', () => {
+    const wrapper = mountWithIntl(<NewsletterScheduler {...baseProps}lastDeliveryError="CONTENT_HASNT_CHANGED" />);
+    expect(wrapper.text()).toContain('The newsletter was not sent because its content has not been updated since the last successful delivery');
+  });
+
+  it('should shows RSS_ERROR alert when lastDeliveryError is set', () => {
+    const wrapper = mountWithIntl(<NewsletterScheduler {...baseProps} lastDeliveryError="RSS_ERROR" />);
+    expect(wrapper.text()).toContain('The newsletter was not sent because no content could be retrieved from the RSS feed');
+  });
+
+  it('should hide alert after handleUpdate is called', () => {
+    const onUpdate = jest.fn();
+    const wrapper = mountWithIntl(<NewsletterScheduler {...baseProps} lastDeliveryError="RSS_ERROR" scheduled type="static" onUpdate={onUpdate} />);
+    expect(wrapper.text()).toContain('The newsletter was not sent because no content could be retrieved from the RSS feed');
+
+    // Simulate clicking the "Pause" button
+    wrapper.find('button').filterWhere(btn => btn.text().toLowerCase().includes('pause')).simulate('click');
+    expect(wrapper.text()).not.toContain('The newsletter was not sent because no content could be retrieved from the RSS feed');
+  });
+
+  it('should sync showDeliveryError state with lastDeliveryError prop changes', () => {
+    const wrapper = mountWithIntl(<NewsletterScheduler {...baseProps} lastDeliveryError={null} />);
+    expect(wrapper.text()).not.toContain('The newsletter was not sent because its content has not been updated since the last successful delivery');
+
+    // Update the prop to trigger the alert
+    wrapper.setProps({ lastDeliveryError: 'CONTENT_HASNT_CHANGED' });
+    wrapper.update();
+    expect(wrapper.text()).toContain('The newsletter was not sent because its content has not been updated since the last successful delivery');
   });
 });


### PR DESCRIPTION
## Description

- [X]  Introduced a new state (`showDeliveryError`) in the `NewsletterScheduler` component to control the visibility of the RSS feed notification.
- [X]  The notification is now hidden immediately when the user pauses or schedules a newsletter.
- [X] Add unit tests

## How to test?

- Running unit tests

## Checklist

- [X] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
