### PR TITLE
CV2-6701: Hide/Show newsletter tab based on Team.settings

### DIFF
--- a/src/app/components/drawer/DrawerTeamSettings.js
+++ b/src/app/components/drawer/DrawerTeamSettings.js
@@ -137,7 +137,7 @@ const DrawerTeamSettingsComponent = ({
               </div>
             </li>
           </Link>
-          { isAdminOrEditor && team.get_tipline_newsletter_enabled ?
+          { isAdminOrEditor && team.get_tipline_newsletter_enabled !== 0 ?
             <Link className={cx('team-settings__newsletter-tab', styles.linkList)} title={intl.formatMessage(messages.newsletter)} to={`/${team.slug}/settings/newsletter`}>
               <li className={cx([styles.listItem], { [styles.listItem_active]: tab === 'newsletter' })}>
                 <div className={styles.listLabel}>

--- a/src/app/components/drawer/DrawerTeamSettings.js
+++ b/src/app/components/drawer/DrawerTeamSettings.js
@@ -137,7 +137,7 @@ const DrawerTeamSettingsComponent = ({
               </div>
             </li>
           </Link>
-          { isAdminOrEditor ?
+          { isAdminOrEditor && team.get_tipline_newsletter_enabled ?
             <Link className={cx('team-settings__newsletter-tab', styles.linkList)} title={intl.formatMessage(messages.newsletter)} to={`/${team.slug}/settings/newsletter`}>
               <li className={cx([styles.listItem], { [styles.listItem_active]: tab === 'newsletter' })}>
                 <div className={styles.listLabel}>
@@ -227,6 +227,7 @@ const DrawerTeamSettings = ({ intl, params }) => {
         team(slug: $teamSlug) {
           slug
           permissions
+          get_tipline_newsletter_enabled
           alegre_bot: team_bot_installation(bot_identifier: "alegre") {
             id
           }

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -84,7 +84,7 @@ class TeamComponent extends Component {
             { tab === 'tipline'
               ? <SmoochBot currentUser={this.getCurrentUser()} />
               : null }
-            { tab === 'newsletter' && team.get_tipline_newsletter_enabled
+            { tab === 'newsletter' && team.get_tipline_newsletter_enabled !== 0
               ? <Newsletter />
               : null }
             { tab === 'rules'

--- a/src/app/components/team/TeamComponent.js
+++ b/src/app/components/team/TeamComponent.js
@@ -84,7 +84,7 @@ class TeamComponent extends Component {
             { tab === 'tipline'
               ? <SmoochBot currentUser={this.getCurrentUser()} />
               : null }
-            { tab === 'newsletter'
+            { tab === 'newsletter' && team.get_tipline_newsletter_enabled
               ? <Newsletter />
               : null }
             { tab === 'rules'
@@ -138,6 +138,7 @@ export default createFragmentContainer(TeamComponent, {
       name
       slug
       permissions
+      get_tipline_newsletter_enabled
       ...TeamDetails_team
       alegre_bot: team_bot_installation(bot_identifier: "alegre") {
         id


### PR DESCRIPTION
## Description

Hide Newsletter settings when the feature is not enabled

References: CV2-6701

## How to test?

Change the `get_tipline_newsletter_enabled` settings via rails c then check Newsletter tab

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
