### PR TITLE
fix: stabilize Elastic dependent integration tests in CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,8 @@ else
   then
     pull_check_web_base_images
     retry_compose build web api api-background pender pender-background postgres elasticsearch
-    retry_compose -f docker-compose.yml -f docker-test.yml up -d web api api-background pender pender-background chromedriver
+    retry_compose -f docker-compose.yml -f docker-test.yml up -d elasticsearch postgres redis web api api-background pender pender-background chromedriver
+    until curl --silent -f "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s"; do printf .; sleep 2; done
   else
     if [[ $GITHUB_JOB_NAME == 'media-similarity-tests' ]]
     then

--- a/test/spec/app_spec_helpers.rb
+++ b/test/spec/app_spec_helpers.rb
@@ -309,9 +309,11 @@ module AppSpecHelpers
 
   def add_related_item(item_name)
     wait_for_selector('#create-media-dialog__dismiss-button')
-    wait_for_selector('#autocomplete-media-item').send_keys(item_name)
-    wait_for_text_change(' ', '#autocomplete-media-item', :css)
-    wait_for_selector('.small-media-card__title').click
+    autocomplete = wait_for_selector('#autocomplete-media-item')
+    autocomplete.send_keys(:control, 'a', :delete)
+    autocomplete.send_keys(item_name)
+    wait_for_text_change(' ', '#autocomplete-media-item', :css, 30)
+    wait_for_selector('.small-media-card__title', :css, 30, true).click
     wait_for_selector('#create-media-dialog__submit-button').click
   end
 

--- a/test/spec/search_spec.rb
+++ b/test/spec/search_spec.rb
@@ -18,15 +18,15 @@ shared_examples 'search' do
 
   it 'should search by keywords', bin1: true, quick: true do
     api_create_team_claims_sources_and_redirect_to_all_items({ count: 2 })
-    verbose_wait # wait for the items to be indexed in Elasticsearch
+    verbose_wait 2 # wait for the items to be indexed in Elasticsearch
     # find all medias with an empty search
-    wait_for_selector('.cluster-card', :css, 20, true)
+    wait_for_selector('.cluster-card', :css, 30, true)
     expect(@driver.find_elements(:css, '.cluster-card').size).to eq 2
     # search by keywords
     wait_for_selector('#search-input').send_keys(:control, 'a', :delete)
     wait_for_selector('#search-input').send_keys('Claim 0')
     @driver.action.send_keys(:enter).perform
-    wait_for_selector('.cluster-card', :css, 20, true)
+    wait_for_selector('.cluster-card', :css, 30, true)
     expect(@driver.find_elements(:css, '.cluster-card').size).to eq 1
   end
 

--- a/test/spec/similarity_spec.rb
+++ b/test/spec/similarity_spec.rb
@@ -1,7 +1,7 @@
 shared_examples 'similarity' do
   it 'should import and export items', bin1: true do
     api_create_team_claims_sources_and_redirect_to_all_items({ count: 3 })
-    verbose_wait 3 # Wait for the items to be indexed in ElasticSearch
+    verbose_wait 4 # Wait for the items to be indexed in ElasticSearch
     wait_for_selector('.search__results-heading')
     wait_for_selector('.cluster-card').click
     wait_for_selector('.test__media')


### PR DESCRIPTION
## Description

Follow-up to #2469 for [IS-90](https://meedan.atlassian.net/browse/IS-90). The lighter integration CI stack is working, but the blocking integration-and-unit-tests job still failed on two Elasticsearch-dependent specs:

- should search by keywords
- should import and export items
This PR stabilizes those flows by waiting for Elasticsearch to be ready before tests start, and by giving search/autocomplete UI more time to reflect indexed data.


## How to test?

Use `git commit --allow-empty -m "[full ci] Run all integration tests for this branch"` to execute all the Actions.

- [x]  Push branch and confirm Build and Run Tests runs on GitHub Actions
- [x]  Verify integration-and-unit-tests passes
- [x]  Confirm Build Test and Deploy still passes on develop after merge

## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).


[IS-90]: https://meedan.atlassian.net/browse/IS-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ