### PR TITLE
CV2-6708: Set TeamSlug for Create TiplineResource mutation

### DIFF
--- a/src/app/components/team/SmoochBot/SmoochBotConfig.js
+++ b/src/app/components/team/SmoochBot/SmoochBotConfig.js
@@ -24,8 +24,8 @@ const SmoochBotConfig = (props) => {
   } = props;
   const defaultOption = 'smooch_content';
   const [currentOption, setCurrentOption] = React.useState(defaultOption);
-  const team = props?.currentUser?.current_team;
-  const environment = createEnvironment(props?.currentUser?.token, team.slug);
+  const teamSlug = window.location.pathname.match(/^\/([^/]+)/)[1];
+  const environment = createEnvironment(props?.currentUser?.token, teamSlug);
 
   // Look for the workflow in the current selected language
   let currentWorkflowIndex = 0;


### PR DESCRIPTION
## Description

Set the team variable for createResourceMutation based on the team the user is browsing instead of User.current_team in. This fixes an issue where Meedan users could trigger the createNewResource mutation without being members of the workspace.

References: CV2-6708

## How to test?

Should follow these steps:

1. Create a new workspace.
2. Log in with a Meedan account that is not a member of the workspace created in step 1. 
3. Create a new resource.

Result: Successfully created a new resource.


## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
