### PR TITLE
Migrate to GitHub runners for future deployments

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -17,18 +17,13 @@ env:
 
 jobs:
   media-similarity-tests:
-    runs-on: 
-      labels: check-web
+    runs-on: ubuntu-latest
     if: >
       github.ref == 'refs/heads/develop' ||
       github.ref == 'refs/heads/master' ||
       contains(github.event.head_commit.message, '[full ci]') ||
       contains(github.event.head_commit.message, '[media similarity tests]')
     steps:
-    - name: Set permissions for _work directory
-      run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-        sudo chmod 755 $GITHUB_WORKSPACE
     - uses: actions/checkout@v4
 
     - name: Configure AWS Credentials
@@ -171,19 +166,13 @@ jobs:
     
   text-similarity-tests:
     needs: [media-similarity-tests]
-    runs-on: 
-      labels: check-web
+    runs-on: ubuntu-latest
     if: >
       success() || 
       github.ref == 'refs/heads/develop' ||
       github.ref == 'refs/heads/master' ||
       contains(github.event.head_commit.message, '[text similarity tests]')
     steps:
-    - name: Set permissions for _work directory
-      run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-        sudo chmod 755 $GITHUB_WORKSPACE
-  
     - uses: actions/checkout@v4
 
     - name: Configure AWS Credentials


### PR DESCRIPTION
## Description
This change promotes the usage of GitHub Runners rather than a self-hosted EC2 instance running in our AWS account

[Reference](https://meedan.atlassian.net/browse/IS-87)

## How has this been tested?
There is no practical way to test locally, but I've been observing the self-hosted runner CPU/Memory consumption for the last deployments, and we should be fine with the regular GitHub Actions runner

## Have you considered secure coding practices when writing this code?
N/A
