### PR TITLE
CV2-6653: Add max length limitation to match UI validation

### DIFF
--- a/localization/react-intl/src/app/components/article/ArticleForm.json
+++ b/localization/react-intl/src/app/components/article/ArticleForm.json
@@ -20,11 +20,6 @@
     "defaultMessage": "Edit Claim & Fact-Check Article"
   },
   {
-    "id": "articleForm.characterLimitReached",
-    "description": "Error message for when the character limit is reached",
-    "defaultMessage": "Character Limit Reached"
-  },
-  {
     "id": "articleForm.saveArticleButton",
     "description": "Button that saves the form data as a new article",
     "defaultMessage": "Create Article"
@@ -193,11 +188,6 @@
     "id": "articleForm.factCheckUrl",
     "description": "Label for article URL field",
     "defaultMessage": "Article URL"
-  },
-  {
-    "id": "articleForm.characterCount",
-    "description": "Label for the character count remaining in the combined text fields",
-    "defaultMessage": "{count, plural, one {# character left} other {# characters left}}"
   },
   {
     "id": "articleForm.selectLanguageLabel",

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { graphql, createFragmentContainer } from 'react-relay/compat';
 import PropTypes from 'prop-types';
-import cx from 'classnames/bind';
 import { FormattedMessage, FormattedHTMLMessage, FormattedDate } from 'react-intl';
 import ArticleTrash from './ArticleTrash.js';
 import CheckArticleTypes from '../../constants/CheckArticleTypes.js';
@@ -11,9 +10,8 @@ import Slideout from '../cds/slideout/Slideout';
 import ButtonMain from '../cds/buttons-checkboxes-chips/ButtonMain';
 import IconReport from '../../icons/fact_check.svg';
 import IconUnpublishedReport from '../../icons/unpublished_report.svg';
-import ErrorIcon from '../../icons/error.svg';
 import TextArea from '../cds/inputs/TextArea';
-import TextField from '../cds/inputs/TextField';
+import LimitedTextArea from '../layout/inputs/LimitedTextArea';
 import LanguagePickerSelect from '../cds/inputs/LanguagePickerSelect';
 import inputStyles from '../../styles/css/inputs.module.css';
 import CheckPropTypes from '../../CheckPropTypes';
@@ -57,10 +55,6 @@ const ArticleForm = ({
   const claimDescriptionMissing = !claimDescription || claimDescription.description?.trim()?.length === 0;
   const statuses = team.verification_statuses || null;
 
-  const [summaryError, setSummaryError] = React.useState(false);
-  const [titleError, setTitleError] = React.useState(false);
-  const [claimDescriptionError, setClaimDescriptionError] = React.useState(false);
-
   const [isValid, setIsValid] = React.useState(false);
   const [canPublish, setCanPublish] = React.useState(false);
   const createAndPublish = createFromMediaPage && canPublish;
@@ -70,11 +64,6 @@ const ArticleForm = ({
   const publishedAt = isPublished ? article.updated_at : null;
   const isStatusLocked = article.claim_description?.project_media?.last_status_obj?.locked || false;
   const factCheckFieldsMissing = (articleType === CheckArticleTypes.FACT_CHECK && (isFactCheckValueBlank(articleTitle) || isFactCheckValueBlank(summary) || !language));
-
-  const maxCount = articleType === CheckArticleTypes.EXPLAINER ? 4096 : 900;
-  const [charCount, setCharCount] = React.useState(summary.length + url.length + articleTitle.length);
-  const [charCountError, setCharCountError] = React.useState(charCount > maxCount);
-  const maxCountErrorMessage = <FormattedMessage defaultMessage="Character Limit Reached" description="Error message for when the character limit is reached" id="articleForm.characterLimitReached" />;
 
   React.useEffect(() => {
     setLanguage(language || defaultArticleLanguage);
@@ -94,16 +83,6 @@ const ArticleForm = ({
       setCanPublish(false);
     }
   }, [articleTitle, summary, claimDescription, language]);
-
-  React.useEffect(() => {
-    const count = summary.length + url.length + articleTitle.length;
-    setCharCount(count);
-    if (count > maxCount) {
-      setCharCountError(true);
-    } else {
-      setCharCountError(false);
-    }
-  }, [articleTitle, summary, url]);
 
   const handleGoToReport = (projectMediaDbid) => {
     const teamSlug = window.location.pathname.match(/^\/([^/]+)/)[1];
@@ -304,7 +283,6 @@ const ArticleForm = ({
                         <TextArea
                           className="article-form__description"
                           defaultValue={claimDescription || ''}
-                          error={claimDescriptionError}
                           id="article-form__description"
                           label={
                             <FormattedMessage
@@ -319,10 +297,7 @@ const ArticleForm = ({
                           onBlur={(e) => {
                             const newValue = e.target.value.trim();
                             if (newValue.length) {
-                              setClaimDescriptionError(false);
                               handleBlur('claim description', newValue);
-                            } else {
-                              setClaimDescriptionError(true);
                             }
                             setClaimDescription(newValue);
                           }}
@@ -404,17 +379,17 @@ const ArticleForm = ({
                         description="Placeholder instructions for article title field"
                         id="articleForm.explainerTitleInputPlaceholder"
                       >
-                        { placeholder => (<TextArea
+                        { placeholder => (<LimitedTextArea
                           autoGrow
                           className="article-form__title"
                           componentProps={{
                             id: 'article-form__title',
                           }}
                           defaultValue={articleTitle}
-                          error={titleError || (charCountError && articleTitle.length)}
-                          helpContent={charCountError && articleTitle.length ? maxCountErrorMessage : null}
                           label={<FormattedMessage defaultMessage="Title" description="Label for explainer title field" id="articleForm.explainerTitle" />}
+                          maxChars={35}
                           maxHeight="266px"
+                          maxLength={35}
                           name="title"
                           placeholder={placeholder}
                           required
@@ -422,10 +397,7 @@ const ArticleForm = ({
                           onBlur={(e) => {
                             const newValue = e.target.value.trim();
                             if (newValue.length) {
-                              setTitleError(false);
                               handleBlur('title', newValue);
-                            } else {
-                              setTitleError(true);
                             }
                             setArticleTitle(newValue);
                           }}
@@ -437,7 +409,7 @@ const ArticleForm = ({
                         description="Placeholder instructions for article title field"
                         id="articleForm.factCheckTitleInputPlaceholder"
                       >
-                        { placeholder => (<TextArea
+                        { placeholder => (<LimitedTextArea
                           autoGrow
                           className="article-form__title"
                           componentProps={{
@@ -445,10 +417,10 @@ const ArticleForm = ({
                           }}
                           defaultValue={isFactCheckValueBlank(articleTitle) ? null : articleTitle}
                           disabled={readOnly}
-                          error={titleError || (charCountError && articleTitle.length)}
-                          helpContent={charCountError && articleTitle.length ? maxCountErrorMessage : null}
                           label={<FormattedMessage defaultMessage="Title" description="Label for fact-check title field" id="articleForm.factCheckTitle" />}
+                          maxChars={35}
                           maxHeight="266px"
+                          maxLength={35}
                           name="title"
                           placeholder={placeholder}
                           rows="1"
@@ -471,17 +443,17 @@ const ArticleForm = ({
                         id="articleForm.explainerSummaryPlaceholder"
                       >
                         { placeholder => (
-                          <TextArea
+                          <LimitedTextArea
                             autoGrow
                             className="article-form__summary"
                             componentProps={{
                               id: 'article-form__summary',
                             }}
                             defaultValue={truncateLength(summary, 4096 - articleTitle.length - url.length - 3)}
-                            error={summaryError || (charCountError && summary.length)}
-                            helpContent={charCountError && summary.length ? maxCountErrorMessage : null}
                             label={<FormattedMessage defaultMessage="Summary" description="Label for article summary field" id="articleForm.explainerSummary" />}
+                            maxChars={3956}
                             maxHeight="500px"
+                            maxLength={3956}
                             name="summary"
                             placeholder={placeholder}
                             required
@@ -489,10 +461,7 @@ const ArticleForm = ({
                             onBlur={(e) => {
                               const newValue = e.target.value.trim();
                               if (newValue.length) {
-                                setSummaryError(false);
                                 handleBlur('description', newValue);
-                              } else {
-                                setSummaryError(true);
                               }
                               setSummary(newValue);
                             }}
@@ -506,7 +475,7 @@ const ArticleForm = ({
                         id="articleForm.factCheckSummaryPlaceholder"
                       >
                         { placeholder => (
-                          <TextArea
+                          <LimitedTextArea
                             autoGrow
                             className="article-form__summary"
                             componentProps={{
@@ -514,10 +483,10 @@ const ArticleForm = ({
                             }}
                             defaultValue={isFactCheckValueBlank(summary) ? null : truncateLength(summary, 900 - articleTitle.length - url.length - 3)}
                             disabled={readOnly}
-                            error={summaryError || (charCountError && summary.length)}
-                            helpContent={charCountError && summary.length ? maxCountErrorMessage : null}
                             key={`article-form__summary-${claimDescription?.description ? '-with-claim' : '-no-claim'}`}
                             label={<FormattedMessage defaultMessage="Summary" description="Label for article summary field" id="articleForm.summary" />}
+                            maxChars={3956}
+                            maxLength={3956}
                             name="summary"
                             placeholder={placeholder}
                             required={false}
@@ -543,15 +512,15 @@ const ArticleForm = ({
                         id="articleForm.explainerUrlPlaceholder"
                       >
                         { placeholder => (
-                          <TextField
+                          <LimitedTextArea
                             className="article-form__url"
                             componentProps={{
                               id: 'article-form__url',
                             }}
                             defaultValue={url}
-                            error={charCountError && url.length}
-                            helpContent={charCountError && url.length ? maxCountErrorMessage : null}
                             label={<FormattedMessage defaultMessage="Article URL" description="Label for article URL field" id="articleForm.explainerUrl" />}
+                            maxChars={35}
+                            maxLength={35}
                             placeholder={placeholder}
                             onBlur={(e) => {
                               const newValue = e.target.value;
@@ -572,17 +541,17 @@ const ArticleForm = ({
                         id="articleForm.factCheckUrlPlaceholder"
                       >
                         { placeholder => (
-                          <TextField
+                          <LimitedTextArea
                             className="article-form__url"
                             componentProps={{
                               id: 'article-form__url',
                             }}
                             defaultValue={url}
                             disabled={readOnly}
-                            error={charCountError && url.length}
-                            helpContent={charCountError && url.length ? maxCountErrorMessage : null}
                             key={`article-form__url-${claimDescription?.description ? '-with-claim' : '-no-claim'}`}
                             label={<FormattedMessage defaultMessage="Article URL" description="Label for article URL field" id="articleForm.factCheckUrl" />}
+                            maxChars={35}
+                            maxLength={35}
                             placeholder={placeholder}
                             onBlur={(e) => {
                               const newValue = e.target.value;
@@ -598,23 +567,6 @@ const ArticleForm = ({
                         )}
                       </FormattedMessage>
                     }
-                  </div>
-                  <div className={inputStyles['input-wrapper']}>
-                    <div className={cx(
-                      [inputStyles['help-container']],
-                      {
-                        'int-error__message--textfield': charCountError,
-                        [inputStyles['error-label']]: charCountError,
-                      })}
-                    >
-                      { charCountError && <ErrorIcon className={inputStyles['error-icon']} />}
-                      <FormattedMessage
-                        defaultMessage="{count, plural, one {# character left} other {# characters left}}"
-                        description="Label for the character count remaining in the combined text fields"
-                        id="articleForm.characterCount"
-                        values={{ count: maxCount - charCount }}
-                      />
-                    </div>
                   </div>
                 </div>
                 { languages.length > 1 ?

--- a/src/app/components/article/ArticleForm.js
+++ b/src/app/components/article/ArticleForm.js
@@ -387,13 +387,14 @@ const ArticleForm = ({
                           }}
                           defaultValue={articleTitle}
                           label={<FormattedMessage defaultMessage="Title" description="Label for explainer title field" id="articleForm.explainerTitle" />}
-                          maxChars={35}
+                          maxChars={800}
                           maxHeight="266px"
-                          maxLength={35}
+                          maxLength={800}
                           name="title"
                           placeholder={placeholder}
                           required
                           rows="1"
+                          value={articleTitle}
                           onBlur={(e) => {
                             const newValue = e.target.value.trim();
                             if (newValue.length) {
@@ -418,12 +419,13 @@ const ArticleForm = ({
                           defaultValue={isFactCheckValueBlank(articleTitle) ? null : articleTitle}
                           disabled={readOnly}
                           label={<FormattedMessage defaultMessage="Title" description="Label for fact-check title field" id="articleForm.factCheckTitle" />}
-                          maxChars={35}
+                          maxChars={800}
                           maxHeight="266px"
-                          maxLength={35}
+                          maxLength={800}
                           name="title"
                           placeholder={placeholder}
                           rows="1"
+                          value={articleTitle}
                           onBlur={(e) => {
                             const newValue = e.target.value.trim();
                             if (newValue.length) {
@@ -458,6 +460,7 @@ const ArticleForm = ({
                             placeholder={placeholder}
                             required
                             rows="1"
+                            value={summary}
                             onBlur={(e) => {
                               const newValue = e.target.value.trim();
                               if (newValue.length) {
@@ -491,6 +494,7 @@ const ArticleForm = ({
                             placeholder={placeholder}
                             required={false}
                             rows="1"
+                            value={summary}
                             onBlur={(e) => {
                               const newValue = e.target.value.trim();
                               if (newValue.length) {
@@ -519,9 +523,10 @@ const ArticleForm = ({
                             }}
                             defaultValue={url}
                             label={<FormattedMessage defaultMessage="Article URL" description="Label for article URL field" id="articleForm.explainerUrl" />}
-                            maxChars={35}
-                            maxLength={35}
+                            maxChars={600}
+                            maxLength={600}
                             placeholder={placeholder}
+                            value={url}
                             onBlur={(e) => {
                               const newValue = e.target.value;
                               let newUrl = newValue;
@@ -550,9 +555,10 @@ const ArticleForm = ({
                             disabled={readOnly}
                             key={`article-form__url-${claimDescription?.description ? '-with-claim' : '-no-claim'}`}
                             label={<FormattedMessage defaultMessage="Article URL" description="Label for article URL field" id="articleForm.factCheckUrl" />}
-                            maxChars={35}
-                            maxLength={35}
+                            maxChars={600}
+                            maxLength={600}
                             placeholder={placeholder}
+                            value={url}
                             onBlur={(e) => {
                               const newValue = e.target.value;
                               let newUrl = newValue;


### PR DESCRIPTION
## Description

Add characters limit for article fields

- [x] Add characters limit for the Article fields (Title / Summary / URL) based on Check-API limitation.
- [x] Replace `TextArea` with `LimitedTextArea` component

 
References: CV2-6653

## How to test?
- Add Fact-Check or Explainer
- Verify that user can't exceed the allowed characters per field (title/summary/url)
## Checklist

- [x] I have performed a self-review of my code and ensured that it is runnable. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
